### PR TITLE
fix: add beta tag and remove ampli for ios swift beta sdk

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,9 +188,8 @@ nav:
         - Android:
           - data/sdks/android-kotlin/index.md
           - Ampli Codegen: data/sdks/android-kotlin/ampli.md
-        - iOS:
+        - iOS (Beta):
           - data/sdks/ios-swift/index.md
-          - Ampli Codegen: data/sdks/ios/ampli.md
         - Java:
           - data/sdks/java/index.md
           - Ampli Codegen: data/sdks/java/ampli.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
- fix: add beta tag and remove ampli for ios swift beta sdk

![image](https://user-images.githubusercontent.com/8689754/210629763-7167502a-b033-411c-ace4-db45d11a34c9.png)

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp