### PR TITLE
DDI-293 Add note about unsupported SDKs

### DIFF
--- a/docs/data/ampli/index.md
+++ b/docs/data/ampli/index.md
@@ -31,7 +31,7 @@ provides autocomplete and static type checking.
  ampli.songPlayed({ title: ‘Song #1’ })
  ```
 
- The Ampli Wrapper is a light wrapper for untyped Amplitude SDKs.
+ The Ampli Wrapper is a light wrapper for untyped Amplitude SDKs. The Unreal, Unity, and Flutter SDKs aren't supported.
 
 ## Amplitude SDK
 


### PR DESCRIPTION
# Amplitude Developer Docs PR
Adds list of unsupported SDKs to Ampli Wrapper. 

## Deadline

When do these changes need to be live on the site?
 
Whenever

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
