### PR TITLE
remove the httpv2 notice for sdk using httpv1

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -187,8 +187,6 @@ For earlier versions, you need to configure the `serverURL` property after initi
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent how users interact with your application. For example, the event "button click" may be an action you want to track.

--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -80,8 +80,6 @@ Amplitude.getInstance().setServerUrl("https://api.eu.amplitude.com")
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent how users interact with your application. For example, "button clicked" may be an action you want to track.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -178,8 +178,6 @@ For earlier versions, you need to configure the `serverURL` property after initi
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -166,8 +166,6 @@ For earlier versions, you need to configure the `apiEndpoint` property after ini
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent user interactions with your app. For example, “Button Clicked” may be an action you want to track.

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -84,8 +84,6 @@ For earlier versions, you need to configure the `serverURL` property after initi
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent how users interact with your application. For example, "button clicked" may be an action you want to track.

--- a/docs/data/sdks/unity/index.md
+++ b/docs/data/sdks/unity/index.md
@@ -140,8 +140,6 @@ amplitude.setServerUrl("https://api.eu.amplitude.com");
 
 ### Send events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 #### Basic events
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.

--- a/docs/data/sdks/unreal/index.md
+++ b/docs/data/sdks/unreal/index.md
@@ -58,8 +58,6 @@ The API of Amplitude Unreal follows the [analytics provider interface](https://
 
 ### Log basic events
 
---8<-- "includes/sdk-httpv2-notice.md"
-
 Events represent how users interact with your app. For example, "Game Started" may be an action you want to note.
 
 ```c++


### PR DESCRIPTION
# Amplitude Developer Docs PR

The old SDK is is using http v1 internally, it's not support overwrite min_id_length

## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp