### PR TITLE
Update statsig.md

### DIFF
--- a/docs/data/destinations/statsig.md
+++ b/docs/data/destinations/statsig.md
@@ -11,7 +11,7 @@ description: Send Amplitude events to Statsig to help find more meaningful data 
 
 !!!info "Other Amplitude + Statsig Integrations"
 
-    This integration streams Amplitude events to Statsig. Amplitude offers other integrations with Statsig: [Send Cohorts to Statsig](https://www.docs.developers.amplitude.com/data/destinations/statsig-cohort/?h=stat)
+    This integration streams Amplitude events to Statsig. Amplitude offers other integrations with Statsig: [Send Cohorts to Statsig](../../destinations/statsig-cohort)
  
 ## Considerations
 

--- a/docs/data/destinations/statsig.md
+++ b/docs/data/destinations/statsig.md
@@ -5,13 +5,13 @@ description: Send Amplitude events to Statsig to help find more meaningful data 
 
 !!!beta "This feature is in open beta"
 
-    This feature is in open beta and is in active development. Contact the [Statsig support team](http://support@statsig.com.) for support with this integration.
+    This feature is in open beta and is in active development. Contact the [Statsig support team](https://statsig.com/slack) for support with this integration.
 
 [Statsig](https://statsig.com/) is a modern feature-management and product experimentation platform that helps you to ship faster by providing actionable causal analysis, meaningful data insights, and automatically running 10x more experiments.
 
 !!!info "Other Amplitude + Statsig Integrations"
 
-    This integration streams Amplitude events to Statsig. Amplitude offers other integrations with Statsig: [Send Cohorts to Statsig](../destinations/statsig-cohort/)
+    This integration streams Amplitude events to Statsig. Amplitude offers other integrations with Statsig: [Send Cohorts to Statsig](https://www.docs.developers.amplitude.com/data/destinations/statsig-cohort/?h=stat)
  
 ## Considerations
 


### PR DESCRIPTION
Got feedback from Statsig team

The Contact the Statsig support team has a malformed url. Can we swap that out with a link to https://statsig.com/slack The second link to the Cohort Sync should point to https://www.docs.developers.amplitude.com/data/destinations/statsig-cohort/ (it currently 404s).

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp