### PR TITLE
add documentation on flag list, flag details, and experiment/flag versions APIs to management api

### DIFF
--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -85,6 +85,7 @@ A successful request returns a `200 OK` response and a list of experiments encod
     ```
 
 ------
+
 ## List flags
 
 ```bash
@@ -206,6 +207,7 @@ A successful request returns a `200 OK` response and a list of experiment's vers
     ```
 
 ------
+
 ## Get experiment version details
 
 ```bash
@@ -236,6 +238,7 @@ A successful request returns a `200 OK` response and a JSON object with details 
     ```
 
 ------
+
 ## Get flag details
 
 ```bash
@@ -266,7 +269,6 @@ A successful request returns a `200 OK` response and a JSON object with the flag
 
 ------
 
-
 ## List flag versions
 
 ```bash
@@ -296,6 +298,7 @@ A successful request returns a `200 OK` response and a list of flag's versions e
     ```
 
 ------
+
 ## Get flag version details
 
 ```bash

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -14,8 +14,14 @@ The Experiment management API can be used to programmatically create and control
 | <div class="big-column">Name</div> | Description |
 | --- | --- |
 | [List experiments](#list-experiments) | List of experiments including their configuration details. |
+| [List flags](#list-flags) | List of flags including their configuration details. |
 | [List deployments](#list-deployments) | List deployments that experiments can be assigned to. |
 | [Get experiment details](#get-experiment-details) | Get the configuration details of an experiment. |
+| [List experiment versions](#list-experiment-versions) | List all versions for an experiment. |
+| [Get experiment version details](#get-experiment-version-details) | Get a specific version for an experiment. |
+| [Get flag details](#get-flag-details) | Get the configuration details of a flag. |
+| [List flag versions](#list-flag-versions) | List all versions for a flag. |
+| [Get flag version details](#get-flag-version-details) | Get a specific version for a flag. |
 | [Create experiment](#create-experiment) | Create a new experiment. |
 | [Activate experiment](#activate-experiment) | Activate a inactive experiment. |
 | [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
@@ -79,6 +85,36 @@ A successful request returns a `200 OK` response and a list of experiments encod
     ```
 
 ------
+## List flags
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/list
+```
+
+Fetch a list of flags including their configuration details. Results are ordered with the most recently created flags first.
+
+### Query parameters
+
+| <div class="big-column">Name</div> | Description |
+| --- | --- |
+| `limit` | The max number of flags to be returned. Capped at 1000. |
+| `cursor` | The offset to start the "page" of results from. |
+
+### Response
+
+A successful request returns a `200 OK` response and a list of flags encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/list?limit=1000' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
 
 ## List deployments
 
@@ -135,6 +171,156 @@ A successful request returns a `200 OK` response and a JSON object with the expe
     ```bash
     curl --request GET \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## List experiment versions
+
+```bash
+GET https://management-api.experiment.amplitude.com/experiments/{id}/versions
+```
+
+Fetch a list of all versions for an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of experiment's versions encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/versions' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+## Get experiment version details
+
+```bash
+GET https://management-api.experiment.amplitude.com/experiments/{id}/versions/{versionId}
+```
+
+Fetch details of a specific version of an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`versionId`| Required. String. The version's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with details of experiment's version.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/versions/<versionId>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+## Get flag details
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}
+```
+
+Fetch the configuration details of a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with the flag's details.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+
+## List flag versions
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}/versions
+```
+
+Fetch a list of all versions for a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of flag's versions encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/versions' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+## Get flag version details
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}/versions/{versionId}
+```
+
+Fetch details of a specific version of a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flags's ID.|
+|`versionId`| Required. String. The version's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with details of flag's version.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/versions/<versionId>' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add the following endpoints to Experiment Management API:
- /flags/list
- /flags/{:id}
- /experiments/{:id}/versions
- /experiments/{:id}/versions/{:versionId}
- /flags/{:id}/versions
- /flags/{:id}/versions/{:versionId}

## Deadline

The feature is live on prod, and customers will be notified of this change asap.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [x] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp