### PR TITLE
add local evaluation benchmarks for golang sdk

### DIFF
--- a/docs/experiment/general/evaluation/local-evaluation.md
+++ b/docs/experiment/general/evaluation/local-evaluation.md
@@ -46,7 +46,7 @@ Local evaluation is only supported by server-side SDKs which have local evaluati
 | [:material-language-java: JVM (Beta)](../../sdks/jvm-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | ![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/experiment-jvm-server.svg?label=Maven%20Central) |
 | [:fontawesome-brands-golang: Go (Beta)](../../sdks/go-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/amplitude/experiment-go-server?sort=semver) |
 | [:material-language-ruby: Ruby (Beta)](../../sdks/ruby-sdk.md) |  :material-check-bold:{ .green } | :material-close-thick:{ .red } | - |
-
+| [:material-language-python: Python (Beta)](../../sdks/python-sdk.md) |  :material-check-bold:{ .green } | :material-close-thick:{ .red } | - |
 
 ### Performance
 

--- a/docs/experiment/general/evaluation/local-evaluation.md
+++ b/docs/experiment/general/evaluation/local-evaluation.md
@@ -55,3 +55,4 @@ The following results are for **a single flag evaluation**, and were collected o
 | SDK | Average | Median | Cold Start |
 | --- | --- | --- | --- |
 | [:material-nodejs: Node.js](../../sdks/nodejs-sdk.md) | 0.025ms | 0.018ms | 3ms |
+| [:fontawesome-brands-golang: Go](../../sdks/go-sdk.md) | 0.098ms | 0.071ms | 0.762ms |


### PR DESCRIPTION
# Dev Docs PR


## Description

Add a row to the benchmarking table for golang sdk

## Deadline

asap


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp