### PR TITLE
update sdk release milestones and versions

### DIFF
--- a/docs/experiment/general/evaluation/local-evaluation.md
+++ b/docs/experiment/general/evaluation/local-evaluation.md
@@ -40,13 +40,13 @@ The only non-local part of local evaluation is getting flag configurations from 
 
 Local evaluation is only supported by server-side SDKs which have local evaluation implemented.
 
-| SDK | Remote Evaluation | Local Evaluation | Version |
-| --- | --- | --- | --- |
-| [:material-nodejs: Node.js](../../sdks/nodejs-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | `1.1.0` |
-| [:material-language-java: JVM (Beta)](../../sdks/jvm-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | ![Maven Central](https://img.shields.io/maven-central/v/com.amplitude/experiment-jvm-server.svg?label=Maven%20Central) |
-| [:fontawesome-brands-golang: Go (Beta)](../../sdks/go-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/amplitude/experiment-go-server?sort=semver) |
-| [:material-language-ruby: Ruby (Beta)](../../sdks/ruby-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green }  | - |
-| [:material-language-python: Python (Beta)](../../sdks/python-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } | - |
+| SDK | Remote Evaluation | Local Evaluation |
+| --- | --- | --- |
+| [:material-nodejs: Node.js](../../sdks/nodejs-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green }  |
+| [:material-language-ruby: Ruby](../../sdks/ruby-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green }  |
+| [:material-language-java: JVM (Beta)](../../sdks/jvm-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } |
+| [:fontawesome-brands-golang: Go (Beta)](../../sdks/go-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } |
+| [:material-language-python: Python (Beta)](../../sdks/python-sdk.md) |  :material-check-bold:{ .green } | :material-check-bold:{ .green } |
 
 ### Performance
 

--- a/includes/data-sources-sdks.md
+++ b/includes/data-sources-sdks.md
@@ -6,12 +6,11 @@
 - :typescript: [Browser](../data/sdks/typescript-browser/index.md)
 - :material-apple-ios: [iOS](../data/sdks/ios/index.md)
 - :java: [Java](../data/sdks/java/index.md)
-- :node: [Node.js](../data/sdks/node/index.md)
-- :node: [Node.js (Beta)](../data/sdks/typescript-node/index.md)
+- :node: [Node.js](../data/sdks/typescript-node/index.md)
 - :python: [Python](../data/sdks/python/index.md)
 - :react: [React Native](../data/sdks/typescript-react-native/index.md)
 - :unity: [Unity](../data/sdks/unity/index.md)
 - :unreal: [Unreal](../data/sdks/unreal/index.md)
-- :go: [Go (Alpha)](../data/sdks/go/index.md)
+- :go: [Go (Beta)](../data/sdks/go/index.md)
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,9 +200,9 @@ nav:
     - iOS SDK: experiment/sdks/ios-sdk.md
     - React Native SDK: experiment/sdks/react-native-sdk.md
     - Node.js SDK: experiment/sdks/nodejs-sdk.md
+    - Ruby SDK: experiment/sdks/ruby-sdk.md
     - JVM SDK (Beta): experiment/sdks/jvm-sdk.md
     - Go SDK (Beta): experiment/sdks/go-sdk.md
-    - Ruby SDK: experiment/sdks/ruby-sdk.md
     - Python SDK (Beta): experiment/sdks/python-sdk.md
     - Legacy:
       - React Native SDK: experiment/sdks/react-native-sdk-legacy.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

* Experiment 
  * Move ruby up in left nav since GA
  * Remove beta tag and versions from local evaluation table
* Analytics SDKs
  * Update grid to remove legacy nodejs sdk and change golang from alpha to beta.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp