### PR TITLE
removed unnecessary minSdkVersion in Ampli android docs

### DIFF
--- a/docs/data/sdks/android-ampli.md
+++ b/docs/data/sdks/android-ampli.md
@@ -7,7 +7,7 @@ icon: material/android
 !!!note
     This page covers the Android Java and Kotlin runtimes. All (Itly) runtimes are deprecated. If you are still using an (Itly) runtime, see the **[migration guide](#migrating-from-previous-version)** to upgrade to the newest runtime. Docs for the Itly version are available **[here](browser)**.
 
-Amplitude Data supports tracking analytics events from Android apps (API 22 and above) written in Kotlin and Java.
+Amplitude Data supports tracking analytics events from Android apps written in Kotlin and Java.
 
 In Kotlin and Java, the tracking library exposes a type-safe function for every event in your team’s tracking plan. The function’s arguments correspond to the event’s properties and are strongly typed to allow for code completion and compile-time checks.
 

--- a/docs/data/sdks/android-kotlin-ampli.md
+++ b/docs/data/sdks/android-kotlin-ampli.md
@@ -7,7 +7,7 @@ icon: material/android
 !!!note
     This page covers the Android Java and Kotlin runtimes. All (Itly) runtimes are deprecated. If you are still using an (Itly) runtime, see the **[migration guide](#migrating-from-an-itly-android-runtime)** to upgrade to the newest runtime. Docs for the Itly version are available **[here](data/deprecated-sdks/android/)**.
 
-Amplitude Data supports tracking analytics events from Android apps (API 22 and above) written in Kotlin and Java.
+Amplitude Data supports tracking analytics events from Android apps written in Kotlin and Java.
 
 In Kotlin and Java, the tracking library exposes a type-safe function for every event in your team’s tracking plan. The function’s arguments correspond to the event’s properties and are strongly typed to allow for code completion and compile-time checks.
 


### PR DESCRIPTION
# Dev Docs PR
https://amplitude.atlassian.net/browse/AMP-56590

## Change type

- [x] Doc bug fix. Fixes #[https://amplitude.atlassian.net/browse/AMP-56590]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x ] My documentation follows the style guidelines of this project.
- [x ] I previewed my documentation on a local server using `mkdocs serve`.
- [x ] Running `mkdocs serve` didn't generate any failures.
- [x ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp