### PR TITLE
Added throttling limits

### DIFF
--- a/docs/analytics/apis/group-identify-api.md
+++ b/docs/analytics/apis/group-identify-api.md
@@ -24,6 +24,9 @@ The Amplitude [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115
 
 - Updates affect only future events, and don't update historical events.
 - You can track up to 5 unique group types and 10 total groups per event.
+- The maximum number of group identifies per request is 1024
+- The maximum number of group properties per request is 1024
+- The maximum byte size/per request is 1 mb
 
 ## Example request
 

--- a/docs/analytics/apis/group-identify-api.md
+++ b/docs/analytics/apis/group-identify-api.md
@@ -24,9 +24,9 @@ The Amplitude [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115
 
 - Updates affect only future events, and don't update historical events.
 - You can track up to 5 unique group types and 10 total groups per event.
-- The maximum number of group identifies per request is 1024
-- The maximum number of group properties per request is 1024
-- The maximum byte size/per request is 1 mb
+- The maximum number of group identifies per request is 1024.
+- The maximum number of group properties per request is 1024.
+- The maximum byte size/per request is 1 mb.
 
 ## Example request
 


### PR DESCRIPTION
https://discourse.amplitude.com/t/group-identify-api-is-it-possible-to-batch-requests/3933/6?u=jshek

# Amplitude Developer Docs PR


## Description

Added throttling limits for group identify API

## Deadline

Not urgent but important 

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp