### PR TITLE
DDI-267 Adding section for user prop operators

### DIFF
--- a/docs/data/converter-configuration-reference.md
+++ b/docs/data/converter-configuration-reference.md
@@ -147,6 +147,9 @@ The following Operators return a JsonPrimitive of type Integer, barring the `add
 |--------------|--------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | N/A          | As syntactic sugar, Amplitude converts an object to a "dict" LIST_OPERATOR | **Note**: the following two descriptions are equivalent:   {"key1": SOURCE_DESCRIPTION,"key2", SOURCE_DESCRIPTION,…}   \["dict","key1", SOURCE_DESCRIPTION,"key2", SOURCE_DESCRIPTION,...] |
 
+### User property operations
+
+The converter supports the same user property operators as the Identify API. See [the Identify documentation](../../analytics/apis/identify-api#user_properties-supported-operations) for details.
 <!-- vale on-->
 
 <!-- ## Converter configuration examples


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adding a section for user property operations for converter config

## Deadline

ASAP

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
