### PR TITLE
docs: add ts logging doc, fix minor import typos

### DIFF
--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -583,4 +583,32 @@ Users who start on Site 1 and then navigate to Site 2 must have the device ID ge
 
 If the `deviceId` isn't provided with the `init` like `init('API_KEY', null, { deviceId: 'custom-device-id' })`, then it automatically fallbacks to use URL parameter.
 
+### Logging
+
+You can control the level of logs printed to the developer console.
+
+- 'None': Suppresses all log messages.
+- 'Error': Shows error messages only.
+- 'Warn': Shows error messages and warnings. This is the default value if `logLevel` is not explicitly specified.
+- 'Verbose': Shows informative messages.
+- 'Debug': Shows error messages, warnings, and informative messages that may be useful for debugging, including the function context information for all SDK public method invocations. This logging mode is only suggested to be used in development phases.
+
+Set the log level by configuring the `logLevel` with the level you want.
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  logLevel: amplitude.Types.LogLevel.Debug,
+});
+```
+
+The default logger outputs logs to the developer console. You can also provide your own logger implementation based on the `Logger` interface for any customization purpose, e.g., collecting any error messages from the SDK in a production environment.
+
+Set the logger by configuring the `loggerProvider` with your own implementation.
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  loggerProvider: new MyLogger(),
+});
+```
+
 --8<-- "includes/abbreviations.md"

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -67,7 +67,7 @@ You can configure the server zone when initializing the client for sending data 
 ```ts
 import * as amplitude from '@amplitude/analytics-node';
 
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+amplitude.init(API_KEY, {
   serverZone: amplitude.Types.ServerZone.EU,
 });
 ```
@@ -466,9 +466,39 @@ export class MyDestinationPlugin implements DestinationPlugin {
     };
   }
 }
-    
+
 init('API_KEY');
 add(new MyDestinationPlugin('https://custom.domain.com'));
+```
+
+## Advanced topics
+
+### Logging
+
+You can control the level of logs printed to the developer console.
+
+- 'None': Suppresses all log messages.
+- 'Error': Shows error messages only.
+- 'Warn': Shows error messages and warnings. This is the default value if `logLevel` is not explicitly specified.
+- 'Verbose': Shows informative messages.
+- 'Debug': Shows error messages, warnings, and informative messages that may be useful for debugging, including the function context information for all SDK public method invocations. This logging mode is only suggested to be used in development phases.
+
+Set the log level by configuring the `logLevel` with the level you want.
+
+```ts
+amplitude.init(API_KEY, {
+  logLevel: amplitude.Types.LogLevel.Debug,
+});
+```
+
+The default logger outputs logs to the developer console. You can also provide your own logger implementation based on the `Logger` interface for any customization purpose, e.g., collecting any error messages from the SDK in a production environment.
+
+Set the logger by configuring the `loggerProvider` with your own implementation.
+
+```ts
+amplitude.init(API_KEY, {
+  loggerProvider: new MyLogger(),
+});
 ```
 
 --8<-- "includes/abbreviations.md"

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -453,7 +453,7 @@ Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying 
 The `add` method adds a plugin to Amplitude. Plugins can help processing and sending events.
 
 ```typescript
-import { add } from '@amplitude/analytics-browser';
+import { add } from '@amplitude/analytics-react-native';
 
 add(new Plugin());
 ```
@@ -463,7 +463,7 @@ add(new Plugin());
 The `remove` method removes the given plugin name from the client instance if it exists.
 
 ```typescript
-import { remove } from '@amplitude/analytics-browser';
+import { remove } from '@amplitude/analytics-react-native';
 
 remove(plugin.name);
 ```
@@ -485,7 +485,7 @@ This method contains the logic for processing events and has event as parameter.
 Here's an example of a plugin that modifies each event that's instrumented by adding an increment integer to `event_id` property of an event starting from 100.
 
 ```ts
-import { init, add } from '@amplitude/analytics-node';
+import { init, add } from '@amplitude/analytics-react-native';
 import { ReactNativeConfig, EnrichmentPlugin, Event, PluginType } from '@amplitude/analytics-types';
 
 export class AddEventIdPlugin implements EnrichmentPlugin {
@@ -522,7 +522,7 @@ add(new AddEventIdPlugin());
 Here's an example of a plugin that sends each instrumented event to a target server URL using your preferred HTTP client.
 
 ```ts
-import { init, add } from '@amplitude/analytics-node';
+import { init, add } from '@amplitude/analytics-react-native';
 import { ReactNativeConfig, DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
 
 export class MyDestinationPlugin implements DestinationPlugin {
@@ -565,9 +565,39 @@ export class MyDestinationPlugin implements DestinationPlugin {
     };
   }
 }
-    
+
 init('API_KEY');
 add(new MyDestinationPlugin('https://custom.domain.com'));
+```
+
+## Advanced topics
+
+### Logging
+
+You can control the level of logs printed to the developer console.
+
+- 'None': Suppresses all log messages.
+- 'Error': Shows error messages only.
+- 'Warn': Shows error messages and warnings. This is the default value if `logLevel` is not explicitly specified.
+- 'Verbose': Shows informative messages.
+- 'Debug': Shows error messages, warnings, and informative messages that may be useful for debugging, including the function context information for all SDK public method invocations. This logging mode is only suggested to be used in development phases.
+
+Set the log level by configuring the `logLevel` with the level you want.
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  logLevel: amplitude.Types.LogLevel.Debug,
+});
+```
+
+The default logger outputs logs to the developer console. You can also provide your own logger implementation based on the `Logger` interface for any customization purpose, e.g., collecting any error messages from the SDK in a production environment.
+
+Set the logger by configuring the `loggerProvider` with your own implementation.
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  loggerProvider: new MyLogger(),
+});
 ```
 
 --8<-- "includes/abbreviations.md"

--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -3,7 +3,7 @@
 |`flushIntervalMillis`| Optional. `number` | The amount of time waiting to upload the event to the server. The default is 1 second.|
 |`flushMaxRetries`| Optional. `number` | The max retry limits. The default is 5 times.|
 |`flushQueueSize`| Optional. `number` |  The maximum number of events that can be stored locally before forcing an upload. The default is 30 events. |
-|`logLevel`| Optional. `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` | The log level.|
+|`logLevel`| Optional. `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug` | The log level.|
 |`loggerProvider`| Optional. `Logger` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.|
 |`minIdLength`| Optional. `number` | Overrides the minimum length of `user_id` & `device_id` fields. The default is 5. |
 |`plan`| Optional. `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. |


### PR DESCRIPTION
# Amplitude Developer Docs PR
## Description
This PR includes:
- Add ts logging doc
- Fix minor import typos in ts node and ts react-native docs

## Deadline
When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp