### PR TITLE
docs: add cross domain section for typescript browser sdk

### DIFF
--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -771,9 +771,9 @@ You can track anonymous behavior across two different domains. Amplitude identif
 Users who start on Site 1 and then navigate to Site 2 must have the device ID generated from Site 1 passed as a parameter to Site 2. Site 2 then needs to initialize the SDK with the device ID.
  The SDK can parse the URL parameter automatically if `deviceIdFromUrlParam` is enabled.
 
-- From Site 1, grab the device ID from `amplitude.getInstance().options.deviceId`.
-- Pass the device ID to Site 2 via a URL parameter when the user navigates. (for example: `www.example.com?amp_device_id=device_id_from_site_1`)
-- Initialize the Amplitude SDK on Site 2 with `amplitude.init('API_KEY', null, {deviceIdFromUrlParam: true})`.
+1. From Site 1, grab the device ID from `amplitude.getInstance().options.deviceId`.
+2. Pass the device ID to Site 2 via a URL parameter when the user navigates. (for example: `www.example.com?amp_device_id=device_id_from_site_1`)
+3. Initialize the Amplitude SDK on Site 2 with `amplitude.init('API_KEY', null, {deviceIdFromUrlParam: true})`.
 
 ### Tracking UTM parameters, referrer, and gclid (JavaScript)
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -566,6 +566,22 @@ add(new MyDestinationPlugin('https://custom.domain.com'));
 
 ## Advanced topics
 
+### Cross domain tracking
+
+You can track anonymous behavior across two different domains. Amplitude identifies anonymous users by their device IDs which must be passed between the domains. For example:
+
+- Site 1: `www.example.com`
+- Site 2: `www.example.org`
+
+Users who start on Site 1 and then navigate to Site 2 must have the device ID generated from Site 1 passed as a parameter to Site 2. Site 2 then needs to initialize the SDK with the device ID.
+ The SDK can parse the URL parameter automatically if `deviceId` is in the URL query parameters.
+
+- From Site 1, grab the device ID from `getDeviceId()`.
+- Pass the device ID to Site 2 via a URL parameter when the user navigates. (for example: `www.example.com?deviceId=device_id_from_site_1`)
+- Initialize the Amplitude SDK on Site 2 with `init('API_KEY', null)`.
+
+If the `deviceId` is not provided with the `init` like `init('API_KEY', null, { deviceId: 'custom-device-id' })`, then it automatically fallbacks to use URL parameter.
+
 ### Web attribution
 
 Amplitude SDK collects attribution data by default. Amplitude supports automatically tracking the following attribution parameters:

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -576,9 +576,9 @@ You can track anonymous behavior across two different domains. Amplitude identif
 Users who start on Site 1 and then navigate to Site 2 must have the device ID generated from Site 1 passed as a parameter to Site 2. Site 2 then needs to initialize the SDK with the device ID.
  The SDK can parse the URL parameter automatically if `deviceId` is in the URL query parameters.
 
-- From Site 1, grab the device ID from `getDeviceId()`.
-- Pass the device ID to Site 2 via a URL parameter when the user navigates. (for example: `www.example.com?deviceId=device_id_from_site_1`)
-- Initialize the Amplitude SDK on Site 2 with `init('API_KEY', null)`.
+1. From Site 1, grab the device ID from `getDeviceId()`.
+2. Pass the device ID to Site 2 via a URL parameter when the user navigates. (for example: `www.example.com?deviceId=device_id_from_site_1`)
+3. Initialize the Amplitude SDK on Site 2 with `init('API_KEY', null)`.
 
 If the `deviceId` is not provided with the `init` like `init('API_KEY', null, { deviceId: 'custom-device-id' })`, then it automatically fallbacks to use URL parameter.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR
## Description
- docs: add cross domain section for typescript browser sdk

<img width="744" alt="image" src="https://user-images.githubusercontent.com/8689754/193366795-8fe2adee-0722-4980-87cf-36f4fe620961.png">


## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp