### PR TITLE
DDI-210 add anchor link copying script

### DIFF
--- a/docs/javascripts/anchor-copy.js
+++ b/docs/javascripts/anchor-copy.js
@@ -1,0 +1,6 @@
+document$.subscribe(() => {
+  const links = Array.from(document.querySelectorAll(".headerlink"))
+  for (const link of links) {
+    link.setAttribute("data-clipboard-text", link.href)
+  }
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ extra_javascript:
   - /javascripts/accessibe.js # Script for Accessibe. Don't remove without speaking to Legal
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
   - /javascripts/tablesort.js #script for Tablesort feature
+  - /javascripts/anchor-copy.js #script for copying anchor links
 
 
 # Plugins


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add functionality to copy anchor link URL when anchor icon clicked. 

## Deadline

ASAP

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
