### PR TITLE
AMP-64861 add file size limit to s3 import docs

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -44,7 +44,8 @@ The files you want to send to Amplitude must follow some basic requirements.
 - Files contain events, with one event per line.
 - Files are uploaded approximately in the events’ chronological order.
 - Filenames are unique.
-- The file hasn’t been ingested by the S3 import already. After a file has been ingested, an S3 import source won’t process the same file again, even if it’s updated.
+- The file wasn't ingested by the S3 import yet. Once a file has been ingested by a S3 import source, the same S3 import source won’t process the file again, even if the file is updated.
+- File size shall be greater than 1MB and smaller than 1GB.
 - Files are compressed or uncompressed JSON, CSV, or parquet files.
 
 ### Limits


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Describe your changes. 
add file size limit to s3 import docs

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp