### PR TITLE
Beta core SDK header update

### DIFF
--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -351,7 +351,7 @@ Amplitude.getInstance().setOptOut(false);
 
 ### Dynamic configuration
 
-Flutter SDK lets users configure their apps to use [dynamic configuration](data/dynamic-configuration/). This feature will find the best server URL automatically based on app users' location.
+Flutter SDK lets users configure their apps to use [dynamic configuration](/data/dynamic-configuration/). This feature will find the best server URL automatically based on app users' location.
 
 - If you have your own proxy server and use `setServerUrl` API, don't use dynamic configuration.
 - If you have users in Mainland China, we recommend that you use dynamic configuration.

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -7,12 +7,14 @@ icon: material/nodejs
 
 ![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-node.svg)
 
+The Node.js SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
+
 !!!beta "Beta SDK Resources"
-    [:material-github: Github](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-node) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
+    - [Node.js SDk Reference :material-book:](https://amplitude.github.io/Amplitude-TypeScript/)
+    - [Node.js SDk Repository :material-github:](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-node)
+    - [Node.js SDk Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-TypeScript/releases)
 
 --8<-- "includes/no-ampli.md"
-
-The Node.js SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 
 ## Getting Started
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -15,6 +15,7 @@ The Node.js SDK lets you send events to Amplitude. This library is open-source, 
     - [Node.js SDk Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-TypeScript/releases)
 
 --8<-- "includes/no-ampli.md"
+    To use Ampli see the [non-Beta SDK](/data/sdks/node/) and [Ampli Wrapper](/data/sdks/node/ampli/) instead.
 
 ## Getting Started
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -14,6 +14,7 @@ The React Native SDK lets you send events to Amplitude. This library is open-sou
     - [React Native SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-TypeScript/releases)
 
 --8<-- "includes/no-ampli.md"
+    To use Ampli see the [non-Beta SDK](/data/sdks/react-native/) and [Ampli Wrapper](/data/sdks/react-native/ampli/) instead.
 
 ## Getting Started
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -6,12 +6,14 @@ icon: material/react
 
 ![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-react-native.svg)
 
+The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
+
 !!!beta "Beta SDK Resources"
-    [:material-github: Github](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
+    - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-TypeScript/)
+    - [React Native SDK Repository :material-github:](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native)
+    - [React Native SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-TypeScript/releases)
 
 --8<-- "includes/no-ampli.md"
-
-The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 
 ## Getting Started
 

--- a/docs/data/sdks/unity/index.md
+++ b/docs/data/sdks/unity/index.md
@@ -121,7 +121,7 @@ Amplitude.getInstance("client_1") //this is the same reference as amplitude1
 ## EU data residency
 
 Starting from version 2.4.0, you can configure the server zone after initializing the client for sending data to Amplitude's EU servers. SDK will switch and send data based on the server zone if it's set.
- The server zone configuration supports [dynamic configuration](data/dynamic-configuration/) as well.
+ The server zone configuration supports [dynamic configuration](/data/dynamic-configuration/) as well.
 
 For earlier versions, you need to configure the `serverURL` property after initializing the client.
 


### PR DESCRIPTION
# Dev Docs PR


## Description

Standardize the 2 Bata SDK docs header:
TS Node 
TS RN

Headers:

Package registry version
SDK description
SDK Resources with beta block
no ampli warning

link fix for dynamic config in flutter and unity page

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp