### PR TITLE
DDI-301 Adds info about base64 encoding to API basic auth reusables

### DIFF
--- a/includes/auth-basic-org-key.md
+++ b/includes/auth-basic-org-key.md
@@ -3,6 +3,10 @@
 This API uses [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication), using an org-level API key and secret key instead of a project-level API key.
 To request an org-level API key, submit a ticket to the support team at support.amplitude.com.
 
-Pass base64-encoded credentials in the request header like `{{org-api-key}}:{{org-secret_key}}`. `org-api-key` replaces username, and `org-secret-key` replaces the password. Encoded credentials look like this `bXlvcmdrZXk6bXlvcmdzZWNyZXQ=`.
+Pass base64-encoded credentials in the request header like `{{org-api-key}}:{{org-secret_key}}`. `org-api-key` replaces username, and `org-secret-key` replaces the password. 
+
+Your authorization header should look something like this: 
+
+`--header 'Authorization: Basic YWhhbWwsdG9uQGFwaWdlZS5jb206bClwYXNzdzByZAo'`
 
 See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 

--- a/includes/auth-basic-org-key.md
+++ b/includes/auth-basic-org-key.md
@@ -1,8 +1,8 @@
 ## Authorization
 
-This API uses Basic Auth, using an org-level API key and secret key instead of a project-level API key.
+This API uses [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication), using an org-level API key and secret key instead of a project-level API key.
 To request an org-level API key, submit a ticket to the support team at support.amplitude.com.
 
-Pass your API key in the request header like `{{org-api-key}}:{{org-secret_key}}`. `org-api-key` replaces username, and `org-secret-key` replaces the password.
+Pass base64-encoded credentials in the request header like `{{org-api-key}}:{{org-secret_key}}`. `org-api-key` replaces username, and `org-secret-key` replaces the password. Encoded credentials look like this `bXlvcmdrZXk6bXlvcmdzZWNyZXQ=`.
 
 See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 

--- a/includes/auth-basic.md
+++ b/includes/auth-basic.md
@@ -1,5 +1,5 @@
 ## Authorization
 
-This API uses Basic Auth, using the API key and secret key for your project. Pass your API key in the request header like `{{api-key}}:{{secret-key}}`. `api-key` replaces username, and `secret-key` replaces the password. 
+This API uses [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication), using the API key and secret key for your project. Pass base64-encoded credentials in the request header like `{{api-key}}:{{secret-key}}`. `api-key` replaces username, and `secret-key` replaces the password. Encoded credentials look like this `bXlvcmdrZXk6bXlvcmdzZWNyZXQ=`.
 
 See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 

--- a/includes/auth-basic.md
+++ b/includes/auth-basic.md
@@ -1,5 +1,10 @@
 ## Authorization
 
-This API uses [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication), using the API key and secret key for your project. Pass base64-encoded credentials in the request header like `{{api-key}}:{{secret-key}}`. `api-key` replaces username, and `secret-key` replaces the password. Encoded credentials look like this `bXlvcmdrZXk6bXlvcmdzZWNyZXQ=`.
+This API uses [basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication), using the API key and secret key for your project. Pass base64-encoded credentials in the request header like `{{api-key}}:{{secret-key}}`. `api-key` replaces username, and `secret-key` replaces the password. 
+
+Your authorization header should look something like this: 
+
+`--header 'Authorization: Basic YWhhbWwsdG9uQGFwaWdlZS5jb206bClwYXNzdzByZAo'`
+
 
 See [Find your Amplitude Project API Credentials](../find-api-credentials.md) for help locating your credentials. 


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds Base64 Encoding info to basic auth reusables. 

## Deadline

ASAP

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
