### PR TITLE
legacy sdk header updates

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -9,7 +9,7 @@ icon: material/android
 
 This is the official documentation for the Amplitude Analytics Android SDK.
 
-!!!info "Legacy SDK"
+!!!attention "Legacy SDK"
     This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [Android Kotlin SDK](../android-kotlin) which supports plugins, SDK integrations and more.
 
 !!!info "SDK Resources"

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -5,16 +5,21 @@ icon: material/android
 ---
 
 
-This is the official documentation for the Amplitude Analytics Android SDK. This is a legacy SDK. If you haven't already deployed this SDK, we recommend using the [Android Kotlin SDK](../android-kotlin) instead.
+[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.amplitude%22%20AND%20a:%22android-sdk%22)
+
+This is the official documentation for the Amplitude Analytics Android SDK.
+
+!!!info "Legacy SDK"
+    This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [Android Kotlin SDK](../android-kotlin) which supports plugins, SDK integrations and more.
 
 !!!info "SDK Resources"
-    [Android SDK Reference :material-book:](http://amplitude.github.io/Amplitude-Android/) · [Android SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Android) · [Android SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Android/releases)
+    - [Android SDK Reference :material-book:](http://amplitude.github.io/Amplitude-Android/)
+    - [Android SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Android)
+    - [Android SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Android/releases)
 
 --8<-- "includes/ampli-vs-amplitude.md"
 
 ## Install
-
-[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.amplitude%22%20AND%20a:%22android-sdk%22)
 
 ### Add dependencies
 

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -9,7 +9,7 @@ icon: material/language-javascript
 
 This is the official documentation for the Amplitude Analytics JavaScript SDK.
 
-!!!info "Legacy SDK"
+!!!attention "Legacy SDK"
     This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [TypeScript Browser SDK](../typescript-browser) which supports plugins and more.
 
 !!!info "SDK Resources"

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -4,16 +4,22 @@ description: The Amplitude JavaScript SDK installation and quick start guide.
 icon: material/language-javascript
 ---
 
+
+[![npm version](https://badge.fury.io/js/amplitude-js.svg)](https://badge.fury.io/js/amplitude-js)
+
 This is the official documentation for the Amplitude Analytics JavaScript SDK.
 
+!!!info "Legacy SDK"
+    This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [TypeScript Browser SDK](../typescript-browser) which supports plugins and more.
+
 !!!info "SDK Resources"
-    [:material-book: API Reference](https://amplitude.github.io/Amplitude-JavaScript/) · [:material-github: GitHub](https://github.com/amplitude/Amplitude-JavaScript) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Javascript/releases)
+    - [JavaScript Browser SDK Reference :material-book:](https://amplitude.github.io/Amplitude-JavaScript/)
+    - [JavaScript Browser SDK Repository :material-github:](https://github.com/amplitude/Amplitude-JavaScript)
+    - [JavaScript Browser SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Javascript/releases)
 
 --8<-- "includes/ampli-vs-amplitude.md"
 
 ## Install
-
-[![npm version](https://badge.fury.io/js/amplitude-js.svg)](https://badge.fury.io/js/amplitude-js)
 
 Install the Amplitude Analytics JavaScript SDK in your project.
 

--- a/docs/data/sdks/node/index.md
+++ b/docs/data/sdks/node/index.md
@@ -18,7 +18,9 @@ While the client-side SDKs are optimized to track session and attribution for a 
 By default, the Node SDK uses the [HTTP API V2](/analytics/apis/http-v2-api/).
 
 !!!attention "Legacy SDK"
-    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for Node.js](/data/sdks/typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins. The Beta SDK does not yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/).
+    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for Node.js](/data/sdks/typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins. 
+    
+    The Beta SDK does not yet support the [Ampli Wrapper](/data/ampli/sdk/). If you use Ampli please continue to use the non-Beta SDK at this time.
 
 !!!info "SDK Resources"
     - [Node.js SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Node)

--- a/docs/data/sdks/node/index.md
+++ b/docs/data/sdks/node/index.md
@@ -4,16 +4,8 @@ description: The Amplitude Node.js SDK installation and quick start guide.
 icon: material/nodejs
 ---
 
+
 ![npm version](https://badge.fury.io/js/%40amplitude%2Fnode.svg)
-
-!!!info "SDK Resources"
-    - [Node.js SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Node)
-    - [Node.js SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Node/releases)
-
-!!!info "New Analytics SDK for Node.js Available in Beta"
-    We just released a new [Analytics SDK for Node.js](/data/sdks/typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins.
-    
-    The Beta SDK does not yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/). If you use Ampli please continue to use the non-Beta SDK at this time.
 
 This is Amplitude Node.js SDK written in Typescript, the 1st backend SDK for Amplitude. We would like to hear your ideas too!
 
@@ -25,9 +17,14 @@ While the client-side SDKs are optimized to track session and attribution for a 
 
 By default, the Node SDK uses the [HTTP API V2](/analytics/apis/http-v2-api/).
 
---8<-- "includes/ampli-vs-amplitude.md"
+!!!attention "Legacy SDK"
+    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for Node.js](/data/sdks/typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins. The Beta SDK does not yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/).
 
-To learn more about Ampli Wrapper, please refer to the [Ampli Node](https://developers.data.amplitude.com/nodejs-ampli) and [examples](https://github.com/amplitude/ampli-examples).
+!!!info "SDK Resources"
+    - [Node.js SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Node)
+    - [Node.js SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Node/releases)
+
+--8<-- "includes/ampli-vs-amplitude.md"
 
 ## Installation
 

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -9,18 +9,13 @@ icon: fontawesome/brands/react
 
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
-!!!info "Legacy SDK"
-    This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [React Native TS SDK](../react-native-sdk) which supports plugins and more.
+!!!attention "Legacy SDK"
+    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for React Native](/data/sdks/react-native-sdk/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web. The Beta SDK doesn't yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/).
 
 !!!info "SDK Resources"
     - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)
     - [React Native SDK Repository :material-github:](https://github.com/amplitude/Amplitude-ReactNative)
     - [React Native SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-ReactNative/releases)
-
-!!!info "New Analytics SDK for React Native Available in Beta"
-    We just released a new [Analytics SDK for React Native](/data/sdks/react-native-sdk/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web.
-    
-    The Beta SDK does not yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/). If you use Ampli please continue to use the non-Beta SDK at this time.
 
 --8<-- "includes/ampli-vs-amplitude.md"
 

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -10,7 +10,9 @@ icon: fontawesome/brands/react
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
 !!!attention "Legacy SDK"
-    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for React Native](/data/sdks/react-native-sdk/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web. The Beta SDK doesn't yet support the [Ampli Wrapper](https://www.docs.developers.amplitude.com/data/ampli/sdk/).
+    This SDK is legacy and only continue to receive bug fixes until deprecated. A new [Analytics SDK for React Native](/data/sdks/react-native-sdk/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web. 
+    
+    The Beta SDK doesn't yet support the [Ampli Wrapper](/data/ampli/sdk/). If you use Ampli please continue to use the non-Beta SDK at this time.
 
 !!!info "SDK Resources"
     - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -9,10 +9,13 @@ icon: fontawesome/brands/react
 
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
+!!!info "Legacy SDK"
+    This SDK is legacy and only continue to receive bug fixes until deprecated. Checkout and upgrade to the [React Native TS SDK](../react-native-sdk) which supports plugins and more.
+
 !!!info "SDK Resources"
-    - [React SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)
-    - [React SDK Repository :material-github:](https://github.com/amplitude/Amplitude-ReactNative)
-    - [React SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-ReactNative/releases)
+    - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)
+    - [React Native SDK Repository :material-github:](https://github.com/amplitude/Amplitude-ReactNative)
+    - [React Native SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-ReactNative/releases)
 
 !!!info "New Analytics SDK for React Native Available in Beta"
     We just released a new [Analytics SDK for React Native](/data/sdks/react-native-sdk/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,10 +217,8 @@ nav:
         - data/sdks/typescript-browser/index.md
         - data/sdks/typescript-browser/migration.md
         - Ampli Codegen: data/sdks/typescript-ampli.md
-      - Node.js:
-        - data/sdks/node/index.md
-        - Ampli Codegen: data/sdks/nodejs-ampli.md
-        - Node.js (Beta): data/sdks/typescript-node/index.md
+      - Node.js (Beta): 
+        - data/sdks/typescript-node/index.md
       - Android:
         - data/sdks/android-kotlin/index.md
         - Ampli Codegen: data/sdks/android-kotlin-ampli.md
@@ -247,6 +245,9 @@ nav:
         - React Native:
           - data/sdks/react-native/index.md
           - Ampli Codegen: data/sdks/react-native-ampli.md
+        - Node.js:
+          - data/sdks/node/index.md
+          - Ampli Codegen: data/sdks/nodejs-ampli.md
 
       - Other Topics:
         - data/dynamic-configuration.md


### PR DESCRIPTION
# Dev Docs PR


## Description

Standardize the three legacy SDK docs header:
React Native
Javascript
Android 
Headers:
1. Package registry version
2. SDK description
3. SDK Resources
4. Legacy info and new SDK "up sell"
5. Ampli wrapper "up sell"

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp