### PR TITLE
DDI-299 Fixes copy paste error in table

### DIFF
--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -13,7 +13,7 @@
 |`serverUrl`| Optional. `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
 |`serverZone`| Optional. `ServerZone.EU` or  `ServerZone.US` | Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `ServerZone.EU` |
 |`storageProvider`| Optional.  `Storage<Event[]>` | Implements a custom `storageProvider` class from Storage. The default is `MemoryStorage`. |
-|`useBatch`| Optional. `boolean` | Disable the attribution tracking, attribution is enabled by default |
+|`useBatch`| Optional. `boolean` | When `true`, uses the Batch API instead of the HTTP V2 API.|
 |`appVersion`| Optional. `string` | The current version of your application. For example: "1.0.0" |
 |`deviceId`| Optional. `string` | A device-specific identifier. |
 |`cookieExpiration`| Optional. `number` | The days when the cookie expires. The default is 365 days. |


### PR DESCRIPTION
# Amplitude Developer Docs PR

Fixes useBatch copy paste error in a shared config table. 

## Deadline

🤷 

## Change type

- [X] Doc bug fix


# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
