### PR TITLE
doc: fix legacy android sdk badge

### DIFF
--- a/docs/data/sdks/android/ampli.md
+++ b/docs/data/sdks/android/ampli.md
@@ -29,14 +29,14 @@ If you haven't already, install the core Amplitude SDK dependencies.
 === "Java"
 
     ```bash
-    implementation 'com.amplitude:android-sdk:2.35.2'
+    implementation 'com.amplitude:android-sdk:2.38.3'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     ```
 
 === "Kotlin"
 
     ```bash
-    implementation 'com.amplitude:android-sdk:2.35.2'
+    implementation 'com.amplitude:android-sdk:2.38.3'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     ```
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -5,7 +5,7 @@ icon: simple/android
 ---
 
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.amplitude%22%20AND%20a:%22android-sdk%22)
+[![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/android-sdk.svg?label=Maven%20Central&versionPrefix=2)](https://search.maven.org/search?q=g:%22com.amplitude%22%20AND%20a:%22android-sdk%22)
 
 This is the official documentation for the Amplitude Analytics Android SDK.
 
@@ -24,13 +24,13 @@ This is the official documentation for the Amplitude Analytics Android SDK.
 
 !!!tip
 
-    We recommend using Android Studio as an IDE and Gradle to manage dependencies.
+    We recommend using Android Studio as an IDE and Gradle to manage dependencies. Please user version 2.x, version 3.35.1 is invalid. 
 <!--vale off-->
 1. In the `build.gradle` file, add these dependencies. The SDK requires OkHttp.
 
     ```bash
     dependencies {
-      implementation 'com.amplitude:android-sdk:2.36.1'
+      implementation 'com.amplitude:android-sdk:2.38.3'
       implementation 'com.squareup.okhttp3:okhttp:4.2.2'
     }
     ```


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update legacy android SDK badge based on the Shileds [doc](https://shields.io/category/version)

## Deadline




## Change type

- [x] Doc bug fix. Fixes #[DXOC-298]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp

[DXOC-298]: https://amplitude.atlassian.net/browse/DXOC-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ