### PR TITLE
AMP-56739 Fix helper doc for S3/GCS import

### DIFF
--- a/docs/data/destinations.md
+++ b/docs/data/destinations.md
@@ -16,6 +16,12 @@ You can add a new destination in just a few clicks.
 
 For detailed instructions, see the documentation for the destination you want to add. 
 
+### Cloud storage
+
+<!-- This content is used in several places. Make changes to includes/data-destinations-cloud-storage.md -->
+
+--8<-- "includes/data-destinations-cloud-storage.md"
+
 ### Warehouse 
 
 <!-- This content is used in several places. Make changes to includes/data-destinations-warehouse.md -->

--- a/docs/data/sources.md
+++ b/docs/data/sources.md
@@ -26,6 +26,12 @@ For detailed instructions, see the documentation for the source you want to add.
 
 --8<-- "includes/data-sources-sdks.md"
 
+### Cloud storage
+
+<!-- This content is used in several places. Make changes to includes/data-sources-cloud-storage.md -->
+
+--8<-- "includes/data-sources-cloud-storage.md"
+
 ### Warehouse
 
 <!-- This content is used in several places. Make changes to includes/data-sources-warehouse.md -->

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -81,8 +81,10 @@ Follow these steps to give Amplitude read access to your AWS S3 bucket.
     }
     ```
 
-3. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1.
-Note: update the yellow highlighted text to match your bucket and prefix information as appropriate (`data/` is a sample prefix ).
+3. Attach the following policy (for example, `AmplitudeS3ReadOnlyAccess`) with the appropriate bucket to the Role created in Step 1. Update **{{}}** in highlighted text.
+
+    * **{{bucket_name}}**: the s3 bucket name where your data will be imported from.
+    * **{{prefix}}**: the location in s3 bucket above where your data lives.
 
     ```json hl_lines="16 30 41"
     {
@@ -95,12 +97,12 @@ Note: update the yellow highlighted text to match your bucket and prefix informa
           ],
           "Effect":"Allow",
           "Resource":[
-            "arn:aws:s3:::shareddatabucket"
+            "arn:aws:s3:::{{bucket_name}}"
           ],
           "Condition":{
             "StringLike":{
               "s3:prefix":[
-                "data/*"
+                "{{prefix}}/*"
               ]
             }
           }
@@ -114,7 +116,7 @@ Note: update the yellow highlighted text to match your bucket and prefix informa
             "s3:Head*"
           ],
           "Resource":[
-            "arn:aws:s3:::shareddatabucket/data/*"
+            "arn:aws:s3:::{{bucket_name}}/{{prefix}}/*"
           ]
         },
         {
@@ -125,7 +127,7 @@ Note: update the yellow highlighted text to match your bucket and prefix informa
             "s3:GetBucketNotification"
           ],
           "Resource":[
-            "arn:aws:s3:::shareddatabucket"
+            "arn:aws:s3:::{{bucket_name}}"
           ]
         }
       ]

--- a/includes/data-destinations-cloud-storage.md
+++ b/includes/data-destinations-cloud-storage.md
@@ -2,8 +2,7 @@
 
 <div class="grid cards" markdown>
 
-- :redshift: [Amazon RedShift](../data/destinations/redshift.md)
-- :bigquery: [Google BigQuery](../data/destinations/bigquery.md)
-- :snowflake: [Snowflake](../data/destinations/snowflake.md)
+- :s3: [Amazon S3](../data/destinations/amazon-s3.md)
+- :google-cloud-platform: [Google Cloud Storage](../data/destinations/google-cloud-storage.md)
 
 </div>

--- a/includes/data-sources-cloud-storage.md
+++ b/includes/data-sources-cloud-storage.md
@@ -2,8 +2,7 @@
 
 <div class="grid cards" markdown>
 
-- :redshift: [Amazon RedShift](../data/destinations/redshift.md)
-- :bigquery: [Google BigQuery](../data/destinations/bigquery.md)
-- :snowflake: [Snowflake](../data/destinations/snowflake.md)
+- :s3: [Amazon S3](../data/sources/amazon-s3.md)
+- :google-cloud-platform: [Google Cloud Storage](../data/sources/google-cloud-storage.md)
 
 </div>

--- a/includes/data-sources-warehouse.md
+++ b/includes/data-sources-warehouse.md
@@ -2,9 +2,7 @@
 
 <div class="grid cards" markdown>
 
-- :s3: [Amazon S3](../data/sources/amazon-s3.md)
 - :bigquery: [Google BigQuery](../data/sources/bigquery.md)
 - :snowflake: [Snowflake](../data/sources/snowflake.md)
-- :google-cloud-platform: [Google Cloud Storage](../data/sources/google-cloud-storage.md)
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,12 +242,13 @@ nav:
       - Unreal: data/sdks/unreal.md
       - Other Topics:
         - data/dynamic-configuration.md
-    - Warehouse:
+    - Cloud Storage:
       - Amazon S3: data/sources/amazon-s3.md
-      - BigQuery: data/sources/bigquery.md
       - Google Cloud Storage: data/sources/google-cloud-storage.md
-      - Snowflake: data/sources/snowflake.md
       - Converter Configuration: data/converter-configuration-reference.md
+    - Warehouse:
+      - BigQuery: data/sources/bigquery.md
+      - Snowflake: data/sources/snowflake.md
     - Other Sources:
       - Adjust: data/sources/adjust.md
       - Adobe: 
@@ -279,10 +280,11 @@ nav:
       - Userflow: data/sources/userflow.md
   - Destinations: 
     - Overview: data/destinations.md
-    - Warehouse:
+    - Cloud Storage:
       - Amazon S3: data/destinations/amazon-s3.md
-      - Redshift: data/destinations/redshift.md
       - Google Cloud Storage: data/destinations/google-cloud-storage.md
+    - Warehouse:
+      - Redshift: data/destinations/redshift.md
       - BigQuery: data/destinations/bigquery.md
       - Snowflake: data/destinations/snowflake.md
     - Event Streaming:


### PR DESCRIPTION
# Dev Docs PR


## Description

Fix 2 bugs in our helper doc.

- Hard to understand how to substitute bucket/prefix values in sample policy which makes it hard for customer to self-config.
- S3/GCS logs are in DWH category which is not correct

## Deadline

When do these changes need to be live on the site?

As soon as possible

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp