### PR TITLE
Amp 57412 ampli docs add all new options to ampli pull docs

### DIFF
--- a/docs/data/ampli/cli.md
+++ b/docs/data/ampli/cli.md
@@ -92,11 +92,16 @@ OPTIONS
   -p, --path=path        where the tracking library will be created
   -t, --token=token      personal API token to authenticate with
   -v, --version=version  the version to pull
+  --include-api-keys     include api keys to the tracking library (default true)
+  --omit-api-keys        omit api keys from the tracking library (default false)
 
 EXAMPLES
+  $ ampli pull
   $ ampli pull web
   $ ampli pull web -p ./ampli -b develop
   $ ampli pull web -p ./ampli -b develop -v 2.1.1
+  $ ampli pull --omit-api-keys
+  $ ampli pull --include-api-keys
 ```
 
 Run this command in the root folder of your project. For example:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -246,7 +246,7 @@ nav:
       - Unity: data/sdks/unity.md
       - Unreal: data/sdks/unreal.md
       - Legacy:
-        - JavaScript:
+        - Browser:
           - data/sdks/javascript/index.md
           - Ampli Codegen: data/sdks/browser-ampli.md
         - Android:


### PR DESCRIPTION
## Description
* Added missing options to `ampli pull` - `omit-api-keys`, `include-api-keys`
* Renamed legacy "JavaScript" to "Browser"

## Screenshots
<img width="237" alt="image" src="https://user-images.githubusercontent.com/5790872/180844247-85818963-d05d-4b6a-8b73-7dd4f7eb3e98.png">

<img width="986" alt="image" src="https://user-images.githubusercontent.com/5790872/180844350-84853ed0-430a-4bba-b412-690810b2ddad.png">


## Change type
- [x] Doc update.
- [x] New documentation.


@amplitude-dev-docs
@caseyamp