### PR TITLE
DDI-339: Update footer copyright to auto-update for year

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ repo_url: https://github.com/Amplitude-Developer-Docs/amplitude-dev-center
 edit_uri: edit/main/docs/
 
 # Copyright
-copyright: Copyright &copy; 2022 Amplitude - <a href="#__consent">Change cookie settings</a>
+copyright: Copyright &copy; <script>document.write(new Date().getFullYear())</script> Amplitude - <a href="#__consent">Change cookie settings</a>
 
 # Configuration
 theme:


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds script to footer to pull in current year.  

## Deadline

Soon

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
