### PR TITLE
DDI-338 Fix absolute link that goes to the wrong place

### DIFF
--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -28,4 +28,4 @@
 |`userId`| Optional. `number` | ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_user_length` option. |
 |`optOut`| Optional. `boolean` | If `optOut` is `true`, the event isn't sent to Amplitude's servers. The default is `false`. |
 |`transport`| Optional. `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`| Set the transport type. |
-|`config.trackingOptions`| Optional. `TrackingOptions` | [Learn more about tracking options](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/). |
+|`config.trackingOptions`| Optional. `TrackingOptions` | [Learn more about tracking options](/data/sdks/typescript-browser/#optional-tracking). |


### PR DESCRIPTION
Fix absolute link in a reusable to go to the right place. 