### PR TITLE
DDI-302 Adds different ways to browse postman collection

### DIFF
--- a/includes/postman.md
+++ b/includes/postman.md
@@ -1,4 +1,7 @@
 !!! tip "Get more examples for this API"
-    Run our Postman Collection for a full library of example requests and responses for this API.
+    
+    The Amplitude Developers Postman profile has a full library of example requests and responses for this API.
 
-    [![Run in Postman](https://run.pstmn.io/button.svg){ .off-glb }](https://god.gw.postman.com/run-collection/20044411-88bd70c1-9e00-483c-aaf1-2b7159f9bb2b?action=collection%2Ffork&collection-url=entityId%3D20044411-88bd70c1-9e00-483c-aaf1-2b7159f9bb2b%26entityType%3Dcollection%26workspaceId%3D2ffc735a-10a6-4f54-818e-16c87aeebcd7)
+    Check out the [Amplitude Developers Profile](https://www.postman.com/amplitude-developer-docs/workspace/amplitude-developers) to view the collection. You don't need a Postman account to browse.
+
+    If you already use Postman, you can [fork and run this collection in Postman](https://god.gw.postman.com/run-collection/20044411-88bd70c1-9e00-483c-aaf1-2b7159f9bb2b?action=collection%2Ffork&collection-url=entityId%3D20044411-88bd70c1-9e00-483c-aaf1-2b7159f9bb2b%26entityType%3Dcollection%26workspaceId%3D2ffc735a-10a6-4f54-818e-16c87aeebcd7).


### PR DESCRIPTION
# Amplitude Developer Docs PR

London Hackathon feedback included that people didn't like the Run in Postman button and requested something "more open". 

- Added a link to the Amplitude Developer Docs profile so users without Postman accounts can browse the collection. 
- Turned the button into an inline link for people who already use postman. 

## Deadline

WHENEVER SHRUG

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
