### PR TITLE
add android kotlin plugin example

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -250,7 +250,7 @@ amplitude.add(new EnrichmentPlugin());
 
 #### Destination Type Plugin
 
-In destination plugin, you are able to overrite the track(), identify(), groupIdentify(), revenue(), flush() functions.
+In destination plugin, you are able to overwrite the track(), identify(), groupIdentify(), revenue(), flush() functions.
 
 ```java
 import com.amplitude.core.Amplitude;

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -187,7 +187,7 @@ Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying 
 
 ### Plugin.setup
 
-This method contains logic for preparing the plugin for use and has `client` instance as a parameter. The expected return value is `null`. A typical use for this method, is to copy configuration from `client.configuration` or instantiate plugin dependencies. This method is called when the plugin is registered to the client via `client.add()`.
+This method contains logic for preparing the plugin for use and has `amplitude` instance as a parameter. The expected return value is `null`. A typical use for this method, is to instantiate plugin dependencies. This method is called when the plugin is registered to the client via `amplitude.add()`.
 
 ### Plugin.execute
 
@@ -197,7 +197,7 @@ This method contains the logic for processing events and has `event` instance as
 
 #### Enrichment Type Plugin
 
-Here's an example of a plugin that modifies each event that is instrumented by adding an increment integer to `event_id` property of an event.
+Here's an example of a plugin that modifies each event that is instrumented by adding extra event property.
 
 ```java
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -250,6 +250,8 @@ amplitude.add(new EnrichmentPlugin());
 
 #### Destination Type Plugin
 
+In destination plugin, you are able to overrite the track(), identify(), groupIdentify(), revenue(), flush() functions.
+
 ```java
 import com.amplitude.core.Amplitude;
 import com.amplitude.core.events.BaseEvent;
@@ -260,15 +262,15 @@ import com.segment.analytics.Properties;
 public class SegmentDestinationPlugin extends DestinationPlugin {
     android.content.Context context;
     Analytics analytics;
-    String SEGMENT_WRITE_KEY;
-    public SegmentDestinationPlugin(android.content.Context appContext, String segmentWriteKey) {
+    String writeKey;
+    public SegmentDestinationPlugin(android.content.Context appContext, String writeKey) {
         this.context = appContext;
-        this.SEGMENT_WRITE_KEY = segmentWriteKey;
+        this.writeKey = writeKey;
     }
     @Override
      public void setup(Amplitude amplitude) {
         super.setup(amplitude);
-        analytics = new Analytics.Builder(this.context, SEGMENT_WRITE_KEY)
+        analytics = new Analytics.Builder(this.context, this.writeKey)
                 .build();
 
         Analytics.setSingletonInstance(analytics);


### PR DESCRIPTION
# Dev Docs PR

## Description

Add the enrichment type and destination type example of Android-Kotlin plugins.
Reference: https://github.com/amplitude/ampli-examples/pull/129/files

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp