### PR TITLE
DDI-312: Add info about prefix for custom properties

### DIFF
--- a/docs/analytics/apis/taxonomy-api.md
+++ b/docs/analytics/apis/taxonomy-api.md
@@ -23,7 +23,7 @@ You can edit planned events and properties, and not events and properties that a
 
 - You may have to URL encode special characters in the names of event types, event properties, and user properties.
  For example, encode `Play Song` as `Play%20Song`. Use the [W3Schools](http://www.w3schools.com/tags/ref_urlencode.asp) encoding reference.
-- In responses, custom user properties have a `gp:` prefix. For example `gp:my_custom_property`.
+- In responses, custom user properties have a `gp:` prefix. For example, `gp:my_custom_property`.
 - You must plan events or properties in the schema before you can delete them via this API.
 
 ## Limits


### PR DESCRIPTION
# Amplitude Developer Docs PR
Adds note about `gp:` prefix for custom properties 

## Deadline

ASAP

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
