### PR TITLE
Correct timestamp common snippet snowflake.md

### DIFF
--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -147,4 +147,4 @@ Converting timestamp column to milliseconds:
 
 Converting milliseconds to timestamp needed for time based import:
 
-`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS) as "timestamp_column"`
+`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS / 1000.0) as "timestamp_column"`

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -145,6 +145,7 @@ Converting timestamp column to milliseconds:
 
 `DATE_PART('EPOCH_MILLISECOND', TIMESTAMP_COLUMN) as "time"`
 
-Converting milliseconds to timestamp needed for time based import:
+Converting milliseconds to timestamp needed for time-based import. This example uses the `scale` argument set to `3` to convert to milliseconds. See the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html) for more details.
 
-`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS / 1000.0) as "timestamp_column"`
+`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS, 3) as "timestamp_column"`
+ 


### PR DESCRIPTION
Milliseconds need to be divided by 1000.0 before converting to timestamp for an accurate timestamp.

# Amplitude Developer Docs PR


## Description

Divide epoch timestamp in milliseconds by 1000.0 before converting to ntz timestamp. Resulting timestamp would be innacurate otherwise. 

## Deadline

just a friendly fix proposed

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp