### PR TITLE
DDI-84 Add startNewSession param to doc

### DIFF
--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -136,7 +136,6 @@ Set `userID` when initializing the client, or after initialization with the `set
     ```
     There is an optional `startNewSession` parameter for `setUserId`. Set it to `true` to start a new user session.
 
-
 #### EU data residency
 
 Beginning with version 8.9.0, you can configure the server zone to send data to Amplitude's EU server after initializing the client.

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -134,6 +134,8 @@ Set `userID` when initializing the client, or after initialization with the `set
     var userId = "12345";
     amplitude.getInstance().setUserId(userId);
     ```
+    There is an optional `startNewSession` parameter for `setUserId`. Set it to `true` to start a new user session.
+
 
 #### EU data residency
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add startNewSession param to legacy js doc. 

## Deadline

Casual

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
