### PR TITLE
adds eu data residency code snippets

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -53,6 +53,28 @@ val amplitude = Amplitude(
 )
 ```
 
+### EU data residency
+
+You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
+ The server zone configuration supports dynamic configuration as well.
+
+For earlier versions, you need to configure the `serverURL` property after initializing the client.
+
+!!!note
+    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
+
+=== "Kotlin"
+
+    ```kotlin
+    // For versions starting from 2.34.0
+    // No need to call setServerUrl for sending data to Amplitude's EU servers
+    client.setServerZone(AmplitudeServerZone.EU)
+
+    // For earlier versions
+    client.setServerUrl("https://api.eu.amplitude.com")
+    ```
+
+
 ## Usage
 
 ### `track`

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -67,7 +67,7 @@ You can configure the server zone when initializing the client for sending data 
       Configuration(
         apiKey = AMPLITUDE_API_KEY,
         context = applicationContext,
-        serverZone = ServerZone.US
+        serverZone = ServerZone.EU
       )
     )
     ```

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -66,6 +66,7 @@ You can configure the server zone when initializing the client for sending data 
     val amplitude = Amplitude(
       Configuration(
         apiKey = AMPLITUDE_API_KEY,
+        context = applicationContext,
         serverZone = ServerZone.US
       )
     )

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -55,10 +55,7 @@ val amplitude = Amplitude(
 
 ### EU data residency
 
-You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
- The server zone configuration supports dynamic configuration as well.
-
-For earlier versions, you need to configure the `serverURL` property after initializing the client.
+You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
 !!!note
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
@@ -66,12 +63,12 @@ For earlier versions, you need to configure the `serverURL` property after initi
 === "Kotlin"
 
     ```kotlin
-    // For versions starting from 2.34.0
-    // No need to call setServerUrl for sending data to Amplitude's EU servers
-    client.setServerZone(AmplitudeServerZone.EU)
-
-    // For earlier versions
-    client.setServerUrl("https://api.eu.amplitude.com")
+    val amplitude = Amplitude(
+      Configuration(
+        apiKey = AMPLITUDE_API_KEY,
+        serverZone = ServerZone.US
+      )
+    )
     ```
 
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -53,7 +53,7 @@ val amplitude = Amplitude(
 )
 ```
 
-### EU data residency
+#### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 

--- a/docs/data/sdks/react-native-sdk.md
+++ b/docs/data/sdks/react-native-sdk.md
@@ -74,6 +74,27 @@ init(API_KEY, 'user@amplitude.com', {
 });
 ```
 
+### EU data residency
+
+You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set. The server zone configuration supports dynamic configuration as well.
+
+For earlier versions, you need to configure the `serverURL` property after initializing the client.
+
+!!!note
+    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
+
+=== "TypeScript"
+
+    ```ts
+    // For versions starting from 2.6.0
+    // No need to call setServerUrl for sending data to Amplitude's EU servers
+    Amplitude.getInstance().setServerZone('EU');
+
+    // For earlier versions
+    Amplitude.getInstance().setServerUrl("https://api.eu.amplitude.com"));
+    ```
+
+
 ### Tracking an event
 
 --8<-- "includes/sdk-httpv2-notice.md"

--- a/docs/data/sdks/react-native-sdk.md
+++ b/docs/data/sdks/react-native-sdk.md
@@ -76,24 +76,18 @@ init(API_KEY, 'user@amplitude.com', {
 
 ### EU data residency
 
-You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set. The server zone configuration supports dynamic configuration as well.
-
-For earlier versions, you need to configure the `serverURL` property after initializing the client.
+You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
 !!!note
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
-=== "TypeScript"
+```ts
+import * as amplitude from '@amplitude/analytics-browser';
 
-    ```ts
-    // For versions starting from 2.6.0
-    // No need to call setServerUrl for sending data to Amplitude's EU servers
-    Amplitude.getInstance().setServerZone('EU');
-
-    // For earlier versions
-    Amplitude.getInstance().setServerUrl("https://api.eu.amplitude.com"));
-    ```
-
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  serverZone: 'EU',
+  });
+```
 
 ### Tracking an event
 

--- a/docs/data/sdks/react-native-sdk.md
+++ b/docs/data/sdks/react-native-sdk.md
@@ -74,7 +74,7 @@ init(API_KEY, 'user@amplitude.com', {
 });
 ```
 
-### EU data residency
+#### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
@@ -82,11 +82,11 @@ You can configure the server zone when initializing the client for sending data 
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
 ```ts
-import * as amplitude from '@amplitude/analytics-browser';
+import * as amplitude from '@amplitude/analytics-react-native';
 
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   serverZone: 'EU',
-  });
+});
 ```
 
 ### Tracking an event

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -73,25 +73,18 @@ init(API_KEY, 'user@amplitude.com', {
 
 ### EU data residency
 
-You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
- The server zone configuration supports dynamic configuration as well.
-
-For earlier versions, you need to configure the `serverURL` property after initializing the client.
+You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
 !!!note
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
-=== "TypeScript"
+```ts
+import * as amplitude from '@amplitude/analytics-browser';
 
-    ```ts
-    // For versions starting from 2.6.0
-    // No need to call setServerUrl for sending data to Amplitude's EU servers
-    Amplitude.getInstance().setServerZone('EU');
-
-    // For earlier versions
-    Amplitude.getInstance().setServerUrl("https://api.eu.amplitude.com"));
-    ```
-
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  serverZone: 'EU',
+  });
+```
 
 ### Tracking an event
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -71,7 +71,7 @@ init(API_KEY, 'user@amplitude.com', {
 });
 ```
 
-### EU data residency
+#### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
@@ -83,7 +83,7 @@ import * as amplitude from '@amplitude/analytics-browser';
 
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   serverZone: 'EU',
-  });
+});
 ```
 
 ### Tracking an event

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -71,6 +71,28 @@ init(API_KEY, 'user@amplitude.com', {
 });
 ```
 
+### EU data residency
+
+You can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
+ The server zone configuration supports dynamic configuration as well.
+
+For earlier versions, you need to configure the `serverURL` property after initializing the client.
+
+!!!note
+    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
+
+=== "TypeScript"
+
+    ```ts
+    // For versions starting from 2.6.0
+    // No need to call setServerUrl for sending data to Amplitude's EU servers
+    Amplitude.getInstance().setServerZone('EU');
+
+    // For earlier versions
+    Amplitude.getInstance().setServerUrl("https://api.eu.amplitude.com"));
+    ```
+
+
 ### Tracking an event
 
 --8<-- "includes/sdk-httpv2-notice.md"

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -54,6 +54,16 @@ init(API_KEY, {
 });
 ```
 
+#### EU Data Residency
+
+Sending data to Amplitude's EU servers, you need to configure the server URL during the initialization.
+
+```ts
+client = Amplitude.init(<AMPLITUDE_API_KEY>, {
+    serverUrl: "https://api.eu.amplitude.com/2/httpapi"
+});
+```
+
 ### Tracking an event
 
 --8<-- "includes/sdk-httpv2-notice.md"

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -56,12 +56,17 @@ init(API_KEY, {
 
 #### EU Data Residency
 
-Sending data to Amplitude's EU servers, you need to configure the server URL during the initialization.
+You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
+
+!!!note
+    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
 ```ts
-client = Amplitude.init(<AMPLITUDE_API_KEY>, {
-    serverUrl: "https://api.eu.amplitude.com/2/httpapi"
-});
+import * as amplitude from '@amplitude/analytics-node';
+
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  serverZone: 'EU',
+  });
 ```
 
 ### Tracking an event

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -66,7 +66,7 @@ import * as amplitude from '@amplitude/analytics-node';
 
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   serverZone: 'EU',
-  });
+});
 ```
 
 ### Tracking an event


### PR DESCRIPTION
# Dev Docs PR


## Description

Adds EU data residency section for browser, node, react native and kotlin

<img width="850" alt="Screen Shot 2022-07-27 at 3 50 39 PM" src="https://user-images.githubusercontent.com/20634289/181385834-bb68c089-adf7-40c3-92d1-7af2caa9d892.png">

## Deadline

When do these changes need to be live on the site?

Earliest convenience

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp