### PR TITLE
DDI-290 Adds info about mobile carrier

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -297,7 +297,7 @@ amplitude.add(
 )
 ```
 
-## Advanced Topic
+## Advanced topics
 
 ### User sessions
 
@@ -516,6 +516,10 @@ Tracking for each field can be individually controlled, and has a corresponding 
 !!!note
 
     Using `TrackingOptions` only prevents default properties from being tracked on newly created projects, where data has not yet been sent. If you have a project with existing data that you want to stop collecting the default properties for, get help in the [Amplitude Community](https://community.amplitude.com/). Disabling tracking doesn't delete any existing data in your project.
+
+### Carrier 
+
+Amplitude determines the user's mobile carrier using [Android's TelephonyManager](https://developer.android.com/reference/kotlin/android/telephony/TelephonyManager#getnetworkoperatorname) `getNetworkOperatorName()`, which returns the current registered operator of the `tower`.  
 
 ### COPPA control
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -519,7 +519,7 @@ Tracking for each field can be individually controlled, and has a corresponding 
 
 ### Carrier 
 
-Amplitude determines the user's mobile carrier using [Android's TelephonyManager](https://developer.android.com/reference/kotlin/android/telephony/TelephonyManager#getnetworkoperatorname) `getNetworkOperatorName()`, which returns the current registered operator of the `tower`.  
+Amplitude determines the user's mobile carrier using [Android's TelephonyManager](https://developer.android.com/reference/kotlin/android/telephony/TelephonyManager#getnetworkoperatorname) `networkOperatorName`, which returns the current registered operator of the `tower`.  
 
 ### COPPA control
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -897,6 +897,10 @@ Tracking for each field can be individually controlled, and has a corresponding 
 
     Using `TrackingOptions` only prevents default properties from being tracked on newly created projects, where data has not yet been sent. If you have a project  with existing data that you want to stop collecting the default properties for, get help in the [Amplitude Community](https://community.amplitude.com/). Disabling tracking doesn't delete any existing data in your project.
 
+### Carrier 
+
+Amplitude determines the user's mobile carrier using [Android's TelephonyManager](https://developer.android.com/reference/android/telephony/TelephonyManager#getNetworkOperatorName()) `getNetworkOperatorName()`, which returns the current registered operator of the `tower`. 
+
 ### COPPA control
 
 COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, city, IP address and location tracking can all be enabled or disabled at one time. Apps that ask for information from children under 13 years of age must comply with COPPA.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -796,6 +796,10 @@ Tracking for each field can be individually controlled, and has a corresponding 
 
     AMPTrackingOptions only prevents default properties from being tracked on newly created projects, where data has not yet been sent. If you have a project with existing data that you would like to stop collecting the default properties for, please get help in the [Amplitude Community](https://community.amplitude.com/). Note that the existing data **is not** deleted.
 
+### Carrier
+
+Amplitude determines the user's mobile carrier using [`CTTelephonyNetworkInfo`](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo), which returns the registered operator of the `sim`. 
+
 ### COPPA control
 
 COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, city, IP address and location tracking can all be enabled or disabled at one time. Apps that ask for information from children under 13 years of age must comply with COPPA.


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds sections for how we derive carrier info to Android and iOS.  

## Deadline

🤷 

## Change type

- [X] Doc update.
- 
# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
