### PR TITLE
docs: update gtm doc with blog link and instance name suggestion

### DIFF
--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -630,6 +630,10 @@ If you set `logAttributionCapturedEvent` to `true` in your JavaScript SDK config
 
 Amplitude's JavaScript SDK supports integration with Google Tag Manager. See the [demo app](https://github.com/amplitude/GTM-Web-Demo) on GitHub for instructions on how to set it up.
 
+Refer to [Introducing the Amplitude Google Tag Manager (GTM) Template](https://amplitude.com/blog/google-tag-manager-template/) for more guidance.
+
+*Tip: it is always suggested to have a custom instance name to avoid naming collision.*
+
 ## Advanced topics
 
 ### Dynamic configuration


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description
This change updates the GTM doc with blog link and instance name suggestion.


## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp