### PR TITLE
doc: add subset flag doc for experiment android, ios, js

### DIFF
--- a/docs/experiment/sdks/android-sdk.md
+++ b/docs/experiment/sdks/android-sdk.md
@@ -293,12 +293,13 @@ The SDK client can be configured once on initialization.
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
 
 ```kotlin
-fun fetch(user: ExperimentUser? = null): Future<ExperimentClient>
+fun fetch(user: ExperimentUser? = null, options: FetchOptions? = null): Future<ExperimentClient>
 ```
 
 | Parameter  | Requirement | Description |
 | --- | --- | --- |
 | `user` | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to evaluate. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. |
+| `options` | optional | Explicit flag keys to fetch.|
 
 Amplitude Experiment recommends calling `fetch()` during application start up so that the user gets the most up-to-date variants for the application session. Furthermore, you'll need to wait for the fetch request to return a result before rendering the user experience to avoid the interface "flickering".
 

--- a/docs/experiment/sdks/ios-sdk.md
+++ b/docs/experiment/sdks/ios-sdk.md
@@ -184,12 +184,13 @@ The SDK client can be configured once on initialization.
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
 
 ```swift
-func fetch(user: ExperimentUser?, completion: ((ExperimentClient, Error?) -> Void)?)
+func fetch(user: ExperimentUser?, options: FetchOptions?, completion: ((ExperimentClient, Error?) -> Void)?)
 ```
 
 | Parameter  | Requirement | Description |
 | --- | --- | --- |
 | `user` | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to evaluate. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. |
+| `options` | optional | Explicit flag keys to fetch.|
 | `completion` | optional | Callback when the variant fetch (success or failure). If the fetch request fails, the error is returned in the second parameter of this callback. |
 
 Amplitude Experiment recommends calling `fetch()` during application start up so that the user gets the most up-to-date variants for the application session. Furthermore, you'll need to wait for the fetch request to return a result before rendering the user experience to avoid the interface "flickering".

--- a/docs/experiment/sdks/javascript-sdk.md
+++ b/docs/experiment/sdks/javascript-sdk.md
@@ -181,12 +181,13 @@ The SDK client can be configured once on initialization.
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
 
 ```js
-fetch(user?: ExperimentUser): Promise<Client>
+fetch(user?: ExperimentUser, options?: FetchOptions): Promise<Client>
 ```
 
-| Parameter  | Requirement | Description |
-| --- | --- | --- |
-| `user` | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to evaluate. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. |
+| Parameter | Requirement | Description                                                                                                                                                                                                                                                                                                               |
+|-----------| --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `user`    | optional | Explicit [user](../general/data-model.md#users) information to pass with the request to evaluate. This user information is merged with user information provided from [integrations](#integrations) via the [user provider](#user-provider), preferring properties passed explicitly to `fetch()` over provided properties. |
+| `options` | optional | Explicit flag keys to fetch.|
 
 !!!beta "Account level bucketing and analysis support (v1.5.6+)"
     If your organization has purchased the [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115001765532-Account-level-reporting-in-Amplitude) you may perform bucketing and analysis on groups rather than users. Reach out to your representative to gain access to this beta feature.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- add subset flag support description in Experiment Android, JS, iOS
- Going to hold util the changes released

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp