### PR TITLE
Added info on configuring Experiment for EU DC

### DIFF
--- a/docs/experiment/sdks/android-sdk.md
+++ b/docs/experiment/sdks/android-sdk.md
@@ -288,6 +288,9 @@ The SDK client can be configured once on initialization.
 
 ---
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.

--- a/docs/experiment/sdks/go-sdk.md
+++ b/docs/experiment/sdks/go-sdk.md
@@ -93,6 +93,9 @@ The SDK client can be configured on initialization.
     | `RetryBackoff.FetchRetryBackoffScalar` | Scales the minimum backoff exponentially. | `1` |
     | `RetryBackoff.FetchRetryTimeout` | The request timeout for retrying variant fetches. | `500 * time.Millisecond` |
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and returns the results. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
@@ -215,6 +218,9 @@ The SDK client can be configured on initialization.
     | `ServerUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `FlagConfigPollingInterval` | The interval to poll for updated flag configs after calling [`Start()`](#start) | `30 * time.Second` |
     | `FlagConfigPollerRequestTimeout` | The timeout for the request made by the flag config poller | `10 * time.Second` |
+
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
 
 ### Start
 

--- a/docs/experiment/sdks/ios-sdk.md
+++ b/docs/experiment/sdks/ios-sdk.md
@@ -179,6 +179,9 @@ The SDK client can be configured once on initialization.
 
 ---
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.

--- a/docs/experiment/sdks/javascript-sdk.md
+++ b/docs/experiment/sdks/javascript-sdk.md
@@ -176,6 +176,9 @@ The SDK client can be configured once on initialization.
 
 ---
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.

--- a/docs/experiment/sdks/jvm-sdk.md
+++ b/docs/experiment/sdks/jvm-sdk.md
@@ -155,6 +155,9 @@ The SDK client can be configured on initialization.
     | `fetchRetryBackoffMaxMillis` | The maximum backoff between retries. If the scaled backoff becomes greater than the max, the max is used for all subsequent requests | `10000` |
     | `fetchRetryBackoffScalar` | Scales the minimum backoff exponentially. | `1` |
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and returns the results. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
@@ -336,7 +339,7 @@ Initializes a [local evaluation](../general/evaluation/local-evaluation.md) clie
 
 #### Configuration
 
-You can configre the SDK client on initialization.
+You can configure the SDK client on initialization.
 
 ???config "Configuration Options"
     | <div class="big-column">Name</div> | Description | Default Value |
@@ -345,6 +348,9 @@ You can configre the SDK client on initialization.
     | `serverUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `flagConfigPollingIntervalMillis` | The interval to poll for updated flag configs after calling [`Start()`](#start) | `30000` |
     | `flagConfigPollerRequestTimeoutMillis` | The timeout for the request made by the flag config poller | `10000` |
+
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
 
 ### Start
 

--- a/docs/experiment/sdks/nodejs-sdk.md
+++ b/docs/experiment/sdks/nodejs-sdk.md
@@ -113,6 +113,9 @@ The SDK client can be configured on initialization.
     | `fetchRetryBackoffScalar` | Scales the minimum backoff exponentially. | `1.5` |
     | `fetchRetryTimeoutMillis` | The request timeout for retrying variant fetches. | `10000` |
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and returns the results. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
@@ -219,6 +222,9 @@ You can configure the SDK client on initialization.
     | `serverUrl` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `bootstrap` | Bootstrap the client with a map of flag key to flag configuration | `{}` |
     | `flagConfigPollingIntervalMillis` | The interval (in milliseconds) to poll for updated flag configs after calling `start()` | `30000` |
+
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
 
 ### Start
 

--- a/docs/experiment/sdks/python-sdk.md
+++ b/docs/experiment/sdks/python-sdk.md
@@ -100,6 +100,9 @@ You can configure the SDK client on initialization.
     | `fetch_retry_backoff_scalar` | Scales the minimum backoff exponentially. | `1.5` |
     | `fetch_retry_timeout_millis` | The request timeout for retrying variant fetches. | `10000` |
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and returns the results. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
@@ -246,6 +249,9 @@ You can configure the SDK client on initialization.
     | `server_url` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `flag_config_polling_interval_millis` | The interval to poll for updated flag configs after calling [`start()`](#start) | `30000` |
     | `flag_config_poller_request_timeout_millis` | The timeout for the request made by the flag config poller | `10000` |
+
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
 
 ### Start
 

--- a/docs/experiment/sdks/react-native-sdk-legacy.md
+++ b/docs/experiment/sdks/react-native-sdk-legacy.md
@@ -136,6 +136,9 @@ The SDK client can be configured once on initialization.
 
 ---
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.

--- a/docs/experiment/sdks/react-native-sdk.md
+++ b/docs/experiment/sdks/react-native-sdk.md
@@ -178,6 +178,9 @@ The SDK client can be configured once on initialization.
 
 ---
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and store the results in the client for fast access. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.

--- a/docs/experiment/sdks/ruby-sdk.md
+++ b/docs/experiment/sdks/ruby-sdk.md
@@ -108,6 +108,9 @@ You can configure the SDK client on initialization.
     | `fetch_retry_backoff_scalar` | Scales the minimum backoff exponentially. | `1.5` |
     | `fetch_retry_timeout_millis` | The request timeout for retrying variant fetches. | `10000` |
 
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
+
 ### Fetch
 
 Fetches variants for a [user](../general/data-model.md#users) and returns the results. This function [remote evaluates](../general/evaluation/remote-evaluation.md) the user for flags associated with the deployment used to initialize the SDK client.
@@ -277,6 +280,9 @@ You can configure the SDK client on initialization.
     | `bootstrap` | Bootstrap the client with a map of flag key to flag configuration | `{}` |
     | `flag_config_polling_interval_millis` | The interval to poll for updated flag configs after calling [`start`](#start) | `30000` |
     | `debug` | Set to `true` to enable debug logging. | `false` |
+
+!!!info "EU Data Center"
+    If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
 
 ### Start
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

I added information on configuring Experiment SDKs to connect to the EU DC for all Experiment SDKs, by adding a blue info bubble calling out the setting after every "Configuration" section. For SDKs with remote and local eval, this info shows up once for each.

## Deadline

ASAP, but no real deadline.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp