### PR TITLE
releases-api: use a copy/pastable date format

### DIFF
--- a/docs/analytics/apis/releases-api.md
+++ b/docs/analytics/apis/releases-api.md
@@ -56,8 +56,8 @@ You can send the release's parameters as a JSON payload, or query parameters.
 |<div class="big-column">Name</div>|Description|
 |----|-------|
 |`version`|Required. The version of your product corresponding to this release.|
-|`release_start`| Required. Timestamp corresponding to the start of this release in UTC. Must be in this format: `YYYY-mm-dd HH:mm:ss`.|
-|`release_end`| Optional. Timestamp corresponding to the end of this release in UTC. Must be in this format: `YYYY-mm-dd HH:mm:ss`.|
+|`release_start`| Required. Timestamp corresponding to the start of this release in UTC. Must be in this format: `yyyy-MM-dd HH:mm:ss`.|
+|`release_end`| Optional. Timestamp corresponding to the end of this release in UTC. Must be in this format: `yyyy-MM-dd HH:mm:ss`.|
 |`title`|Required. A name for the release.|
 |`description`|Optional. A description for the release.|
 |`platforms`|Optional. A list of platforms for this release.|


### PR DESCRIPTION
# Dev Docs PR

## Description

See:
.NET https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
Java https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html?is-external=true
JS https://date-fns.org/v2.28.0/docs/format

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

Because this is equivalent to a typo, I don't think the following apply.

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.

@amplitude-dev-docs
@caseyamp