### PR TITLE
Correct the response type for getting all events

### DIFF
--- a/docs/analytics/apis/taxonomy-api.md
+++ b/docs/analytics/apis/taxonomy-api.md
@@ -382,12 +382,14 @@ A successful request returns a `200 OK` status with a JSON body:
     "success": true,
     "data": [
         {
-            "id": 412931,
-            "name": "Attribution"
+            "event_type": "Attribution",
+            "category": "Attribution Events".
+            "description": null
         },
         {
-            "id": 412941,
-            "name": "Conversion"
+            "event_type": "Converstion",
+            "category": "Conversion Events".
+            "description": "This event is fired when a user converts."
         }
     ]
 }


### PR DESCRIPTION
# Amplitude Developer Docs PR

Seems we get to pay for the privilege to make sure the docs are up to date 😂 

## Description

The documentation for the response type is incorrect. When making a request to the endpoint per:

```
GET /api/2/taxonomy/event HTTP/1.1
Host: amplitude.com
Authorization: Basic {{api-key}:{{secret-key}}}
```
Source: https://www.docs.developers.amplitude.com/analytics/apis/taxonomy-api/#get-all-event-types

Instead of being the response type in the docs the response is instead:

```
~/w/canva jack-taxonomy-worker-deploy *2 !386579
> curl https://amplitude.com/api/2/taxonomy/event -u api-key:secret-key -X GET 

{"success": true, "data": [{"event_type": "event1", "category": null, "description": "account"}, {"event_type": "event2", "category": null, "description": "account"}]}
```

## Deadline

ASAP

@amplitude-dev-docs
@caseyamp