### PR TITLE
Fix heading and code example

### DIFF
--- a/docs/data/ampli/index.md
+++ b/docs/data/ampli/index.md
@@ -32,7 +32,7 @@ provides autocomplete and static type checking.
 
  The Ampli Wrapper is a light wrapper for untyped Amplitude SDKs.
 
-## Amplitude Wrapper
+## Amplitude SDK
 
 The Amplitude SDK is a static, open source SDK with untyped events.
 
@@ -59,7 +59,7 @@ class Ampli {
   }
 
   // strongly typed event method wraps "generic" track
-  myEvent(properties: EventProperties) {
+  myEvent(properties: MyEventProperties) {
     this.track(new MyEvent(properties));
   }
 }


### PR DESCRIPTION
# Dev Docs PR


## Description

Fix amplitude sdk heading typo and fix a code example. 

## Deadline

Whenever

## Change type

- [X] Doc bug fix. Fixes DDI-191


# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
