### PR TITLE
Add plugin differences section

### DIFF
--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -537,7 +537,6 @@ init('API_KEY', configuration);
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Web Attribution Plugin](../marketing-analytics-browser/#web-attribution) supports.
 
-
 ###### Differences from base SDK
 
 Enabling the Attribution plugin overwrites the default attribution tracking behavior of the SDK.

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -547,7 +547,7 @@ If the trackNewCampaigns option is set to true, the campaigns will be tracked, a
 
 The Attribution plugin tracks all campaigns, irrespective of whether the user is at the start of a session.
 
-The resetSessionOnNewCampaign option can be set to true to cause the user’s session to be reset when a new campaign is detected. The session won’t be reset in the case where the referrer is just a different subdomain of the implementer’s site.
+Set the `resetSessionOnNewCampaign` option to `true` to cause the user’s session to be reset when a new campaign is detected. The session isn't reset in the case where the referrer is just a different subdomain of the implementer’s site.
 
 ##### Page View Enrichment Plugin
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -541,7 +541,7 @@ Learn more about what the [Web Attribution Plugin](../marketing-analytics-browse
 
 Enabling the Attribution plugin overwrites the default attribution tracking behavior of the SDK.
 
-The SDK’s built in attribution tracking only tracks attribution at the start of sessions. This mean if a user re-enters the site through a new campaign channel (such as direct or an ad) in the middle of a session, this new channel will not be recorded.
+The SDK’s built in attribution tracking only tracks attribution at the start of sessions. This mean if a user re-enters the site through a new campaign channel (such as direct or an ad) in the middle of a session, this new channel isn't recorded.
 
 If the trackNewCampaigns option is set to true, the campaigns will be tracked, and the user’s session will be reset when a new campaign is detected.
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -581,7 +581,7 @@ Learn more about what the [Page View Plugin](../marketing-analytics-browser/#pag
 
 The base SDK sends Page View events when a user’s campaign is tracked if the `attribution.trackPageViews` option is set to `true`.
 
-The page view plugin will send a Page View event on each page a user visits by default. It also offers a number of options to customize this behavior.
+The page view plugin sends a Page View event on each page a user visits by default. It also offers a number of options to customize this behavior.
 
 ## Advanced topics
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -545,7 +545,7 @@ The SDK’s built in attribution tracking only tracks attribution at the start o
 
 If the trackNewCampaigns option is set to true, the campaigns will be tracked, and the user’s session will be reset when a new campaign is detected.
 
-The Attribution plugin tracks all campaigns, irrespective of whether the user is at the start of a session.
+The Attribution plugin tracks all campaigns, regardless of whether the user is at the start of a session.
 
 Set the `resetSessionOnNewCampaign` option to `true` to cause the user’s session to be reset when a new campaign is detected. The session isn't reset in the case where the referrer is just a different subdomain of the implementer’s site.
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -547,7 +547,7 @@ If the `trackNewCampaigns` option is set to `true`, the campaigns are tracked, a
 
 The Attribution plugin tracks all campaigns, regardless of whether the user is at the start of a session.
 
-Set the `resetSessionOnNewCampaign` option to `true` to cause the user’s session to be reset when a new campaign is detected. The session isn't reset in the case where the referrer is just a different subdomain of the implementer’s site.
+Set the `resetSessionOnNewCampaign` option to `true` to cause the user’s session to be reset when a new campaign is detected. The session isn't reset in the case where the referrer is just a different subdomain of your site.
 
 ##### Page View Enrichment Plugin
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -537,6 +537,19 @@ init('API_KEY', configuration);
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Web Attribution Plugin](../marketing-analytics-browser/#web-attribution) supports.
 
+
+###### Differences from base SDK
+
+Enabling the Attribution plugin overwrites the default attribution tracking behavior of the SDK.
+
+The SDK’s built in attribution tracking only tracks attribution at the start of sessions. This mean if a user re-enters the site through a new campaign channel (such as direct or an ad) in the middle of a session, this new channel will not be recorded.
+
+If the trackNewCampaigns option is set to true, the campaigns will be tracked, and the user’s session will be reset when a new campaign is detected.
+
+The Attribution plugin tracks all campaigns, irrespective of whether the user is at the start of a session.
+
+The resetSessionOnNewCampaign option can be set to true to cause the user’s session to be reset when a new campaign is detected. The session won’t be reset in the case where the referrer is just a different subdomain of the implementer’s site.
+
 ##### Page View Enrichment Plugin
 
 You need to download `plugin-page-view-tracking-browser` and add the `pageViewTrackingPlugin` before calling the init method.
@@ -564,6 +577,12 @@ init('API_KEY', configuration);
 
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Page View Plugin](../marketing-analytics-browser/#page-view) supports.
+
+###### Differences from base SDK
+
+The base SDK will send Page View events when a user’s campaign is tracked if the attribution.trackPageViews option is set to true.
+
+The page view plugin will send a Page View event on each page a user visits by default. It also offers a number of options to customize this behavior.
 
 ## Advanced topics
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -579,7 +579,7 @@ Learn more about what the [Page View Plugin](../marketing-analytics-browser/#pag
 
 ###### Differences from base SDK
 
-The base SDK will send Page View events when a user’s campaign is tracked if the attribution.trackPageViews option is set to true.
+The base SDK sends Page View events when a user’s campaign is tracked if the `attribution.trackPageViews` option is set to `true`.
 
 The page view plugin will send a Page View event on each page a user visits by default. It also offers a number of options to customize this behavior.
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -543,7 +543,7 @@ Enabling the Attribution plugin overwrites the default attribution tracking beha
 
 The SDK’s built in attribution tracking only tracks attribution at the start of sessions. This mean if a user re-enters the site through a new campaign channel (such as direct or an ad) in the middle of a session, this new channel isn't recorded.
 
-If the trackNewCampaigns option is set to true, the campaigns will be tracked, and the user’s session will be reset when a new campaign is detected.
+If the `trackNewCampaigns` option is set to `true`, the campaigns are tracked, and the user’s session is reset when a new campaign is detected.
 
 The Attribution plugin tracks all campaigns, regardless of whether the user is at the start of a session.
 


### PR DESCRIPTION
## Description

Adds specific callouts for differences between the default SDK and our marketing plugins. Added to plugins section rather than marketing analytics sdk docs because MA SDK is targeted at newer and less sophisticated customers.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp