### PR TITLE
Typos fixes in Dashboard API doc

### DIFF
--- a/docs/analytics/apis/dashboard-rest-api.md
+++ b/docs/analytics/apis/dashboard-rest-api.md
@@ -147,14 +147,14 @@ The event parameter can include these keys:
 ## Get results from an existing chart
 
 Get JSON results from any saved chart via chart ID.
-`GET https://amplitude.com/api/3/chart/chart_id/`
+`GET https://amplitude.com/api/3/chart/chart_id/query`
 
 ### Example request
 
 --8<-- "includes/postman.md"
 
 ```bash
-GET /api/3/chart/:chart_id/ HTTP/1.1
+GET /api/3/chart/:chart_id/query HTTP/1.1
 Host: amplitude.com
 Authorization: Basic {{api-key}}:{{secret-key}}
 ```
@@ -180,7 +180,7 @@ Get the number of active or new users.
 --8<-- "includes/postman.md"
 
 ```bash
-GET /api/2/users?users?start=20210101&end=20210901&m=active&i=30&g=city HTTP/1.1
+GET /api/2/users?start=20210101&end=20210901&m=active&i=30&g=city HTTP/1.1
 Host: amplitude.com
 Authorization: Basic {{api-key}}:{{secret-key}}
 ```


### PR DESCRIPTION
## Description

As Amplitude user I found typos in the documentation that I have been working with. The existing chart request won't work without the '/query' part after the 'chart_id', which is missing in the example. And the users request example has 'users?users?' part which causes the error, and should instead be 'users?' just one time.

## Change type

Doc update.