### PR TITLE
DDI-292 Adds section for using MA SDK with Ampli

### DIFF
--- a/.github/styles/Amplitude/Headings.yml
+++ b/.github/styles/Amplitude/Headings.yml
@@ -86,3 +86,4 @@ exceptions:
   - Movable Ink
   - FreeMarker Templating Language
   - Data Share
+  - Marketing Analytics SDK

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -64,8 +64,23 @@ In addition to the [basic configuration options](../typescript-browser/#configur
 |`attribution.disabled`| Optional. `boolean`. Disable the attribution tracking, attribution is enabled by default |
 |`attribution.excludeReferrers`|  Optional. `string[]`. Exclude the attribution tracking for the provided referrers string |
 |`attribution.initialEmptyValue`| Optional. `string`. Reset the `sessionId` on a new campaign, Default value is `EMPTY` |
-|`attribution.resetSessionOnNewCampaign`| Optional. `boolean`. Reset the `sessionId` on a new campaign, won't create a new session for new campaign by default |
+|`attribution.resetSessionOnNewCampaign`| Optional. `boolean`. Reset the `sessionId` on a new campaign, won't create a new session for new campaign by default. |
 |`pageViewTracking.trackOn`| Optional. `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions|
 |`attribution.pageViewTracking.trackHistoryChanges`  | Optional. `pathOnly` or `all`. Track the page view only on the path changes, track `all` URL changes by default|
 
 --8<-- "includes/sdk-ts-browser/marketing-analytics.md"
+
+## Use the Marketing Analytics SDK with Ampli
+
+To use the Marketing Analytics Browser SDK you can do the following. 
+
+1. Add the Marketing Analytics Browser SDK to your project.
+2. Create an instance of the SDK.
+3. Pass the instance into `ampli.load()`
+
+This example passes the "amplitude" instance to `ampli.load`.
+
+```ts
+amplitude.init(REACT_APP_AMPLITUDE_API_KEY, undefined, { ...DefaultConfiguration, logLevel: 3 });
+ampli.load({ client: { instance: amplitude } });
+```


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds a little info for using MA Browser SDK with Ampli. 

## Deadline

🤷 

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
