### PR TITLE
Update Intercom Dev Doc for Intercom Source v2

### DIFF
--- a/docs/data/sources/intercom.md
+++ b/docs/data/sources/intercom.md
@@ -18,7 +18,7 @@ Sync Intercom event data to Amplitude so that you can better engage your users b
 
 - You need both an Amplitude and an Intercom account.
 - You may select either Intercom users' User ID property or their email property to map to Amplitude users' User ID.
-- Users in Amplitude and Intercom must either have the same user IDs or emails for this integration to work. You can select which property to match on; but, if the property does not match for the same user between Amplitude and Intercom, Amplitude interprets the user as new. 
+- Users in Amplitude and Intercom must either have the same user ID or email for this integration to work. You can choose which property to match on. If the property doesn't match for the same user between Amplitude and Intercom, Amplitude interprets the user as new. 
     - If there is no email or user ID for the user at all, Amplitude drops the events. 
 - This integration must be enabled on a per-project basis.
 

--- a/docs/data/sources/intercom.md
+++ b/docs/data/sources/intercom.md
@@ -17,7 +17,9 @@ Sync Intercom event data to Amplitude so that you can better engage your users b
 ## Considerations
 
 - You need both an Amplitude and an Intercom account.
-- The user IDs in Intercom and Amplitude must be the same for each user in order for this integration to work. If the Intercom user ID doesn't match Amplitude's user ID for the same user, Amplitude interprets the user as new. If there is no Intercom user ID at all, Amplitude drops the events.
+- You may select either Intercom users' User ID property or their email property to map to Amplitude users' User ID.
+- Users in Amplitude and Intercom must either have the same user IDs or emails for this integration to work. You can select which property to match on; but, if the property does not match for the same user between Amplitude and Intercom, Amplitude interprets the user as new. 
+    - If there is no email or user ID for the user at all, Amplitude drops the events. 
 - This integration must be enabled on a per-project basis.
 
 ## Setup
@@ -29,9 +31,12 @@ To set up the integration to send event data from Intercom to Amplitude, follow 
 3. In the modal that appears, click **Connect to Intercom**.
 4. Log into your Intercom account via OAuth. Select the dedicated workspace and click **Authorize access**.
 5. Intercom automatically redirects you back to Amplitude, where you see the *Connect Intercom* page.
-6. You are now ready to send Intercom events to Amplitude. After Amplitude receives events from Intercom, there is a notification on the *Listen to Event* tab. Click **Finish**. Intercom appears on the Data Sources page, with a status of "Connected."
+6. Select the Intercom user property you would like to map as Amplitude's User ID, and click **Next**.
+7. You are now ready to send Intercom events to Amplitude. After Amplitude receives events from Intercom, there is a notification on the *Listen to Event* tab. Click **Finish**. Intercom appears on the Data Sources page, with a status of "Connected."
 
 After you finish setup, events are automatically streamed into Amplitude. Event names have the prefix "[Intercom]".
+
+You can see the user property mapping preference you selected from the data source detail page for Intercom.
 
 Amplitude supports the following Intercom events, also known as **topics**:
 


### PR DESCRIPTION
> You can see the user property mapping preference you selected from the data source detail page for Intercom.
Looking to improve the wording here. The page I'm referring to is this: https://analytics.amplitude.com/amplitude/connections/project/187520/sources/detail/bGlicmFyeTphZGFwdGVyL2ludGVyY29t

Here is a lucid diagram of the new flow: https://lucid.app/lucidchart/a20cb365-6aab-450b-9f26-eec165c6507e/edit?viewport_loc=-139%2C-53%2C2269%2C1245%2CTqnafomwO3dB&invitationId=inv_836b9c96-c5ba-4973-b29e-7c39c87996d0

![Intercom Source v2 Setup - Front end UX](https://user-images.githubusercontent.com/109614503/205411808-58695d94-1edf-4558-8a9b-1154bd0e579c.png)


# Amplitude Developer Docs PR


## Description

- Updated wording to reflect properties of new Intercom source integration
  - users no longer require a valid intercom ID that maps to Amplitude users. Instead, a choice can be made to map from Intercom users' user ID or email to Amplitude User IDs.
- Updated set up guide to better illustrate intercom V2 source set up steps

## Deadline

When do these changes need to be live on the site?
Once the new UI is deployed to production.
- Estimation: December 14

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp
@Brandoncharleskhoo1 