### PR TITLE
DDI-323 Add statuspage integration and link to status page to footer

### DIFF
--- a/docs/javascripts/statuspage.js
+++ b/docs/javascripts/statuspage.js
@@ -1,0 +1,61 @@
+(function(){
+
+  var frame = document.createElement('iframe');
+  frame.src = 'https://bn2d4b3wgfdd.statuspage.io/embed/frame';
+  frame.style.position = 'fixed';
+  frame.style.border = 'none';
+  frame.style.boxShadow = '0 20px 32px -8px rgba(9,20,66,0.25)';
+  frame.style.zIndex = '9999';
+  frame.style.transition = 'left 1s ease, bottom 1s ease, right 1s ease';
+
+  frame.title = 'Amplitude Status';
+  frame.ariaHidden = true;
+
+  var mobile;
+  if (mobile = screen.width < 450) {
+    frame.src += '?mobile=true';
+    frame.style.height = '20vh';
+    frame.style.width = '100vw';
+    frame.style.left = '-9999px';
+    frame.style.bottom = '-9999px';
+    frame.style.transition = 'bottom 1s ease';
+  } else {
+    frame.style.height = '115px';
+    frame.style.width = '320px';
+    frame.style.left = '-9999px';
+    frame.style.right = 'auto';
+    frame.style.bottom = '60px';
+  }
+
+  document.body.appendChild(frame);
+
+  var actions = {
+    showFrame: function() {
+      if (mobile) {
+        frame.style.left = '0';
+        frame.style.bottom = '0';
+      }
+      else {
+        frame.style.left = '60px';
+        frame.style.right = 'auto'
+      }
+    },
+    dismissFrame: function(){
+      frame.style.left = '-9999px';
+    }
+  }
+
+  window.addEventListener('message', function(event){
+    if (event.data.action && actions.hasOwnProperty(event.data.action)) {
+      actions[event.data.action](event.data);
+    }
+  }, false);
+
+  window.statusEmbedTest = actions.showFrame;
+})();
+
+
+
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ extra_javascript:
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js # Tablesort
   - /javascripts/tablesort.js #script for Tablesort feature
   - /javascripts/anchor-copy.js #script for copying anchor links
+  - /javascripts/statuspage.js #script for status page embed
 
 # Plugins
 # When you add a plugin here, make sure the change is updated in insiders.mkdocs.yml too.
@@ -114,6 +115,7 @@ extra:
   support_contact: https://amplitude.com
   community: https://community.amplitude.com
   help_site: https://help.amplitude.com
+  status_page: https://status.amplitude.com/
   training_site: https://academy.amplitude.com/
   postman_workspace: https://www.postman.com/amplitude-developer-docs/workspace/amplitude-developers/overview
   report_issue: https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/issues/new/?title=[Feedback]+{{page.title}}+-+{{page.url}}

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -3,7 +3,6 @@
 {% extends "main.html" %} <!-- extends the main template-->
 {% block tabs %}
 {{ super() }}
-
 <!-- Sets the CSS for the Home page template. It's included in the template because it's hard to conditionally specify  -->
 <style>
 

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -11,6 +11,7 @@
 		<ul>
 			<li><a href="{{ config.extra.community }}">Get support in the Amplitude Community</a></li>
 			<li><a href="{{ config.extra.help_site }}">Go to the Help Center</a></li>
+      <li><a href="{{ config.extra.status_page }}">Amplitude Status</a></li>
 		</ul>
 		<!-- Social links -->
 		{% if config.extra.social %}


### PR DESCRIPTION
# Amplitude Developer Docs PR

Embeds the Amplitude Status Page widget and adds link to the status page to the footer. 

## Deadline

Whenever

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
