### PR TITLE
DDI-199 create new reusable for API Key auth in query params

### DIFF
--- a/docs/analytics/apis/attribution-api.md
+++ b/docs/analytics/apis/attribution-api.md
@@ -7,7 +7,7 @@ The Attribution API is for sending attribution campaign events (identified by `
 
 --8<-- "includes/postman.md"
 
---8<-- "includes/auth-api-key.md"
+--8<-- "includes/auth-api-key-query-param.md"
 
 ## Endpoints
 

--- a/docs/analytics/apis/group-identify-api.md
+++ b/docs/analytics/apis/group-identify-api.md
@@ -11,7 +11,7 @@ The Amplitude [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115
 
 --8<-- "includes/postman.md"
 
---8<-- "includes/auth-api-key.md"
+--8<-- "includes/auth-api-key-query-param.md"
 
 ## Endpoints
 

--- a/docs/analytics/apis/identify-api.md
+++ b/docs/analytics/apis/identify-api.md
@@ -7,7 +7,7 @@ Use the Identify API to set the User ID for a particular Device ID or update use
 
 --8<-- "includes/postman.md"
 
---8<-- "includes/auth-api-key.md"
+--8<-- "includes/auth-api-key-query-param.md"
 
 ## Endpoints
 

--- a/includes/auth-api-key-query-param.md
+++ b/includes/auth-api-key-query-param.md
@@ -1,0 +1,5 @@
+## Authorization
+
+This API doesn't use authorization, but uses your API key. Pass your API key in the URL of the request like `https://api2.amplitude.com/endpoint?api_key={{api-key}}`.
+
+See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 


### PR DESCRIPTION
# Dev Docs PR


## Description

Create new reusable and update some of the API docs to reflect that the API key is passsed in the query, not the body. 

## Deadline

ASAP

## Change type

- [X] Doc bug fix.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
