### PR TITLE
Interactive API tables for experiment APIs and getting started guide

### DIFF
--- a/docs/experiment/apis/evaluation-api.md
+++ b/docs/experiment/apis/evaluation-api.md
@@ -1,45 +1,57 @@
 ---
-title: Evaluation API
+title: Evaluation REST API
 description: Retrieve variation assignment data for users with the Amplitude Experiment REST API.
 ---
 
-The Amplitude Experiment REST API lets you retrieve variation assignment data for users.
+The Amplitude Experiment Evaluation REST API lets you retrieve variant assignment data for users via [remote evaluation](../general/evaluation/remote-evaluation.md). User information is passed as query parameters on the request to allow for [caching the response on the CDN](../general/performance-and-caching.md#cdn-caching).
+
+!!!tip "[Try it out in your browser!](#example)"
 
 ## Authorization
 
-The REST API supports API Key authentication by setting an Authorization header. Use a Server API Key from your **Experiment Environments** page. Add the API key in the Authorization header with a prefix `Api-Key`, like this: `Authorization: Api-Key YourApiKeyHere`
+The REST API authenticates the request using your [deployment](../general/data-model.md#deployments) key set in the Authorization header with the prefix `Api-Key`. For example, `Authorization: Api-Key <deployment_key>`
 
-## Get assignment data for a user
-
-`GET https://api.lab.amplitude.com/v1/vardata`
-
-Fetches variation assignment data for a particular user. The `user_id` and `device_id` values passed to Experiment should be the same as the values passed to Amplitude.
-
-### Example request
-
-<!-- Brian: Can we please get an example request here? It would be best for it to look like a real request a customer might make and includes all parameters.  -->
-
-### Query parameters
+## Query parameters
 
 |<div class="big-column">Name</div>|Description|
 |---|----|
-|`user_id`| String. The user's ID.|
-|`device_id`| String. The user's device ID.|
-|`flag_key`| String. The flag's key. Found on the **Flags** page. If you don't include `flag_key`, then the request returns all available flags. |
-|`context`| String. JSON string consisting of the user context. Set user properties in the `user_properties` field.|
+|`user_id`| The user's ID.|
+|`device_id`| The user's device ID.|
+|`flag_key`| A specific flag key to get the variant of. If empty/missing, all flags & experiments associated with the deployment key are evaluated. |
+|`context`| JSON string consisting of a full user context. Set user properties in the `user_properties` field (e.g. `{"user_properties":{"premium":true}}`). |
 
-### Response
+## Responses
 
-#### 200 OK
+### 200 OK
 
-A successful request returns a `200` response and a map of flag key to variants. If `flag_key` isn't provided, it returns all available flags.
+A successful request returns a `200` response and a map of flag key to variants. If `flag_key` isn't provided, all flags associated with the deployment key in the authorization header are evaluated.
 
-<!-- Brian: we need an example response body-->
+**Response Body**
 
-#### 400 Bad Request
+The response body is a JSON object keyed by the flag key. The value for a given flag key is the variant which was assigned to the user. The variant contains its identification `key` (a.k.a value) and an optional payload containing a JSON element.
+
+```
+{
+    "<flag_key>": {
+        "key": "<variant_value>",
+        "payload": <variant_payload>
+    },
+    // ...
+}
+```
+
+Use the [example](#example) below to try the API from your browser or copy a curl.
+
+### 400 Bad Request
 
 If the request has invalid JSON in the context parameter, it returns a `400` status.
 
-#### 401 Unauthorized
+### 401 Unauthorized
 
 If the request doesn't include a valid API key, it returns a `401` response.
+
+## Example
+
+Set the fields in the table, and press send to send the request in browser, or copy the curl to send the request yourself.
+
+--8<-- "includes/experiment-interactive-evaluation-api-table.md"

--- a/docs/experiment/general/exposure-tracking.md
+++ b/docs/experiment/general/exposure-tracking.md
@@ -36,19 +36,6 @@ The exposure event has been designed to be simple and ergonomic enough to be sen
 | **`$exposure`** | `flag_key` | Required | The flag or experiment key which the user is being exposed to. |
 | | `variant` | Optional | The variant for the flag or experiment that the user has been exposed to. If `null` or missing, the user property for the flag/experiment is unset, meaning that the user no longer is considered to be a part of the experiment. |
 
-### Examples
+### Example
 
-=== "cURL"
-
-    ```bash
-    curl --request POST \
-        --url https://api2.amplitude.com/2/httpapi \
-        --data '{"api_key": "<ANALYTICS_API_KEY>","events":[{"event_type":"$exposure","user_id":"<USER_ID>","event_properties":{"flag_key":"<FLAG_KEY>","variant":"<VARIANT>"}}]}'
-    ```
-
-| <div class='big-column'>Variable</div> | Description |
-| --- | --- |
-| `<ANALYTICS_API_KEY>` | The analytics api key from [project](./data-model.md#projects) which you created your [flag](./data-model.md#flags-and-experiments) and [deployment](./data-model.md#deployments) in. |
-| `<USER_ID>`| The user ID used to identify the [user](./data-model.md#users). This should be the same user whose variants were previously fetched. |
-| `<FLAG_KEY>` | The key used to identify which [flag or experiment](./data-model.md#flags-and-experiments) the user is being exposed to. |
-| `<VARIANT>` | The [variant](#variant) value that the user is exposed to for the flag or experiment. |
+--8<-- "includes/experiment-interactive-exposure-tracking-table.md"

--- a/docs/experiment/guides/getting-started/fetch-variants.md
+++ b/docs/experiment/guides/getting-started/fetch-variants.md
@@ -4,30 +4,15 @@ description: How to fetch flag and experiment variants for a user using various 
 template: guide.html
 ---
 
-You can fetch variants for a user using either the [Evaluation REST API](../../apis/evaluation-api.md) or one of our [SDKs](../../index.md#sdks).
+To evaluate a user for you flag you'll want to **fetch** variants from our [remote evaluation](../../general/evaluation/remote-evaluation.md) servers. You can fetch variants for a user using either the [Evaluation REST API](../../apis/evaluation-api.md) or one of our [SDKs](../../index.md#sdks).
 
 ### Evaluation REST API
 
-To evaluate a user for you flag you'll want to **fetch** variants from our [remote evaluation](../../general/evaluation/remote-evaluation.md) servers. Use the following `curl` replacing `<USER_ID>` and `<EXPERIMENT_DEPLOYMENT_KEY>`, with the User ID and Deployment key respectively.
+The [Evaluation REST API](../../apis/evaluation-api.md) is the fastest way to test your flag without having to install an SDK.
 
-```
-curl --request GET \
-     --url 'https://api.lab.amplitude.com/v1/vardata?user_id=<USER_ID>' \
-     --header 'Authorization: Api-Key <EXPERIMENT_DEPLOYMENT_KEY>'
-```
+Input your `deployment_key` and a `user_id` into the table below. You may either copy the `curl` command, or press the **Fetch Variants** button to make the request in the browser.
 
-Replace the following variables with your own values:
-
-| <div class='big-column'>Variable</div> | Description |
-| --- | --- |
-|   `<EXPERIMENT_DEPLOYMENT_KEY>` | The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
-| `<USER_ID>` | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
-
-You should see the following JSON in the response body:
-
-```
-{"getting-started":{"key":"on"}}
-```
+--8<-- "includes/experiment-interactive-fetch-table.md"
 
 ### SDKs
 

--- a/docs/experiment/guides/getting-started/track-exposure.md
+++ b/docs/experiment/guides/getting-started/track-exposure.md
@@ -10,20 +10,7 @@ template: guide-last.html
 
 To keep things simple, we're going to `curl` an [exposure event](../../general/exposure-tracking.md#exposure-event) to amplitude using the [Analytics REST API v2.0](../../../analytics/apis/http-v2-api.md).
 
-```
-curl --request POST \
-     --url https://api2.amplitude.com/2/httpapi \
-     --data '{"api_key": "<ANALYTICS_API_KEY>","events":[{"event_type":"$exposure","user_id":"<USER_ID>","event_properties":{"flag_key":"<FLAG_KEY>","variant":"<VARIANT>"}}]}'
-```
-
-Replace the following variables with your own values:
-
-| <div class='big-column'>Variable</div> | Description |
-| --- | --- |
-|   `<ANALYTICS_API_KEY>` | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
-| `<USER_ID>` | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [fetched variants](./fetch-variants.md) for. |
-| `<FLAG_KEY>` | The flag key; `getting-started` if you're using the naming from this guide. |
-| `<VARIANT>` | The variant key, `on` if you're using the default flag variant. |
+--8<-- "includes/experiment-interactive-exposure-table.md"
 
 If the request succeeded, you should see a user in the Exposures chart in Experiment.
 

--- a/docs/experiment/index.md
+++ b/docs/experiment/index.md
@@ -68,7 +68,7 @@ Guide to getting started developing for Amplitude Experiment.
 | API | Description |
 | --- | --- |
 | [Evaluation API](apis/evaluation-api.md) | Evaluate a user for the feature flags and experiments assigned to the deployment used to authorize the request |
-| [Management API (Beta)](apis/management-api.md) | Manage or list flags and experiments within your organization. |
+| [Management API (Beta)](https://developers.experiment.amplitude.com/reference/management-api) | Manage or list flags and experiments within your organization. |
 
 
 ## System overview

--- a/docs/javascripts/api-table.js
+++ b/docs/javascripts/api-table.js
@@ -22,6 +22,15 @@ function setupCurlVariable(id, query) {
     }, false);
 }
 
+function setFailureTip(message) {
+    const tip = document.getElementById('failure_tip');
+    if (tip && message && message.length > 0) {
+        tip.innerHTML = '<p>'+ message + '</p>';
+    } else {
+        tip.innerHTML = '';
+    }
+}
+
 /**
  * Setup an interactive api table.
  *
@@ -44,8 +53,12 @@ function setupApiTable(ids, action) {
         try {
             const result = await action(fields);
             document.getElementById("result").innerHTML = result;
+            setFailureTip();
         } catch (e) {
             document.getElementById("result").innerHTML = e;
+            if (e.message === 'Failed to fetch') {
+                setFailureTip('🚫 Request blocked. Disable your ad blocker and retry.');
+            }
         }
     });
 }

--- a/docs/javascripts/api-table.js
+++ b/docs/javascripts/api-table.js
@@ -1,0 +1,51 @@
+function setCurlVariable(id, query) {
+    let value = document.getElementById(id).value;
+    if (value) {
+        value = value.trim();
+    }
+    if (query) {
+        if (value && value.length > 0) {
+            document.getElementById('curl_' + id).innerHTML =
+                '&' + id + '=' + encodeURIComponent(value);
+        } else {
+            document.getElementById('curl_' + id).innerHTML = '';
+        }
+    } else {
+        document.getElementById('curl_' + id).innerHTML = value;
+    }
+}
+
+function setupCurlVariable(id, query) {
+    setCurlVariable(id, query);
+    document.getElementById(id).addEventListener('input', function() {
+        setCurlVariable(id, query);
+    }, false);
+}
+
+/**
+ * Setup an interactive api table.
+ *
+ * @param {object} ids map of textarea id to bool, if the field is a query param
+ * @param {async function(object): string} action the async action function, takes a map of id:value as input and
+ * should return a string.
+ */
+function setupApiTable(ids, action) {
+    for (const id of Object.keys(ids)) {
+        let value = ids[id];
+        setupCurlVariable(id, value || false);
+    }
+    const button = document.getElementById('at-action-button');
+    button.addEventListener('click', async function() {
+        let fields = {};
+        for (const id of Object.keys(ids)) {
+            let value = document.getElementById(id).value.trim();
+            fields[id] = value;
+        }
+        try {
+            const result = await action(fields);
+            document.getElementById("result").innerHTML = result;
+        } catch (e) {
+            document.getElementById("result").innerHTML = e;
+        }
+    });
+}

--- a/docs/javascripts/api-table.js
+++ b/docs/javascripts/api-table.js
@@ -31,6 +31,12 @@ function setFailureTip(message) {
     }
 }
 
+function trackAction() {
+    if (trackWithPageContext) {
+        trackWithPageContext("api table action", new URL(window.location.href));
+    }
+}
+
 /**
  * Setup an interactive api table.
  *
@@ -45,6 +51,7 @@ function setupApiTable(ids, action) {
     }
     const button = document.getElementById('at-action-button');
     button.addEventListener('click', async function() {
+        trackAction();
         let fields = {};
         for (const id of Object.keys(ids)) {
             let value = document.getElementById(id).value.trim();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -432,3 +432,11 @@ margin: 1em auto 1em;
   -webkit-mask-image: var(--md-admonition-icon--alpha);
           mask-image: var(--md-admonition-icon--alpha);
 }
+
+/* textarea style for interactive api tables */
+
+textarea.at-field {
+  width: 220px;
+  height: 30px;
+  resize: none;
+}

--- a/includes/experiment-interactive-evaluation-api-table.md
+++ b/includes/experiment-interactive-evaluation-api-table.md
@@ -10,7 +10,7 @@
 
 | <div class='big-column'>Variable</div> | Description |
 | --- | --- |
-| <textarea class="at-field" spellcheck="false" placeholder="deployment_key" id="deployment_key"></textarea> |  (Required) The [deployment](../../general/data-model.md#deployments) key. |
+| <textarea class="at-field" spellcheck="false" placeholder="deployment_key" id="deployment_key"></textarea> |  (Required) The [deployment](../general/data-model.md#deployments) key. |
 | <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | The user's ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | A specific flag key to get the variant of. If empty/missing, all flags & experiments associated with the deployment key are evaluated. |

--- a/includes/experiment-interactive-evaluation-api-table.md
+++ b/includes/experiment-interactive-evaluation-api-table.md
@@ -1,3 +1,6 @@
+!!!warning "Potential data changes"
+    This example makes real requests to the API and can potentially change the data in your Amplitude project. We recommend using a development project when testing APIs.
+
 <pre>
 <code>curl --request GET \
      --url 'https://api.lab.amplitude.com/v1/vardata?<span id='curl_user_id'></span><span id='curl_device_id'></span><span id='curl_flag_key'></span><span id='curl_context'></span>' \
@@ -14,7 +17,7 @@
 | <textarea class="at-field" spellcheck="false" placeholder="context" id="context"></textarea> | JSON string consisting of a full user context. Set user properties in the `user_properties` field (e.g. `{"user_properties":{"premium":true}}`). |
 | <a class="md-button" id="at-action-button">Send</a> | |
 
-Result:
+Result: <span id="failure_tip"></span>
 <pre>
 <code id="result">
 </code>

--- a/includes/experiment-interactive-evaluation-api-table.md
+++ b/includes/experiment-interactive-evaluation-api-table.md
@@ -25,7 +25,7 @@ Result:
 
 <script>
 document.getElementById('deployment_key').value =
-    localStorage.getItem('deployment_key') || 'deployment_key';
+    localStorage.getItem('deployment_key') || '';
 
 setupApiTable({
     'deployment_key': false,

--- a/includes/experiment-interactive-evaluation-api-table.md
+++ b/includes/experiment-interactive-evaluation-api-table.md
@@ -12,49 +12,36 @@
 | <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | A specific flag key to get the variant of. If empty/missing, all flags & experiments associated with the deployment key are evaluated. |
 | <textarea class="at-field" spellcheck="false" placeholder="context" id="context"></textarea> | JSON string consisting of a full user context. Set user properties in the `user_properties` field (e.g. `{"user_properties":{"premium":true}}`). |
-| <a class="md-button" onclick="evaluationApiSend()">Send</a> | |
+| <a class="md-button" id="at-action-button">Send</a> | |
+
+Result:
+<pre>
+<code id="result">
+</code>
+</pre>
+
+<script src="/javascripts/api-table.js">
+</script>
 
 <script>
-function setCurlVariable(id, query) {
-    const value = document.getElementById(id).value;
-    if (value) {
-        value = value.trim();
-    }
-    if (query) {
-        if (value && value.length > 0) {
-            document.getElementById('curl_' + id).innerHTML =
-                '&' + id + '=' + encodeURIComponent(value);
-        } else {
-            document.getElementById('curl_' + id).innerHTML = '';
-        }
-    } else {
-        document.getElementById('curl_' + id).innerHTML = value;
-    }
-}
-function setupCurlVariable(id, query) {
-    setCurlVariable(id, query);
-    document.getElementById(id).addEventListener('input', function() {
-        setCurlVariable(id, query);
-    }, false);
-}
-
 document.getElementById('deployment_key').value =
     localStorage.getItem('deployment_key') || 'deployment_key';
 
-setupCurlVariable('deployment_key', false);
-setupCurlVariable('user_id', true);
-setupCurlVariable('device_id', true);
-setupCurlVariable('flag_key', true);
-setupCurlVariable('context', true);
+setupApiTable({
+    'deployment_key': false,
+    'user_id': true,
+    'device_id': true,
+    'flag_key': true,
+    'context': true,
+}, async function(fields) {
+    const deploymentKey = fields['deployment_key'];
+    const userId = fields['user_id'];
+    const deviceId = fields['device_id'];
+    const flagKey = fields['flag_key'];
+    const context = fields['context'];
 
-// Fetch Variants for the table above
-async function evaluationApiSend() {
-    const deploymentKey = document.getElementById("deployment_key").value.trim();
     localStorage.setItem('deployment_key', deploymentKey);
-    const userId = document.getElementById("user_id").value.trim();
-    const deviceId = document.getElementById("device_id").value.trim();
-    const flagKey = document.getElementById("flag_key").value.trim();
-    const context = document.getElementById("context").value.trim();
+
     let uri = 'https://api.lab.amplitude.com/v1/vardata?'
     if (userId && userId.length > 0) {
         uri = uri + '&user_id=' + userId;
@@ -68,26 +55,17 @@ async function evaluationApiSend() {
     if (context && context.length > 0) {
         uri = uri + '&context=' + context;
     }
-    try {
-        const response = await fetch(uri, {
-            headers: {
-                'Authorization': 'Api-Key ' + deploymentKey,
-           },
-        });
-        if (response.status != 200) {
-            const body = await response.text();
-            throw Error(response.status + ': ' + body);
-        }
-        const result = await response.json();
-        document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
-    } catch (e) {
-        document.getElementById("result").innerHTML = e;
-    }
-}
-</script>
 
-Result:
-<pre>
-<code id="result">
-</code>
-</pre>
+    const response = await fetch(uri, {
+        headers: {
+            'Authorization': 'Api-Key ' + deploymentKey,
+        },
+    });
+    if (response.status != 200) {
+        const body = await response.text();
+        throw Error(response.status + ': ' + body);
+    }
+    const result = await response.json();
+    return JSON.stringify(result, null, 2);
+});
+</script>

--- a/includes/experiment-interactive-evaluation-api-table.md
+++ b/includes/experiment-interactive-evaluation-api-table.md
@@ -1,0 +1,93 @@
+<pre>
+<code>curl --request GET \
+     --url 'https://api.lab.amplitude.com/v1/vardata?<span id='curl_user_id'></span><span id='curl_device_id'></span><span id='curl_flag_key'></span><span id='curl_context'></span>' \
+     --header 'Authorization: Api-Key <span id='curl_deployment_key'></span>'
+</code>
+</pre>
+
+| <div class='big-column'>Variable</div> | Description |
+| --- | --- |
+| <textarea class="at-field" spellcheck="false" placeholder="deployment_key" id="deployment_key"></textarea> |  (Required) The [deployment](../../general/data-model.md#deployments) key. |
+| <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | The user's ID. |
+| <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
+| <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | A specific flag key to get the variant of. If empty/missing, all flags & experiments associated with the deployment key are evaluated. |
+| <textarea class="at-field" spellcheck="false" placeholder="context" id="context"></textarea> | JSON string consisting of a full user context. Set user properties in the `user_properties` field (e.g. `{"user_properties":{"premium":true}}`). |
+| <a class="md-button" onclick="evaluationApiSend()">Send</a> | |
+
+<script>
+function setCurlVariable(id, query) {
+    const value = document.getElementById(id).value;
+    if (value) {
+        value = value.trim();
+    }
+    if (query) {
+        if (value && value.length > 0) {
+            document.getElementById('curl_' + id).innerHTML =
+                '&' + id + '=' + encodeURIComponent(value);
+        } else {
+            document.getElementById('curl_' + id).innerHTML = '';
+        }
+    } else {
+        document.getElementById('curl_' + id).innerHTML = value;
+    }
+}
+function setupCurlVariable(id, query) {
+    setCurlVariable(id, query);
+    document.getElementById(id).addEventListener('input', function() {
+        setCurlVariable(id, query);
+    }, false);
+}
+
+document.getElementById('deployment_key').value =
+    localStorage.getItem('deployment_key') || 'deployment_key';
+
+setupCurlVariable('deployment_key', false);
+setupCurlVariable('user_id', true);
+setupCurlVariable('device_id', true);
+setupCurlVariable('flag_key', true);
+setupCurlVariable('context', true);
+
+// Fetch Variants for the table above
+async function evaluationApiSend() {
+    const deploymentKey = document.getElementById("deployment_key").value.trim();
+    localStorage.setItem('deployment_key', deploymentKey);
+    const userId = document.getElementById("user_id").value.trim();
+    const deviceId = document.getElementById("device_id").value.trim();
+    const flagKey = document.getElementById("flag_key").value.trim();
+    const context = document.getElementById("context").value.trim();
+    let uri = 'https://api.lab.amplitude.com/v1/vardata?'
+    if (userId && userId.length > 0) {
+        uri = uri + '&user_id=' + userId;
+    }
+    if (deviceId && deviceId.length > 0) {
+        uri = uri + '&device_id=' + deviceId;
+    }
+    if (flagKey && flagKey.length > 0) {
+        uri = uri + '&flag_key=' + flagKey;
+    }
+    if (context && context.length > 0) {
+        uri = uri + '&context=' + context;
+    }
+    try {
+        const response = await fetch(uri, {
+            headers: {
+                'Authorization': 'Api-Key ' + deploymentKey,
+           },
+        });
+        if (response.status != 200) {
+            const body = await response.text();
+            throw Error(response.status + ': ' + body);
+        }
+        const result = await response.json();
+        document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
+    } catch (e) {
+        document.getElementById("result").innerHTML = e;
+    }
+}
+</script>
+
+Result:
+<pre>
+<code id="result">
+</code>
+</pre>

--- a/includes/experiment-interactive-exposure-table.md
+++ b/includes/experiment-interactive-exposure-table.md
@@ -1,17 +1,17 @@
 <pre>
 <code>curl --request POST \
      --url https://api2.amplitude.com/2/httpapi \
-     --data '{"api_key": "<span id="curl_api_key">api_key</span>","events":[{"event_type":"$exposure","user_id":"<span id="curl_user_id">user_id</span>","event_properties":{"flag_key":"<span id="curl_flag_key">flag_key</span>","variant":"<span id="curl_variant">variant</span>"}}]}'
+     --data '{"api_key": "<span id="curl_api_key"></span>","events":[{"event_type":"$exposure","user_id":"<span id="curl_user_id"></span>","event_properties":{"flag_key":"<span id="curl_flag_key"></span>","variant":"<span id="curl_variant"></span>"}}]}'
 </code>
 </pre>
 
 | <div class='big-column'>Variable</div> | Description |
 | --- | --- |
-|  <textarea class="at-field" spellcheck="false" id="api_key">api_key</textarea> | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
-| <textarea class="at-field" spellcheck="false" id="user_id">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [fetched variants](./fetch-variants.md) for. |
-| <textarea class="at-field" spellcheck="false" id="flag_key">getting-started</textarea> | The flag key; `getting-started` if you're using the naming from this guide. |
-| <textarea class="at-field" spellcheck="false" id="variant">on</textarea> | The variant key, `on` if you're using the default flag variant. |
-| <a class="md-button" onclick="trackExposure()">Track Exposure</a> | |
+|  <textarea class="at-field" spellcheck="false" placeholder="analytics_api_key" id="api_key">api_key</textarea> | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
+| <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [fetched variants](./fetch-variants.md) for. |
+| <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key">getting-started</textarea> | The flag key; `getting-started` if you're using the naming from this guide. |
+| <textarea class="at-field" spellcheck="false" placeholder="variant" id="variant">on</textarea> | The variant key, `on` if you're using the default flag variant. |
+| <a class="md-button" id="at-action-button">Track Exposure</a> | |
 
 Result:
 <pre>
@@ -19,76 +19,51 @@ Result:
 </code>
 </pre>
 
+<script src="/javascripts/api-table.js">
+</script>
+
 <script>
 document.getElementById('api_key').value =
      localStorage.getItem('api_key') || 'api_key';
 
-document.getElementById("curl_api_key").innerHTML =
-     document.getElementById("api_key").value;
-document.getElementById("api_key").addEventListener('input', function() {
-     document.getElementById("curl_api_key").innerHTML =
-          document.getElementById("api_key").value;
-}, false);
-
-document.getElementById("curl_user_id").innerHTML =
-     document.getElementById("user_id").value;
-document.getElementById("user_id").addEventListener('input', function() {
-     document.getElementById("curl_user_id").innerHTML =
-          document.getElementById("user_id").value;
-}, false);
-
-document.getElementById("curl_flag_key").innerHTML =
-     document.getElementById("flag_key").value;
-document.getElementById("flag_key").addEventListener('input', function() {
-     document.getElementById("curl_flag_key").innerHTML =
-          document.getElementById("flag_key").value;
-}, false);
-
-document.getElementById("curl_variant").innerHTML =
-     document.getElementById("variant").value;
-document.getElementById("variant").addEventListener('input', function() {
-     document.getElementById("curl_variant").innerHTML =
-          document.getElementById("variant").value;
-}, false);
-
-// Fetch Variants for the table above
-async function trackExposure() {
-     const apiKey = document.getElementById("api_key").value.trim();
-     const userId = document.getElementById("user_id").value.trim();
-     const flagKey = document.getElementById("flag_key").value.trim();
-     const variant = document.getElementById("variant").value.trim();
+setupApiTable({
+     'api_key': false,
+     'user_id': false,
+     'flag_key': false,
+     'variant': false,
+}, async function(fields) {
+     const apiKey = fields['api_key'];
+     const userId = fields['user_id'];
+     const flagKey = fields['flag_key'];
+     const variant = fields['variant'];
 
      localStorage.setItem('api_key', apiKey);
 
-     try {
-          const response = await fetch('https://api2.amplitude.com/2/httpapi', {
-               method: 'POST',
-               headers: {
-                    'Content-Type':'application/json',
-                    'Accept':'*/*'
-               },
-               body: JSON.stringify({
-                    "api_key": apiKey,
-                    "events":[
-                         {
-                              "event_type":"$exposure",
-                              "user_id": userId,
-                              "event_properties":{
-                                   "flag_key":flagKey,
-                                   "variant":variant
-                              }
+     const response = await fetch('https://api2.amplitude.com/2/httpapi', {
+          method: 'POST',
+          headers: {
+               'Content-Type':'application/json',
+               'Accept':'*/*'
+          },
+          body: JSON.stringify({
+               "api_key": apiKey,
+               "events":[
+                    {
+                         "event_type":"$exposure",
+                         "user_id": userId,
+                         "event_properties":{
+                              "flag_key":flagKey,
+                              "variant":variant
                          }
-                    ]
-               })
-          });
-          if (response.status != 200) {
-               const body = await response.text();
-               throw Error(response.status + ': ' + body);
-          }
-          const result = await response.json();
-          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
-     } catch (e) {
-          document.getElementById("result").innerHTML = e;
+                    }
+               ]
+          })
+     });
+     if (response.status != 200) {
+          const body = await response.text();
+          throw Error(response.status + ': ' + body);
      }
-}
+     const result = await response.json();
+     return JSON.stringify(result, null, 2);
+});
 </script>

--- a/includes/experiment-interactive-exposure-table.md
+++ b/includes/experiment-interactive-exposure-table.md
@@ -1,3 +1,6 @@
+!!!warning "Potential data changes"
+    This example makes real requests to the API and can potentially change the data in your Amplitude project. We recommend using a development project when testing APIs.
+
 <pre>
 <code>curl --request POST \
      --url https://api2.amplitude.com/2/httpapi \
@@ -13,7 +16,7 @@
 | <textarea class="at-field" spellcheck="false" placeholder="variant" id="variant">on</textarea> | The variant key, `on` if you're using the default flag variant. |
 | <a class="md-button" id="at-action-button">Track Exposure</a> | |
 
-Result:
+Result: <span id="failure_tip"></span>
 <pre>
 <code id="result">
 </code>

--- a/includes/experiment-interactive-exposure-table.md
+++ b/includes/experiment-interactive-exposure-table.md
@@ -24,7 +24,7 @@ Result:
 
 <script>
 document.getElementById('api_key').value =
-     localStorage.getItem('api_key') || 'api_key';
+     localStorage.getItem('api_key') || '';
 
 setupApiTable({
      'api_key': false,

--- a/includes/experiment-interactive-exposure-table.md
+++ b/includes/experiment-interactive-exposure-table.md
@@ -1,0 +1,94 @@
+<pre>
+<code>curl --request POST \
+     --url https://api2.amplitude.com/2/httpapi \
+     --data '{"api_key": "<span id="curl_api_key">api_key</span>","events":[{"event_type":"$exposure","user_id":"<span id="curl_user_id">user_id</span>","event_properties":{"flag_key":"<span id="curl_flag_key">flag_key</span>","variant":"<span id="curl_variant">variant</span>"}}]}'
+</code>
+</pre>
+
+| <div class='big-column'>Variable</div> | Description |
+| --- | --- |
+|  <textarea class="at-field" spellcheck="false" id="api_key">api_key</textarea> | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
+| <textarea class="at-field" spellcheck="false" id="user_id">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [fetched variants](./fetch-variants.md) for. |
+| <textarea class="at-field" spellcheck="false" id="flag_key">getting-started</textarea> | The flag key; `getting-started` if you're using the naming from this guide. |
+| <textarea class="at-field" spellcheck="false" id="variant">on</textarea> | The variant key, `on` if you're using the default flag variant. |
+| <a class="md-button" onclick="trackExposure()">Track Exposure</a> | |
+
+Result:
+<pre>
+<code id="result">
+</code>
+</pre>
+
+<script>
+document.getElementById('api_key').value =
+     localStorage.getItem('api_key') || 'api_key';
+
+document.getElementById("curl_api_key").innerHTML =
+     document.getElementById("api_key").value;
+document.getElementById("api_key").addEventListener('input', function() {
+     document.getElementById("curl_api_key").innerHTML =
+          document.getElementById("api_key").value;
+}, false);
+
+document.getElementById("curl_user_id").innerHTML =
+     document.getElementById("user_id").value;
+document.getElementById("user_id").addEventListener('input', function() {
+     document.getElementById("curl_user_id").innerHTML =
+          document.getElementById("user_id").value;
+}, false);
+
+document.getElementById("curl_flag_key").innerHTML =
+     document.getElementById("flag_key").value;
+document.getElementById("flag_key").addEventListener('input', function() {
+     document.getElementById("curl_flag_key").innerHTML =
+          document.getElementById("flag_key").value;
+}, false);
+
+document.getElementById("curl_variant").innerHTML =
+     document.getElementById("variant").value;
+document.getElementById("variant").addEventListener('input', function() {
+     document.getElementById("curl_variant").innerHTML =
+          document.getElementById("variant").value;
+}, false);
+
+// Fetch Variants for the table above
+async function trackExposure() {
+     const apiKey = document.getElementById("api_key").value.trim();
+     const userId = document.getElementById("user_id").value.trim();
+     const flagKey = document.getElementById("flag_key").value.trim();
+     const variant = document.getElementById("variant").value.trim();
+
+     localStorage.setItem('api_key', apiKey);
+
+     try {
+          const response = await fetch('https://api2.amplitude.com/2/httpapi', {
+               method: 'POST',
+               headers: {
+                    'Content-Type':'application/json',
+                    'Accept':'*/*'
+               },
+               body: JSON.stringify({
+                    "api_key": apiKey,
+                    "events":[
+                         {
+                              "event_type":"$exposure",
+                              "user_id": userId,
+                              "event_properties":{
+                                   "flag_key":flagKey,
+                                   "variant":variant
+                              }
+                         }
+                    ]
+               })
+          });
+          if (response.status != 200) {
+               const body = await response.text();
+               throw Error(response.status + ': ' + body);
+          }
+          const result = await response.json();
+          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
+     } catch (e) {
+          document.getElementById("result").innerHTML = e;
+     }
+}
+</script>

--- a/includes/experiment-interactive-exposure-tracking-table.md
+++ b/includes/experiment-interactive-exposure-tracking-table.md
@@ -12,7 +12,7 @@
 | <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | The flag key of the flag or experiment the user has been exposed to. |
 | <textarea class="at-field" spellcheck="false" placeholder="variant" id="variant"></textarea> | The variant key (e.g. `on`, `control`, `treatment`). |
-| <a class="md-button" onclick="trackExposure()">Track Exposure</a> | |
+| <a class="md-button" id="at-action-button">Track Exposure</a> | |
 
 Result:
 <pre>
@@ -20,77 +20,52 @@ Result:
 </code>
 </pre>
 
-<script>
-function setCurlVariable(id, query) {
-    let value = document.getElementById(id).value;
-    if (value) {
-        value = value.trim();
-    }
-    if (query) {
-        if (value && value.length > 0) {
-            document.getElementById('curl_' + id).innerHTML =
-                '&' + id + '=' + encodeURIComponent(value);
-        } else {
-            document.getElementById('curl_' + id).innerHTML = '';
-        }
-    } else {
-        document.getElementById('curl_' + id).innerHTML = value;
-    }
-}
-function setupCurlVariable(id, query) {
-    setCurlVariable(id, query);
-    document.getElementById(id).addEventListener('input', function() {
-        setCurlVariable(id, query);
-    }, false);
-}
+<script src="/javascripts/api-table.js">
+</script>
 
+<script>
 document.getElementById('api_key').value =
      localStorage.getItem('api_key') || 'api_key';
 
-setupCurlVariable('api_key', false);
-setupCurlVariable('user_id', false);
-setupCurlVariable('device_id', false);
-setupCurlVariable('flag_key', false);
-setupCurlVariable('variant', false);
-
-// Fetch Variants for the table above
-async function trackExposure() {
-     const apiKey = document.getElementById("api_key").value.trim();
-     const userId = document.getElementById("user_id").value.trim();
-     const deviceId = document.getElementById("device_id").value.trim();
-     const flagKey = document.getElementById("flag_key").value.trim();
-     const variant = document.getElementById("variant").value.trim();
+setupApiTable({
+     'api_key': false,
+     'user_id': false,
+     'device_id': false,
+     'flag_key': false,
+     'variant': false
+}, async function(fields) {
+     const apiKey = fields['api_key'];
+     const userId = fields['user_id'];
+     const deviceId = fields['device_id'];
+     const flagKey = fields['flag_key'];
+     const variant = fields['variant'];
 
      localStorage.setItem('api_key', apiKey);
 
-     try {
-          const response = await fetch('https://api2.amplitude.com/2/httpapi', {
-               method: 'POST',
-               headers: {
-                    'Content-Type':'application/json',
-                    'Accept':'*/*'
-               },
-               body: JSON.stringify({
-                    "api_key": apiKey,
-                    "events":[{
-                         "event_type":"$exposure",
-                         "user_id": userId,
-                         "device_id": deviceId,
-                         "event_properties":{
-                              "flag_key": flagKey,
-                              "variant": variant
-                         }
-                    }]
-               })
-          });
-          if (response.status != 200) {
-               const body = await response.text();
-               throw Error(response.status + ': ' + body);
-          }
-          const result = await response.json();
-          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
-     } catch (e) {
-          document.getElementById("result").innerHTML = e;
+     const response = await fetch('https://api2.amplitude.com/2/httpapi', {
+          method: 'POST',
+          headers: {
+               'Content-Type':'application/json',
+               'Accept':'*/*'
+          },
+          body: JSON.stringify({
+               "api_key": apiKey,
+               "events":[{
+                    "event_type":"$exposure",
+                    "user_id": userId,
+                    "device_id": deviceId,
+                    "event_properties":{
+                         "flag_key": flagKey,
+                         "variant": variant
+                    }
+               }]
+          })
+     });
+     if (response.status != 200) {
+          const body = await response.text();
+          throw Error(response.status + ': ' + body);
      }
-}
+     const result = await response.json();
+     return JSON.stringify(result, null, 2);
+});
 </script>

--- a/includes/experiment-interactive-exposure-tracking-table.md
+++ b/includes/experiment-interactive-exposure-tracking-table.md
@@ -1,0 +1,96 @@
+<pre>
+<code>curl --request POST \
+     --url https://api2.amplitude.com/2/httpapi \
+     --data '{"api_key":"<span id="curl_api_key"></span>","events":[{"event_type":"$exposure","user_id":"<span id="curl_user_id"></span>","device_id":"<span id="curl_device_id"></span>","event_properties":{"flag_key":"<span id="curl_flag_key"></span>","variant":"<span id="curl_variant"></span>"}}]}'
+</code>
+</pre>
+
+| <div class='big-column'>Variable</div> | Description |
+| --- | --- |
+|  <textarea class="at-field" spellcheck="false" placeholder="analytics_api_key" id="api_key"></textarea> | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
+| <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | The user's ID. |
+| <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
+| <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | The flag key of the flag or experiment the user has been exposed to. |
+| <textarea class="at-field" spellcheck="false" placeholder="variant" id="variant"></textarea> | The variant key (e.g. `on`, `control`, `treatment`). |
+| <a class="md-button" onclick="trackExposure()">Track Exposure</a> | |
+
+Result:
+<pre>
+<code id="result">
+</code>
+</pre>
+
+<script>
+function setCurlVariable(id, query) {
+    let value = document.getElementById(id).value;
+    if (value) {
+        value = value.trim();
+    }
+    if (query) {
+        if (value && value.length > 0) {
+            document.getElementById('curl_' + id).innerHTML =
+                '&' + id + '=' + encodeURIComponent(value);
+        } else {
+            document.getElementById('curl_' + id).innerHTML = '';
+        }
+    } else {
+        document.getElementById('curl_' + id).innerHTML = value;
+    }
+}
+function setupCurlVariable(id, query) {
+    setCurlVariable(id, query);
+    document.getElementById(id).addEventListener('input', function() {
+        setCurlVariable(id, query);
+    }, false);
+}
+
+document.getElementById('api_key').value =
+     localStorage.getItem('api_key') || 'api_key';
+
+setupCurlVariable('api_key', false);
+setupCurlVariable('user_id', false);
+setupCurlVariable('device_id', false);
+setupCurlVariable('flag_key', false);
+setupCurlVariable('variant', false);
+
+// Fetch Variants for the table above
+async function trackExposure() {
+     const apiKey = document.getElementById("api_key").value.trim();
+     const userId = document.getElementById("user_id").value.trim();
+     const deviceId = document.getElementById("device_id").value.trim();
+     const flagKey = document.getElementById("flag_key").value.trim();
+     const variant = document.getElementById("variant").value.trim();
+
+     localStorage.setItem('api_key', apiKey);
+
+     try {
+          const response = await fetch('https://api2.amplitude.com/2/httpapi', {
+               method: 'POST',
+               headers: {
+                    'Content-Type':'application/json',
+                    'Accept':'*/*'
+               },
+               body: JSON.stringify({
+                    "api_key": apiKey,
+                    "events":[{
+                         "event_type":"$exposure",
+                         "user_id": userId,
+                         "device_id": deviceId,
+                         "event_properties":{
+                              "flag_key": flagKey,
+                              "variant": variant
+                         }
+                    }]
+               })
+          });
+          if (response.status != 200) {
+               const body = await response.text();
+               throw Error(response.status + ': ' + body);
+          }
+          const result = await response.json();
+          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
+     } catch (e) {
+          document.getElementById("result").innerHTML = e;
+     }
+}
+</script>

--- a/includes/experiment-interactive-exposure-tracking-table.md
+++ b/includes/experiment-interactive-exposure-tracking-table.md
@@ -25,7 +25,7 @@ Result:
 
 <script>
 document.getElementById('api_key').value =
-     localStorage.getItem('api_key') || 'api_key';
+     localStorage.getItem('api_key') || '';
 
 setupApiTable({
      'api_key': false,

--- a/includes/experiment-interactive-exposure-tracking-table.md
+++ b/includes/experiment-interactive-exposure-tracking-table.md
@@ -1,3 +1,6 @@
+!!!warning "Potential data changes"
+    This example makes real requests to the API and can potentially change the data in your Amplitude project. We recommend using a development project when testing APIs.
+
 <pre>
 <code>curl --request POST \
      --url https://api2.amplitude.com/2/httpapi \
@@ -14,7 +17,7 @@
 | <textarea class="at-field" spellcheck="false" placeholder="variant" id="variant"></textarea> | The variant key (e.g. `on`, `control`, `treatment`). |
 | <a class="md-button" id="at-action-button">Track Exposure</a> | |
 
-Result:
+Result: <span id="failure_tip"></span>
 <pre>
 <code id="result">
 </code>

--- a/includes/experiment-interactive-exposure-tracking-table.md
+++ b/includes/experiment-interactive-exposure-tracking-table.md
@@ -10,7 +10,7 @@
 
 | <div class='big-column'>Variable</div> | Description |
 | --- | --- |
-|  <textarea class="at-field" spellcheck="false" placeholder="analytics_api_key" id="api_key"></textarea> | The analytics API key from [project](../../general/data-model.md#projects) which you created your [flag](../../general/data-model.md#flags-and-experiments) and [deployment](../../general/data-model.md#deployments) in. |
+|  <textarea class="at-field" spellcheck="false" placeholder="analytics_api_key" id="api_key"></textarea> | The analytics API key from [project](./data-model.md#projects) which you created your [flag](./data-model.md#flags-and-experiments) and [deployment](./data-model.md#deployments) in. |
 | <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | The user's ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="device_id" id="device_id"></textarea> | The user's device ID. |
 | <textarea class="at-field" spellcheck="false" placeholder="flag_key" id="flag_key"></textarea> | The flag key of the flag or experiment the user has been exposed to. |

--- a/includes/experiment-interactive-fetch-table.md
+++ b/includes/experiment-interactive-fetch-table.md
@@ -1,0 +1,60 @@
+<pre>
+<code id="curl">curl --request GET \
+     --url 'https://api.lab.amplitude.com/v1/vardata?user_id=<span id='curl_user_id'>user_id</span>' \
+     --header 'Authorization: Api-Key <span id='curl_deployment_key'>deployment_key</span>'
+</code>
+</pre>
+
+| <div class='big-column'>Variable</div> | Description |
+| --- | --- |
+|   <textarea spellcheck="false" style="resize:none" id="deployment_key" rows="1" cols="40">deployment_key</textarea> | The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
+| <textarea spellcheck="false" style="resize:none" id="user_id" rows="1" cols="40">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
+| <a id="fetch_button" class="md-button" onclick="fetchVariants()">Fetch Variants</a> | |
+
+<script>
+// Set the deployment key from local storage in table
+document.getElementById('deployment_key').value =
+     localStorage.getItem('deployment_key') || 'deployment_key';
+// Set the deployment key and user id in the curl command
+document.getElementById("curl_deployment_key").innerHTML =
+     document.getElementById("deployment_key").value;
+document.getElementById("curl_user_id").innerHTML =
+     document.getElementById("user_id").value;
+// Update deployment key and user id in curl command when table input changes
+document.getElementById("deployment_key").addEventListener('input', function() {
+     document.getElementById("curl_deployment_key").innerHTML =
+          document.getElementById("deployment_key").value;
+}, false);
+document.getElementById("user_id").addEventListener('input', function() {
+     document.getElementById("curl_user_id").innerHTML =
+          document.getElementById("user_id").value;
+}, false);
+// Fetch Variants for the table above
+async function fetchVariants() {
+     const dk = document.getElementById("deployment_key").value.trim();
+     localStorage.setItem('deployment_key', dk);
+     const id = document.getElementById("user_id").value.trim();
+     try {
+          const response = await fetch('https://api.lab.amplitude.com/v1/vardata?user_id=' + id, {
+               headers: {
+                    'Authorization': 'Api-Key ' + dk,
+               },
+          });
+          if (response.status != 200) {
+               const body = await response.text();
+               throw Error(response.status + ': ' + body);
+          }
+          const result = await response.json();
+          console.log(result);
+          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
+     } catch (e) {
+          document.getElementById("result").innerHTML = e;
+     }
+}
+</script>
+
+Result:
+<pre>
+<code id="result">
+</code>
+</pre>

--- a/includes/experiment-interactive-fetch-table.md
+++ b/includes/experiment-interactive-fetch-table.md
@@ -1,60 +1,48 @@
 <pre>
 <code>curl --request GET \
-     --url 'https://api.lab.amplitude.com/v1/vardata?user_id=<span id='curl_user_id'>user_id</span>' \
-     --header 'Authorization: Api-Key <span id='curl_deployment_key'>deployment_key</span>'
+     --url 'https://api.lab.amplitude.com/v1/vardata?<span id='curl_user_id'></span>' \
+     --header 'Authorization: Api-Key <span id='curl_deployment_key'></span>'
 </code>
 </pre>
 
 | <div class='big-column'>Variable</div> | Description |
 | --- | --- |
-|   <textarea class="at-field" spellcheck="false" id="deployment_key">deployment_key</textarea> | The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
-| <textarea class="at-field" spellcheck="false" id="user_id">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
-| <a class="md-button" onclick="fetchVariants()">Fetch Variants</a> | |
-
-<script>
-// Set the deployment key from local storage in table
-document.getElementById('deployment_key').value =
-     localStorage.getItem('deployment_key') || 'deployment_key';
-// Set the deployment key and user id in the curl command
-document.getElementById("curl_deployment_key").innerHTML =
-     document.getElementById("deployment_key").value;
-document.getElementById("curl_user_id").innerHTML =
-     document.getElementById("user_id").value;
-// Update deployment key and user id in curl command when table input changes
-document.getElementById("deployment_key").addEventListener('input', function() {
-     document.getElementById("curl_deployment_key").innerHTML =
-          document.getElementById("deployment_key").value;
-}, false);
-document.getElementById("user_id").addEventListener('input', function() {
-     document.getElementById("curl_user_id").innerHTML =
-          document.getElementById("user_id").value;
-}, false);
-// Fetch Variants for the table above
-async function fetchVariants() {
-     const dk = document.getElementById("deployment_key").value.trim();
-     localStorage.setItem('deployment_key', dk);
-     const id = document.getElementById("user_id").value.trim();
-     try {
-          const response = await fetch('https://api.lab.amplitude.com/v1/vardata?user_id=' + id, {
-               headers: {
-                    'Authorization': 'Api-Key ' + dk,
-               },
-          });
-          if (response.status != 200) {
-               const body = await response.text();
-               throw Error(response.status + ': ' + body);
-          }
-          const result = await response.json();
-          console.log(result);
-          document.getElementById("result").innerHTML = JSON.stringify(result, null, 2);
-     } catch (e) {
-          document.getElementById("result").innerHTML = e;
-     }
-}
-</script>
+| <textarea class="at-field" spellcheck="false" placeholder="deployment_key" id="deployment_key"></textarea> | (Required) The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
+| <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | (Required) The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
+| <a class="md-button" id="at-action-button">Fetch Variants</a> | |
 
 Result:
 <pre>
 <code id="result">
 </code>
 </pre>
+
+<script src="/javascripts/api-table.js">
+</script>
+
+<script>
+document.getElementById('deployment_key').value =
+     localStorage.getItem('deployment_key') || 'deployment_key';
+
+setupApiTable({
+     'deployment_key': false,
+     'user_id': true
+}, async function(fields) {
+     const deploymentKey = fields['deployment_key'];
+     const userId = fields['user_id'];
+
+     localStorage.setItem('deployment_key', deploymentKey);
+
+     const response = await fetch('https://api.lab.amplitude.com/v1/vardata?user_id=' + userId, {
+          headers: {
+               'Authorization': 'Api-Key ' + deploymentKey,
+          },
+     });
+     if (response.status != 200) {
+          const body = await response.text();
+          throw Error(response.status + ': ' + body);
+     }
+     const result = await response.json();
+     return JSON.stringify(result, null, 2);
+});
+</script>

--- a/includes/experiment-interactive-fetch-table.md
+++ b/includes/experiment-interactive-fetch-table.md
@@ -22,7 +22,7 @@ Result:
 
 <script>
 document.getElementById('deployment_key').value =
-     localStorage.getItem('deployment_key') || 'deployment_key';
+     localStorage.getItem('deployment_key') || '';
 
 setupApiTable({
      'deployment_key': false,

--- a/includes/experiment-interactive-fetch-table.md
+++ b/includes/experiment-interactive-fetch-table.md
@@ -1,3 +1,6 @@
+!!!warning "Potential data changes"
+    This example makes real requests to the API and can potentially change the data in your Amplitude project. We recommend using a development project when testing APIs.
+
 <pre>
 <code>curl --request GET \
      --url 'https://api.lab.amplitude.com/v1/vardata?<span id='curl_user_id'></span>' \
@@ -11,7 +14,7 @@
 | <textarea class="at-field" spellcheck="false" placeholder="user_id" id="user_id"></textarea> | (Required) The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
 | <a class="md-button" id="at-action-button">Fetch Variants</a> | |
 
-Result:
+Result: <span id="failure_tip"></span>
 <pre>
 <code id="result">
 </code>

--- a/includes/experiment-interactive-fetch-table.md
+++ b/includes/experiment-interactive-fetch-table.md
@@ -1,5 +1,5 @@
 <pre>
-<code id="curl">curl --request GET \
+<code>curl --request GET \
      --url 'https://api.lab.amplitude.com/v1/vardata?user_id=<span id='curl_user_id'>user_id</span>' \
      --header 'Authorization: Api-Key <span id='curl_deployment_key'>deployment_key</span>'
 </code>
@@ -7,9 +7,9 @@
 
 | <div class='big-column'>Variable</div> | Description |
 | --- | --- |
-|   <textarea spellcheck="false" style="resize:none" id="deployment_key" rows="1" cols="40">deployment_key</textarea> | The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
-| <textarea spellcheck="false" style="resize:none" id="user_id" rows="1" cols="40">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
-| <a id="fetch_button" class="md-button" onclick="fetchVariants()">Fetch Variants</a> | |
+|   <textarea class="at-field" spellcheck="false" id="deployment_key">deployment_key</textarea> | The [deployment](../../general/data-model.md#deployments) key you [created](./create-a-deployment.md). |
+| <textarea class="at-field" spellcheck="false" id="user_id">user_id</textarea> | The user ID used to fetch variants. This should be the same [user](../../general/data-model.md#users) you [track exposure](./track-exposure.md) for. |
+| <a class="md-button" onclick="fetchVariants()">Fetch Variants</a> | |
 
 <script>
 // Set the deployment key from local storage in table

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -190,7 +190,7 @@ nav:
     - Ruby SDK (Beta): experiment/sdks/ruby-sdk.md
     - Python SDK (Beta): experiment/sdks/python-sdk.md
   - REST APIs:
-    - Evaluation API: "https://developers.experiment.amplitude.com/reference/get_v1-vardata"
+    - Evaluation API: experiment/apis/evaluation-api.md
     - Management API (Beta): "https://developers.experiment.amplitude.com/reference/management-api"
   # - Remove / Move:
   #   - experiment/sdks/beta-migration.md

--- a/overrides/partials/integrations/analytics/amplitude.html
+++ b/overrides/partials/integrations/analytics/amplitude.html
@@ -34,32 +34,36 @@ if (consent) {
         includeReferrer: true,
         includeGclid: true
     });
+
+    function trackWithPageContext(event, url) {
+        let paths = [];
+        for (const seg of url.pathname.split('/')) {
+            if (seg.length > 0) {
+                paths.push(seg);
+            }
+        }
+        let properties = {
+            url: window.location.href,
+            path: url.pathname,
+        };
+        if (paths.length > 0) {
+            properties.product = paths[0];
+            properties.page = paths[paths.length-1];
+        }
+        if (url.hash) {
+            properties.anchor = url.hash;
+        }
+        // HACK: figure out better environment switching
+        if (url.hostname === 'docs.developers.amplitude.com' || url.hostname === 'www.docs.developers.amplitude.com') {
+            amplitude.getInstance().logEvent(event, properties);
+        }
+    }
+
     /* Wait for page to load and application to mount */
     document.addEventListener("DOMContentLoaded", function() {
         // Subscribe to navigation changes
         location$.subscribe(function(url) {
-            /* Track a page event */
-            let paths = [];
-            for (const seg of url.pathname.split('/')) {
-                if (seg.length > 0) {
-                    paths.push(seg);
-                }
-            }
-            let properties = {
-                url: window.location.href,
-                path: url.pathname,
-            };
-            if (paths.length > 0) {
-                properties.product = paths[0];
-                properties.page = paths[paths.length-1];
-            }
-            if (url.hash) {
-                properties.anchor = url.hash;
-            }
-            // HACK: figure out better environment switching
-            if (url.hostname === 'docs.developers.amplitude.com' || url.hostname === 'www.docs.developers.amplitude.com') {
-                amplitude.getInstance().logEvent("page viewed", properties);
-            }
+            trackWithPageContext("page viewed", url);
         });
     });
 }


### PR DESCRIPTION
# Dev Docs PR

## Description

This is a project I worked on this week in preparation for the dev docs GA. I know that a commonly used feature of the readme.com site was the interactive api, where the user could send requests from the browser.

This PR adds initial implementations for sending requests from the browser. Eventually I want to abstract this out and make a mkdocs plugin for generating these tables based on some schema, but that is currently out-of-scope and would require a lot more work.

![Screen Shot 2022-06-21 at 12 32 35 PM](https://user-images.githubusercontent.com/3282199/174882847-7bfe3187-e9f5-4e72-abb6-a0b445034727.png)

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [x] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp