### PR TITLE
AMP-56307 Fix aws account and external id in S3 import doc

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -81,7 +81,7 @@ Follow these steps to give Amplitude read access to your AWS S3 bucket.
     }
     ```
 
-4. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1.
+3. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1.
 Note: update the yellow highlighted text to match your bucket and prefix information as appropriate (`data/` is a sample prefix ).
 
     ```json hl_lines="16 30 41"

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -56,30 +56,32 @@ When your dataset is ready to be ingested, you can set up Amazon S3 Import in Am
 Follow these steps to give Amplitude read access to your AWS S3 bucket.
 
 1. Create a new IAM role, for example: “AmplitudeReadRole”.
-2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy, using the following example. Update **only** the highlighted text as needed.
+2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy, using the following example. Update **{{}}** in highlighted text. 
 
-    ```json hl_lines="7 8 13"
+    * **{{amplitude_account}}**: `358203115967` for Amplitude US data center. `202493300829` for Amplitude EU data center. 
+    * **{{external_id}}**: unique identifiers used when assuming roles. Example can be `vzup2dfp-5gj9-8gxh-5294-sd9wsncks7dc`.
+
+    ``` json hl_lines="7 12"
     {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "arn:aws:iam::358203115967:root"(us region)
-        "AWS": "arn:aws:iam::202493300829:root"(eu region)
-        },
-        "Action": "sts:AssumeRole",
-        "Condition": {
-          "StringEquals": {
-            "sts:ExternalId": "vzup2dfp-5gj9-8gxh-5294-sd9wsncks7dc"
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::{{amplitude_account}}:root"
+          },
+          "Action": "sts:AssumeRole",
+          "Condition": {
+            "StringEquals": {
+              "sts:ExternalId": "{{external_id}}"
+            }
           }
         }
-      }
-    ]
+      ]
     }
     ```
 
-3. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1.
+4. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1.
 Note: update the yellow highlighted text to match your bucket and prefix information as appropriate (`data/` is a sample prefix ).
 
     ```json hl_lines="16 30 41"
@@ -154,10 +156,10 @@ When you have your bucket details, create the Amazon S3 Import source.
 
 3. Complete the **Configure S3 location** section on the Set up S3 Bucket page:
 
-   1. **Bucket Name**: Name of bucket you created to store the files. For example, `com-amplitude-vacuum-<customername>.` This tells Amplitude where to look for your files.
-   2. **Prefix**: Location of files to be imported. This must end with “/”. For example, `dev/event-data/`.
-   3. **AWS Role ARN**. Required.
-   4. **AWS External ID**. Required.
+    * **Bucket Name**: Name of bucket you created to store the files. For example, `com-amplitude-vacuum-<customername>.` This tells Amplitude where to look for your files.
+    * **Prefix**: Location of files to be imported. This must end with “/”. For example, `dev/event-data/`.
+    * **AWS Role ARN**. Required.
+    * **AWS External ID**. Required.
 
 4. Optional: enable **S3 Event Notification**. See [Manage Event Notifications](#optional-manage-event-notifications) for more information.
 


### PR DESCRIPTION
# Dev Docs PR
Fix aws account and external id in S3 import doc

## Description

Please read thread for details https://amplitude.slack.com/archives/CMW3ZELRE/p1656597999363599?thread_ts=1656529407.024349&cid=CMW3ZELRE. In summary, fix the s3 import instruction to reduce confusions when setting up IAM roles for s3 import.

## Deadline

When do these changes need to be live on the site?
ASAP.

## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp