### PR TITLE
Removes unused tracking options and adds code sample for usage

### DIFF
--- a/docs/data/sdks/react-native-sdk.md
+++ b/docs/data/sdks/react-native-sdk.md
@@ -392,28 +392,35 @@ setOptOut(false);
 
 ### Optional tracking
 
-By default, the SDK tracks some properties automatically. You can override this behavior by passing an object called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
+By default, the SDK tracks these properties automatically. You can override this behavior by passing an configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
 
 | Tracking Options | Default |
 | --- | --- |
-| `city` | `true` |
-| `country` | `true` |
+| `adid` | `true` |
 | `carrier` | `true` |
 | `deviceManufacturer` | `true` |
 | `deviceModel` | `true` |
-| `dma` | `true` |
 | `ipAddress` | `true` |
 | `language` | `true` |
 | `osName` | `true` |
 | `osVersion` | `true` |
 | `platform` | `true` |
-| `region` | `true` |
-| `versionName` | `true` |
-| `adid` | `true` |
 
-!!!note
-
-    The optional tracking configurations only prevent default properties from being tracked on newly-created projects, where data has not yet been sent. If you have a project with existing data that you would like to stop collecting the default properties for, please get help in the [Amplitude Community](https://community.amplitude.com/). Note that the existing data is not deleted.
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  trackingOptions: {
+    adid: false,
+    carrier: false,
+    deviceManufacturer: false,
+    deviceModel: false,
+    ipAddress: false,
+    language: false,
+    osName: false,
+    osVersion: false,
+    platform: false,
+  },
+});
+```
 
 ### Callback
 

--- a/docs/data/sdks/react-native-sdk.md
+++ b/docs/data/sdks/react-native-sdk.md
@@ -392,7 +392,7 @@ setOptOut(false);
 
 ### Optional tracking
 
-By default, the SDK tracks these properties automatically. You can override this behavior by passing an configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
+By default, the SDK tracks these properties automatically. You can override this behavior by passing a configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
 
 | Tracking Options | Default |
 | --- | --- |

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -388,27 +388,32 @@ setOptOut(false);
 
 ### Optional tracking
 
-By default, the SDK tracks some properties automatically. You can override this behavior by passing an object called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
+By default, the SDK tracks these properties automatically. You can override this behavior by passing an configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
 
 | Tracking Options | Default |
 | --- | --- |
-| `city` | `true` |
-| `country` | `true` |
-| `carrier` | `true` |
 | `deviceManufacturer` | `true` |
 | `deviceModel` | `true` |
-| `dma` | `true` |
 | `ipAddress` | `true` |
 | `language` | `true` |
 | `osName` | `true` |
 | `osVersion` | `true` |
 | `platform` | `true` |
-| `region` | `true` |
-| `versionName` | `true` |
 
-!!!note
 
-    The optional tracking configurations only prevent default properties from being tracked on newly-created projects, where data has not yet been sent. If you have a project with existing data that you would like to stop collecting the default properties for, please get help in the [Amplitude Community](https://community.amplitude.com/). Note that the existing data is not deleted.
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  trackingOptions: {
+    deviceManufacturer: false,
+    deviceModel: false,
+    ipAddress: false,
+    language: false,
+    osName: false,
+    osVersion: false,
+    platform: false,
+  },
+});
+```
 
 ### Callback
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -388,7 +388,7 @@ setOptOut(false);
 
 ### Optional tracking
 
-By default, the SDK tracks these properties automatically. You can override this behavior by passing an configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
+By default, the SDK tracks these properties automatically. You can override this behavior by passing a configuration called `trackingOptions` when initializing the SDK, setting the appropriate options to false.
 
 | Tracking Options | Default |
 | --- | --- |


### PR DESCRIPTION
# Dev Docs PR


## Description

* Removes inaccurate note on tracking options
* Removes unused tracking options
* Adds code sample for tracking options usage

Code update: https://github.com/amplitude/Amplitude-TypeScript/pull/193

## Deadline

When do these changes need to be live on the site?

Earliest convenience

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp