### PR TITLE
DDI-277 Make SDK Quickstart guide easier to find

### DIFF
--- a/docs/data/sdks/index.md
+++ b/docs/data/sdks/index.md
@@ -1,6 +1,7 @@
 ---
 title: Amplitude SDK Quickstart Guide
 description: Use this guide to get started with the Amplitude SDKs.
+icon: material/clock-fast
 hide: 
   - toc
 status: new

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ extra:
   postman_workspace: https://www.postman.com/amplitude-developer-docs/workspace/amplitude-developers/overview
   report_issue: https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/issues/new/?title=[Feedback]+{{page.title}}+-+{{page.url}}
   getting_started_guide: https://docs.developers.amplitude.com/getting-started
+  sdk_quickstart: https://www.docs.developers.amplitude.com/data/sdks/
   more_resources: all-resources
   status:
     new: Recently added
@@ -222,7 +223,8 @@ nav:
       - data/ampli/plugin.md
       - data/ampli/migration.md
     - SDKs:
-      - Quick Start: data/sdks/index.md
+      - data/sdks/index.md
+      - Quickstart Guide: data/sdks/index.md
       - Browser:
         - data/sdks/typescript-browser/index.md
         - Marketing Analytics Browser:

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -224,8 +224,8 @@
           <h1>Welcome to the Amplitude Developer center</h1>
           <p>Get started integrating, instrumenting, and extending Amplitude's products.</p>
           
-          <a href="{{ config.extra.getting_started_guide }}" title="{{ lang.t('source.link.title') }}" class="md-button md-button--primary">
-            Getting Started Guide
+          <a href="{{ config.extra.sdk_quickstart }}" title="{{ lang.t('source.link.title') }}" class="md-button md-button--primary">
+            SDK Quickstart Guide
           </a>
           <a href="{{ config.extra.community }}" title="{{ lang.t('source.link.title') }}" class="md-button">
             Go to the Community

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,1 @@
 {% extends "base.html" %}
-
-
-{% block announce %}
-<div class="announce">Welcome to the new Amplitude developer docs experience. <a href="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/issues/new/choose">Give us your feedback.</a></div> 
-{% endblock %}


### PR DESCRIPTION
# Amplitude Developer Docs PR

After a conversation with an internal customer, I realized that the Quickstart guide wasn't easily findable. So I promoted it a bit and gave it a page icon. Also made small changes to site home page. 

## Deadline

ASAP

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
