### PR TITLE
fixed typo error

### DIFF
--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -563,7 +563,7 @@ Amplitude can capture the initial UTM parameters and referrer information for ea
 - `initial_gclid`
 - `initial_fbclid`
 
-Capture these parameters by setting the JavaScript SDK configuration options `includeReferrer`, `includeUtm`, `includeFclid`, and `includeGclid` to `true`.
+Capture these parameters by setting the JavaScript SDK configuration options `includeReferrer`, `includeUtm`, `includeFbclid`, and `includeGclid` to `true`.
 
 !!!note
     Initial attribution information for users can change if they're merged with another user.
@@ -582,7 +582,7 @@ Amplitude captures where a user came from for each of their sessions by setting 
 - `gclid`
 - `fbclid`
 
-TO use this, set the JavaScript SDK configuration options `includeReferrer`, `includeUtm`, `includeFclid`, and `includeGclid` to `true`.
+TO use this, set the JavaScript SDK configuration options `includeReferrer`, `includeUtm`, `includeFbclid`, and `includeGclid` to `true`.
  By default, the SDK saves values only at the start of the session, so if a user triggers some flow that causes them to land on the site again with a different set of UTM parameters within the same session,
   the second set isn't saved.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Fixed typos for `includeFclid`, changed it to `includeFbclid`.

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp