### PR TITLE
Fixed trailing slash in schemas API example

### DIFF
--- a/docs/data/iglu-api.md
+++ b/docs/data/iglu-api.md
@@ -8,10 +8,10 @@ Amplitude Data fully supports the Iglu schema service APIs as defined in [Iglu s
 To get started:
 
 1. Generate an API Token in your Amplitude Data account. This is the `apikey` that the Iglu client uses to authenticate itself to the Amplitude Data Iglu-compatible schema repository.
-    1. Browse to [Settings](https://data.amplitude.com/settings), select the API Tokens page, and create a new token
+    1. Browse to Settings, select the API Tokens page, and create a new token
 2. Add another repository to your Iglu configuration file:
 
-```tsx
+```json
 {
   "name": "Amplitude",
   "priority": 0,
@@ -28,5 +28,10 @@ To get started:
 To retrieve all schemas ever created in your tracking plan:
 
 ```bash
-curl 'https://data-api.amplitude.com/iglu/schemas/{vendor-name}/' --header 'apikey: {your-api-key}'
+curl 'https://data-api.amplitude.com/iglu/schemas/{vendor-name}' --header 'apikey: {your-api-key}'
+```
+
+Filter them by event name if required:
+```bash
+curl 'https://data-api.amplitude.com/iglu/schemas/{vendor-name}/{event-name}' --header 'apikey: {your-api-key}'
 ```


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Fixed trailing slash in schemas API example

## Deadline

ASAP

## Change type

- [X] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
https://discourse.amplitude.com/t/data-iteratively-api-to-extract-taxonomy-returns-400-error/8883/2

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp