### PR TITLE
added Ampli header to TypeScript SDK docs

### DIFF
--- a/docs/data/sdks/typescript-browser.md
+++ b/docs/data/sdks/typescript-browser.md
@@ -12,6 +12,8 @@ icon: material/language-typescript
     - [TypeScript Browser SDK Repository :material-github:](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-browser)
     - [TypeScript Browser SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-TypeScript/releases)
 
+--8<-- "includes/ampli-vs-amplitude.md"
+
 The TypeScript Browser SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 
 ## Getting Started


### PR DESCRIPTION
# Dev Docs PR


## Description
Addded missing Ampli wrapper info to top of TypeScript SDK page

https://amplitude.atlassian.net/browse/AMP-56802
<img width="735" alt="image" src="https://user-images.githubusercontent.com/5790872/179128516-1a934db6-5dbe-4cd0-ad27-6f9512f0faf4.png">

## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp