### PR TITLE
Fix response type

### DIFF
--- a/docs/analytics/apis/taxonomy-api.md
+++ b/docs/analytics/apis/taxonomy-api.md
@@ -430,7 +430,9 @@ A successful request returns a `200 OK` status and a JSON body with the event ty
     "success": true,
     "data": {
         "event_type": "ce:Event 2",
-        "category": "Attribution",
+        "category": {
+            "name": "Conversion Events"
+        },
         "description": null
     }
 }

--- a/docs/analytics/apis/taxonomy-api.md
+++ b/docs/analytics/apis/taxonomy-api.md
@@ -383,12 +383,16 @@ A successful request returns a `200 OK` status with a JSON body:
     "data": [
         {
             "event_type": "Attribution",
-            "category": "Attribution Events".
+            "category": {
+                "name": "Attribution Events"
+            },
             "description": null
         },
         {
             "event_type": "Converstion",
-            "category": "Conversion Events".
+            "category": {
+                "name": "Conversion Events"
+            },
             "description": "This event is fired when a user converts."
         }
     ]


### PR DESCRIPTION
```
> curl https://amplitude.com/api/2/taxonomy/event -u api-key:secret-key -X GET                                   
{"success": true, "data": [{"event_type": "event1", "category": {"name": "account"}, "description": "null"}]}
```
```
> curl https://amplitude.com/api/2/taxonomy/event/test%20event3 -u api-key:secret-key -X GET
{"success": true, "data": {"event_type": "test event3", "category": {"name": "account"}, "description": null}}
```

My previous PR was wrong because my category was `null` which obfuscated the nested category name.

@amplitude-dev-docs
@caseyamp