### PR TITLE
Fix minor spelling mistake in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 # Contributing to Amplitude Developer docs
 
-We welcome contributions from partners and users. 
+We welcome contributions from partners and users.
 
 ## Getting started
 
@@ -14,17 +14,17 @@ More information is coming soon!
 ### For users
 --------
 
-If you are making subtantial updates, read our [style guide](/style-guide.md) and [formatting cheatsheet](formatting-cheatsheet.md) before starting work. When you're ready, open a PR. 
+If you are making substantial updates, read our [style guide](/style-guide.md) and [formatting cheatsheet](formatting-cheatsheet.md) before starting work. When you're ready, open a PR.
 
-### For Ampliteers 
+### For Ampliteers
 -----
 
 - To get started with contributing, check out the [Developer Docs Confluence site](https://amplitude.atlassian.net/wiki/spaces/PT/pages/1751449830/Developer+Docs). There, you'll find more conceptual content, including style guides and markdown cheatsheets.
 - If you're working on a feature that hasn't been announced yet, do your work in the **amp-internal-dev repo**. When you're ready to ship, open a PR against main. Learn more in [Confluence](https://amplitude.atlassian.net/wiki/spaces/PT/pages/1778384912/Working+on+Docs+Secretly).
 - **This is an open source project**! Before you push, make sure you haven't committed any sensitive information, including test account API keys or other credentials. It's hard to undo this kind of mistake, so if you accidentally push sensitive info, consider it compromised. Check the Developer Docs Confluence site for next steps.
-- If you have questions or need any help getting started, reach out in #dev-doc-requests. 
+- If you have questions or need any help getting started, reach out in #dev-doc-requests.
 
 ## How long will it take to get your PR merged?
 
-It depends. We have a small documenation team. Someone will acknowledge your PR within a week and can give you a better idea of how long it will take to get merged.
+It depends. We have a small documentation team. Someone will acknowledge your PR within a week and can give you a better idea of how long it will take to get merged.
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ This is the Amplitude Developer Center site. This site is currently in beta and 
 
 ## About
 
-We use [Material for MkDocs](https://github.com/squidfunk/mkdocs-material) to create our docs. 
+We use [Material for MkDocs](https://github.com/squidfunk/mkdocs-material) to create our docs.
 
 If you have any questions, comments, or concerns open an issue.
 
 ## Contribute
 
-Anyone can suggest changes to the docs. Just open a PR with your changes! See our [contribution guide](CONTRIBUTING.md) to get started. 
+Anyone can suggest changes to the docs. Just open a PR with your changes! See our [contribution guide](CONTRIBUTING.md) to get started.
 
 ## Install
-  
+
   Before you can install, you need pip. To install the link checker and Vale locally, you need brew and npm too.
 
 ### 1. Install Material
@@ -27,13 +27,13 @@ This command installs almost every dependency.
 ### 2. Install Git Revision Plugin
 
 `pip install mkdocs-git-revision-date-plugin`
-  
+
 ### 3. (Optional, but highly encouraged) Install Vale CLI
-  
-  Vale is a style linter we use to help enforce consistency and accessibilty in our docs. Our style guide config is included in this repo. To use the linter, you need to install Vale. 
-  
+
+  Vale is a style linter we use to help enforce consistency and accessibility in our docs. Our style guide config is included in this repo. To use the linter, you need to install Vale.
+
   `brew install vale`
-  
+
   After it's installed, you can run Vale in the terminal. See [Vale docs](https://docs.errata.ai/vale/cli). You can also install the plugin for your editor:
   - [Atom](https://github.com/errata-ai/vale-atom)
   - [VS Code](https://github.com/errata-ai/vale-vscode)
@@ -41,26 +41,26 @@ This command installs almost every dependency.
   - [Sublime](https://github.com/errata-ai/SubVale)
 
 The changes Vale flags are mostly suggestions, but please make an effort to address problems. The closer we stick to the style guide, the better the docs will be.
-  
+
 ## Write and publish
 
-### 1. Get the repo 
+### 1. Get the repo
 
 - Ampliteers, clone the repo: `git clone https://github.com/Amplitude-Developer-Docs/amplitude-dev-center.git`. If you aren't on the team, request access in #dev-doc-requests.
-- Everyone else: Fork the repo. 
+- Everyone else: Fork the repo.
 
 **Note for Ampliteers**: If you're working on a secret feature, use the amp-internal-dev repo instead. Contact Casey Smith for access and instructions.
-  
+
 ### 2. Create a branch and make your changes
 
-  - See our [formatting cheatsheet](/formatting-cheatsheet.md) for help with our most frequently used formatting elements. 
+  - See our [formatting cheatsheet](/formatting-cheatsheet.md) for help with our most frequently used formatting elements.
 
 ### 3. Run a local server and preview your changes
 
 Preview changes locally using `mkdocs serve`
-  
+
 When you're ready, open a PR against the staging branch*. Fill out the pull request template the best you can.
-  
+
  **Note for Ampliteers**: *If you have questions about which staging branch to use, ask in #dev-doc-requests.
 
 ### 4. Merge
@@ -68,8 +68,8 @@ When you're ready, open a PR against the staging branch*. Fill out the pull requ
 After your PR is approved, we'll merge it. Merging to `main` publishes to the website.
 
 ## Notes
-- The files in the repo make use of [Insiders](https://squidfunk.github.io/mkdocs-material/insiders/) features. If you don't have Insiders, you can still build, but some [features](https://squidfunk.github.io/mkdocs-material/insiders/#available-features) won't render in your build. However, you can see them on the preview site when you open a PR. 
-- If you're using VS Code, install the [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint). This extension flags problems with your markdown. The project includes a config file to cut down on noisier errors. 
+- The files in the repo make use of [Insiders](https://squidfunk.github.io/mkdocs-material/insiders/) features. If you don't have Insiders, you can still build, but some [features](https://squidfunk.github.io/mkdocs-material/insiders/#available-features) won't render in your build. However, you can see them on the preview site when you open a PR.
+- If you're using VS Code, install the [markdownlint extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint). This extension flags problems with your markdown. The project includes a config file to cut down on noisier errors.
 
 ## Resources
 
@@ -80,7 +80,7 @@ After your PR is approved, we'll merge it. Merging to `main` publishes to the we
 [Contribution Guide](CONTRIBUTING.md)
 
 [Material Docs](https://squidfunk.github.io/mkdocs-material/)
-  
+
 [Markdown Link Check](https://github.com/tcort/markdown-link-check)
 
 [Vale Docs](https://docs.errata.ai/)
@@ -88,5 +88,5 @@ After your PR is approved, we'll merge it. Merging to `main` publishes to the we
 ## Known issues and hacks I don't feel bad about
 
 - **Two mkdocs config files**. Because of the way Insiders and config inheritance work, I had to make a config file for people who don't have Insiders and one for the build bot (which does have Insiders). This was intentional. Site builds should always use `insiders.mkdocs.yml`. If you want to know more, read the dissertation I wrote in `insiders.mkdocs.yml`.
-- **Column CSS classes**. Markdown tables are easier to write than HTML tables. However, column width is set by the width of the contents in the first cell for each column. This can lead to too-narrow column widths in some data tables (especially param tables). Because you can add HTML to markdown, I created some CSS classes to manually set the width in cases where it makes sense. Just wrap the contents of the column's table heading with a `<div class="big-column">` (180px) or <div class="med-column"> (100px) as needed. See `docs/stylesheets/extra.css` and search for "column width classes" for an explanation and the classes. 
-- **Unsupported language syntax highlighting**. The project uses Pygments for code syntax highlighting. As with all highlighters, some languages aren't explicitly supported. If you can't find your language supported in [this list](https://pygments.org/languages/), you can either write your own, or just use the closest thing you can. This is an edge case. For NodeJs, just use `js`. 
+- **Column CSS classes**. Markdown tables are easier to write than HTML tables. However, column width is set by the width of the contents in the first cell for each column. This can lead to too-narrow column widths in some data tables (especially param tables). Because you can add HTML to markdown, I created some CSS classes to manually set the width in cases where it makes sense. Just wrap the contents of the column's table heading with a `<div class="big-column">` (180px) or <div class="med-column"> (100px) as needed. See `docs/stylesheets/extra.css` and search for "column width classes" for an explanation and the classes.
+- **Unsupported language syntax highlighting**. The project uses Pygments for code syntax highlighting. As with all highlighters, some languages aren't explicitly supported. If you can't find your language supported in [this list](https://pygments.org/languages/), you can either write your own, or just use the closest thing you can. This is an edge case. For NodeJs, just use `js`.


### PR DESCRIPTION
# Dev Docs PR


## Description

Fixes some spelling in `CONTRIBUTING.md`

## Deadline

N/A

## Change type

- [x] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp