### PR TITLE
removed beta notice on Git workflow

### DIFF
--- a/docs/data/ampli/git-workflow.md
+++ b/docs/data/ampli/git-workflow.md
@@ -3,7 +3,7 @@ title: Use Ampli with Source Control
 description: Learn how to use branches in Ampli with source control systems like Git. 
 ---
 
-!!!warning
+!!!info
 
     This workflow requires [Ampli CLI 1.9.0+](./cli)
 

--- a/docs/data/ampli/git-workflow.md
+++ b/docs/data/ampli/git-workflow.md
@@ -3,8 +3,9 @@ title: Use Ampli with Source Control
 description: Learn how to use branches in Ampli with source control systems like Git. 
 ---
 
-!!!beta "Beta Notice"
-    This new workflow is in Beta and requires Ampli CLI 1.9.0+
+!!!warning
+
+    This workflow requires [Ampli CLI 1.9.0+](./cli)
 
 Larger organizations with multiple teams will likely need to make changes to their tracking plan and analytics implementations in parallel.
 


### PR DESCRIPTION
# Dev Docs PR


## Description

[AMP-55661](https://amplitude.atlassian.net/browse/AMP-55661) removed beta notice on Git workflow 


## Screenshot

<img width="816" alt="image" src="https://user-images.githubusercontent.com/5790872/174171704-a5746bc7-1aab-449e-ae51-022a32026001.png">



## Change type

- [x ] Doc update.

# PR checklist:

- [ x] My documentation follows the style guidelines of this project.
- [ x] I previewed my documentation on a local server using `mkdocs serve`.
- [ x] Running `mkdocs serve` didn't generate any failures.
- [ x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp