### PR TITLE
DDI-220 Cron Job for Link Checking

### DIFF
--- a/.github/workflows/cron-link-check.yml
+++ b/.github/workflows/cron-link-check.yml
@@ -4,18 +4,12 @@
 name: MegaLinter
 
 on:
-  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to master
-  pull_request:
-    branches: [master, main]
+
   schedule:
   # Run every day at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-    - cron: "0 0 * * *"
+    #- cron: "0 0 * * *"
+    - cron: '*/15 * * * *' #set to run every 15 minutes for testing and troubleshooting for now
 
-#env: # Comment env block if you do not want to apply fixes
-  # Apply linter fixes configuration
-  #APPLY_FIXES: none # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
-  #APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
-  #APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -42,16 +36,11 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/
-          VALIDATE_ALL_CODEBASE: false # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/main&#39; }} to validate only diff with main branch
+          VALIDATE_ALL_CODEBASE: true # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/main&#39; }} to validate only diff with main branch
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+          EMAIL_REPORTER: true
+          EMAIL_REPORTER_EMAIL: developerdocs@amplitude.com
+          EMAIL_REPORTER_SEND_SUCCESS: true
 
-      # Upload MegaLinter artifacts
-      - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: MegaLinter reports
-          path: |
-            report
-            mega-linter.log
+

--- a/.github/workflows/cron-link-check.yml
+++ b/.github/workflows/cron-link-check.yml
@@ -1,46 +1,18 @@
----
-# MegaLinter GitHub Action configuration file
-# More info at https://megalinter.github.io
-name: MegaLinter
+name: Scheduled Link Check
 
 on:
-
   schedule:
-  # Run every day at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-    #- cron: "0 0 * * *"
-    - cron: '*/15 * * * *' #set to run every 15 minutes for testing and troubleshooting for now
-
-
-concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
+  - cron: "*/15 * * * *"
 
 jobs:
-  build:
-    name: MegaLinter
+  markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      # Git Checkout
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      # MegaLinter
-      - name: MegaLinter
-        id: ml
-        # You can override MegaLinter flavor used to have faster performances
-        # More info at https://megalinter.github.io/flavors/
-        uses: oxsecurity/megalinter/flavors/documentation@v6
-        env:
-          # All available variables are described in documentation
-          # https://megalinter.github.io/configuration/
-          VALIDATE_ALL_CODEBASE: true # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/main&#39; }} to validate only diff with main branch
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-          EMAIL_REPORTER: true
-          EMAIL_REPORTER_EMAIL: developerdocs@amplitude.com
-          EMAIL_REPORTER_SEND_SUCCESS: true
-
-
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: '.markdown-link-check.json'
+        folder-path: 'docs/'

--- a/.github/workflows/cron-link-check.yml
+++ b/.github/workflows/cron-link-check.yml
@@ -1,18 +1,36 @@
-name: Scheduled Link Check
+---
+# MegaLinter GitHub Action configuration file for our daily link check. 
+# This action runs a link check on our entire doc set every day at 12:00 AM so we're warned when a link breaks.
+# This is a separate workflow file from main Megalinter checks because we needed to use different settings for this run. 
 
+name: Daily Link Check 
 on:
   schedule:
-  # Run everyday at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-  - cron: "*/15 * * * *"
+  # Run everyday at 12:00 AM
+  - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
-  markdown-link-check:
+  build:
+    name: MegaLinter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        config-file: '.markdown-link-check.json'
-        folder-path: 'docs/'
+      # Git Checkout
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # MegaLinter
+      - name: MegaLinter
+        id: ml
+        uses: oxsecurity/megalinter/flavors/documentation@v6
+        env:
+          VALIDATE_ALL_CODEBASE: true # Scans all doc files for broken links.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_LINTERS: MARKDOWNLINT
+          # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,6 +1,6 @@
 ---
 # MegaLinter GitHub Action configuration file
-# This action runs on ever push to a PR against main. It checks the entire docset for markdown violations and broken links. 
+# This action runs on every push to a PR against main. It checks the entire docset for markdown violations and broken links. 
 # This is separate from the Megalinter cron job that runs daily (see cron-link-check.yml) to check for broken links.
 # More info at https://megalinter.github.io
 name: MegaLinter

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,5 +1,7 @@
 ---
 # MegaLinter GitHub Action configuration file
+# This action runs on ever push to a PR against main. It checks the entire docset for markdown violations and broken links. 
+# This is separate from the Megalinter cron job that runs daily (see cron-link-check.yml) to check for broken links.
 # More info at https://megalinter.github.io
 name: MegaLinter
 
@@ -7,15 +9,6 @@ on:
   # Trigger mega-linter at every push. Action will also be visible from Pull Requests to master
   pull_request:
     branches: [master, main]
-  schedule:
-  # Run every day at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-    - cron: "0 0 * * *"
-
-#env: # Comment env block if you do not want to apply fixes
-  # Apply linter fixes configuration
-  #APPLY_FIXES: none # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
-  #APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
-  #APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -42,7 +35,7 @@ jobs:
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/
-          VALIDATE_ALL_CODEBASE: false # Set ${{ github.event_name == &#39;push&#39; &amp;&amp; github.ref == &#39;refs/heads/main&#39; }} to validate only diff with main branch
+          VALIDATE_ALL_CODEBASE: false # checks only diff against main.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

We recently changed the Megalinter action to only lint the diff so we use fewer minutes and checks complete faster. Because we no longer check the entire doc set on every pull, we risk links becoming broken without any warning. This PR adds a cron job github action to check for broken links every day at 12:00 AM. 

## Deadline

Casual

## Change type

- [X] Non-documentation related fix or update.
