### PR TITLE
AMP-63782 GraphQL Taxonomy API 2.0 fixed draft state callout

### DIFF
--- a/docs/analytics/apis/taxonomy-api-2.md
+++ b/docs/analytics/apis/taxonomy-api-2.md
@@ -9,7 +9,8 @@ The Taxonomy API 2.0 grants clients the ability to programmatically plan their e
 
 It's a GraphQL API, if you're not familiar with GraphQL query & manipulation language check for example [GitHub GraphQL API introduction](https://docs.github.com/en/graphql/guides/introduction-to-graphql).
 
-TODO: **Note**: This document is currently in draft state. We're seeking feedback from the community as we develop this new API.
+!!!note
+    This document is currently in draft state. We're seeking feedback from the community as we develop this new API.
 
 ## Authorization
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

AMP-63782 GraphQL Taxonomy API 2.0 fixed draft state callout

## Change type

- [X] Doc bug fix. Fixes AMP-63782
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp