### PR TITLE
Update batch-event-upload-api.md

### DIFF
--- a/docs/analytics/apis/batch-event-upload-api.md
+++ b/docs/analytics/apis/batch-event-upload-api.md
@@ -378,7 +378,7 @@ These properties belong to the `options` object.
 | --- | --- | --- |
 | 200 | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | Successful batch upload. |
 | 400 | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1) | Invalid upload request. Read the error message to fix the request. |
-| 413 | [Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11) | Payload size is too big (request size exceeds 20MB). Split your events array payload in half and try again. |
+| 413 | [Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11) | Payload size is too big (request size exceeds 20MB). Split your events array payload in half and try again. The maximum number of events per batch is 2000 events. |
 | 429 | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too many requests for a user or device. Amplitude throttles requests for users and devices that exceed 1000 events per second or 500,000 events per day. |
 
 ### SuccessSummary <!-- vale off -->

--- a/docs/analytics/apis/batch-event-upload-api.md
+++ b/docs/analytics/apis/batch-event-upload-api.md
@@ -378,7 +378,7 @@ These properties belong to the `options` object.
 | --- | --- | --- |
 | 200 | [OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) | Successful batch upload. |
 | 400 | [Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1) | Invalid upload request. Read the error message to fix the request. |
-| 413 | [Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11) | Payload size is too big (request size exceeds 20MB). Split your events array payload in half and try again. The maximum number of events per batch is 2000 events. |
+| 413 | [Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11) | Payload size is too big (request size exceeds 20MB). Split your events array payload in half and try again. The limit per batch is 2000 events. |
 | 429 | [Too Many Requests](https://tools.ietf.org/html/rfc6585#section-4) | Too many requests for a user or device. Amplitude throttles requests for users and devices that exceed 1000 events per second or 500,000 events per day. |
 
 ### SuccessSummary <!-- vale off -->


### PR DESCRIPTION
The maximum number of events per batch is 2000 events https://discourse.amplitude.com/t/event-limit-for-batch-api-for-413-error/1578

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp