### PR TITLE
AMP-66512 Update CI docs to remove deprecated ampli-swift docker image

### DIFF
--- a/docs/data/ampli/integrating-with-ci.md
+++ b/docs/data/ampli/integrating-with-ci.md
@@ -14,7 +14,7 @@ After you've added Amplitude Data to your CI environment, Amplitude Data verifie
 
 ### Step 1: Create an API token
 
-Create an [API token](https://data.amplitude.com/settings/api-tokens) in your account. Ampli uses this token for authentication when running inside CI to update your tracking plan's implementation status.
+Create an API token in [your account](https://data.amplitude.com/) (page `Settings`/`API Tokens`). Ampli uses this token for authentication when running inside CI to update your tracking plan's implementation status.
 
 !!!warning
 

--- a/docs/data/ampli/integrating-with-ci.md
+++ b/docs/data/ampli/integrating-with-ci.md
@@ -50,10 +50,9 @@ To install Ampli locally, run `npm install @amplitude/ampli -D`.
 
 ### Step 4: Run Ampli in CI
 
-To integrate Ampli with your CI system, change your CI configuration to run [`ampli status`](cli.md#ampli-status) as part of the build process. Amplitude has made it easy by creating [Docker Containers](https://hub.docker.com/u/amplitudeinc) that you can use which include dependencies. Some runtimes have their own containers:
+To integrate Ampli with your CI system, change your CI configuration to run [`ampli status`](cli.md#ampli-status) as part of the build process. Amplitude has made it easy by creating [Docker Containers](https://hub.docker.com/u/amplitudeinc) that you can use which include dependencies. .NET runtimes have their own container:
 
 - `amplitudeinc/ampli`
-- `amplitudeinc/ampli-swift`
 - `amplitudeinc/ampli-dotnet`
 - `amplitudeinc/ampli-all` (for convenience this contains everything but is larger in size)
 
@@ -61,41 +60,14 @@ The following examples are for Bitbucket Pipelines but you can use the same imag
 
 === "ampli"
 
-    The [ampli image](https://hub.docker.com/r/amplitudeinc/ampli) can be used to verify the following SDK runtimes.
-
-    - android-java
-    - android-kotlin
-    - browser-javascript
-    - browser-typescript
-    - ios-objc
-    - jre-java
-    - node-javascript
-    - node-typescript
-    - python (2 & 3)
-    - ruby
+    The [ampli image](https://hub.docker.com/r/amplitudeinc/ampli) can be used to verify any SDK runtime except .NET.
 
     ```yaml
     # bitbucket-pipelines.yml
-    # Runtimes:
-    # android-java, android-kotlin, browser-javascript, browser-javascript,
-    # ios-objc, jre-java, node-javascript, node-typescript, python, ruby
+    # Runtimes: except .NET C#
     - step:
         name: Run 'ampli status' in CI
         image: amplitudeinc/ampli
-        script:
-          - ampli status [-u] -t $ITLY_KEY
-    ```
-
-=== "Swift"
-
-    The [ampli-swift image](https://hub.docker.com/r/amplitudeinc/ampli-swift) can be used to verify Swift runtimes.
-
-    ```yaml
-    # bitbucket-pipelines.yml
-    # Runtimes: Swift
-    - step:
-        name: Run 'ampli status' in CI
-        image: amplitudeinc/ampli-swift
         script:
           - ampli status [-u] -t $ITLY_KEY
     ```
@@ -110,21 +82,6 @@ The following examples are for Bitbucket Pipelines but you can use the same imag
     - step:
         name: Run 'ampli status' in CI
         image: amplitudeinc/ampli-dotnet
-        script:
-          - ampli status [-u] -t $ITLY_KEY
-    ```
-
-    </TabItem>
-    <TabItem value="ruby">
-
-    The ampli-ruby image can be used to verify Ruby.
-
-    ```yaml
-    # bitbucket-pipelines.yml
-    # Runtimes: Ruby
-    - step:
-        name: Run 'ampli status' in CI
-        image: amplitudeinc/ampli-ruby
         script:
           - ampli status [-u] -t $ITLY_KEY
     ```

--- a/docs/data/ampli/integrating-with-ci.md
+++ b/docs/data/ampli/integrating-with-ci.md
@@ -12,7 +12,7 @@ After you've added Amplitude Data to your CI environment, Amplitude Data verifie
 
     Amplitude Data checks your analytics implementation against the tracking plan version that's currently checked in. If your team made changes to your tracking plan since the last call to `ampli pull`, those changes will not cause a failure in CI.
 
-### Step 1: Create an API token
+## Step 1: Create an API token
 
 Create an API token for [your Amplitude Data account](https://data.amplitude.com/) by going to `Settings` => `API Tokens`. Ampli uses this token for authentication when running inside CI to update your tracking plan's implementation status.
 
@@ -20,7 +20,7 @@ Create an API token for [your Amplitude Data account](https://data.amplitude.com
 
     Keep your token secret. Your token has global permissions on your account.
 
-### Step 2: Configure a CI environment variable
+## Step 2: Configure a CI environment variable
 
 Create an environment variable in your CI service called `AMPLI_TOKEN` and set it to the API token you created. Use this environment variable to pass the token to `ampli status` when it runs inside CI.
 
@@ -36,7 +36,7 @@ Read the documentation for your CI service to get step-by-step instructions:
 - [Jenkins](https://jenkins.io/doc/pipeline/tour/environment/#credentials-in-the-environment)
 - [Travis CI](https://docs.travis-ci.com/user/environment-variables/)
 
-### Step 3: Prepare your project
+## Step 3: Prepare your project
 
 By now, you've run `ampli pull` and `ampli status` in your project's root folder. The folder contains an `ampli.json` file with metadata about the current state of the Ampli Wrapper in your project. When you run `ampli status`, on your local machine or soon in CI, Ampli verifies your analytics against this file.
 
@@ -44,23 +44,23 @@ For non-JavaScript and non-TypeScript projects, this is all the configuration th
 
 Optionally, for JavaScript and TypeScript projects, you may decide to install Ampli locally as a dev dependency. Installing Ampli locally in the project's `node_modules` folder simplifies installation and usage of Ampli for your team and CI environment. There are two steps to this.
 
-#### Install Ampli as a dev dependency
+### Install Ampli as a dev dependency
 
 To install Ampli locally, run `npm install @amplitude/ampli -D`.
 
-### Step 4: Run Ampli in CI
+## Step 4: Run Ampli in CI
 
 To integrate Ampli with your CI system, change your CI configuration to run [`ampli status`](cli.md#ampli-status) as part of the build process.
 
-#### Docker Containers
+### Docker Containers
 
 Amplitude has made it easy to run the Ampli CLI anywhere by creating [Docker Containers](https://hub.docker.com/u/amplitudeinc) which include all necessary dependencies.
 
-##### amplitudeinc/ampli
+#### amplitudeinc/ampli
 
 The [ampli image](https://hub.docker.com/r/amplitudeinc/ampli) can be used to verify any Ampli SDK runtime except .NET.
 
-##### amplitudeinc/ampli-all
+#### amplitudeinc/ampli-all
 
 The [ampli-all image](https://hub.docker.com/r/amplitudeinc/ampli-all) can be used to verify any Ampli SDK runtime, including .NET C#, but is larger in size.
 
@@ -69,13 +69,14 @@ The [ampli-all image](https://hub.docker.com/r/amplitudeinc/ampli-all) can be us
     
     Use latest version of `amplitudeinc/ampli-all` instead.
 
-#### Github Actions
+### GitHub Actions
 
-The Ampli CLI Docker containers can be used in your Github Actions workflows by setting the `container.image` value.
+The Ampli CLI Docker containers can be used in your GitHub Actions workflows by setting the `container.image` value.
 
-Learn more about how to run Github Actions in containers in Github's documentation [here](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
+Learn more about how to run GitHub Actions in containers in GitHub's documentation [here](https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container)
 
 === "ampli"
+
     ```yaml
     name: Ampli Implementation Check
     on: pull_request
@@ -95,6 +96,7 @@ Learn more about how to run Github Actions in containers in Github's documentati
     ```
 
 === "ampli-all"
+
     ```yaml
     name: Ampli Implementation Check
     on: pull_request
@@ -113,7 +115,7 @@ Learn more about how to run Github Actions in containers in Github's documentati
             run: ampli status -t ${{secrets.AMPLI_TOKEN}} [--update]
     ```
 
-#### Bitbucket Pipelines
+### Bitbucket Pipelines
 
 The Ampli CLI Docker containers can be used in your `bitbucket-pipelines.yml` by setting the `image` value.
 
@@ -135,9 +137,8 @@ The Ampli CLI Docker containers can be used in your `bitbucket-pipelines.yml` by
             - ampli status [-u] -t $AMPLI_TOKEN
     ```
 
-#### Other CI Systems
+### Other CI systems
 
-The examples above are for Github and Bitbucket, but you can use the same images in any CI system that supports containers.
-
+The examples above are for GitHub and Bitbucket, but you can use the same images in any CI system that supports containers.
 
 You should now have Ampli running inside your CI system. Congratulations!

--- a/docs/data/ampli/integrating-with-ci.md
+++ b/docs/data/ampli/integrating-with-ci.md
@@ -14,7 +14,7 @@ After you've added Amplitude Data to your CI environment, Amplitude Data verifie
 
 ### Step 1: Create an API token
 
-Create an API token in [your account](https://data.amplitude.com/) (page `Settings`/`API Tokens`). Ampli uses this token for authentication when running inside CI to update your tracking plan's implementation status.
+Create an API token for [your Amplitude Data account](https://data.amplitude.com/) by going to `Settings` => `API Tokens`. Ampli uses this token for authentication when running inside CI to update your tracking plan's implementation status.
 
 !!!warning
 
@@ -26,7 +26,7 @@ Create an environment variable in your CI service called `AMPLI_TOKEN` and set i
 
 For example, this is what the [Netlify](https://docs.netlify.com/configure-builds/environment-variables/) environment variables screen would look like.
 
-![screen shot of the ITLY_KEY variable in Netlify](../../assets/images/data-netlify-environment-variables.png)
+![screen shot of the AMPLI_TOKEN variable in Netlify](../../assets/images/data-netlify-environment-variables.png)
 
 Read the documentation for your CI service to get step-by-step instructions:
 

--- a/docs/data/ampli/integrating-with-ci.md
+++ b/docs/data/ampli/integrating-with-ci.md
@@ -50,9 +50,11 @@ To install Ampli locally, run `npm install @amplitude/ampli -D`.
 
 ### Step 4: Run Ampli in CI
 
-To integrate Ampli with your CI system, change your CI configuration to run [`ampli status`](cli.md#ampli-status) as part of the build process. Amplitude has made it easy by creating [Docker Containers](https://hub.docker.com/u/amplitudeinc) which include all necessary dependencies for the Ampli CLI.
+To integrate Ampli with your CI system, change your CI configuration to run [`ampli status`](cli.md#ampli-status) as part of the build process.
 
 #### Docker Containers
+
+Amplitude has made it easy to run the Ampli CLI anywhere by creating [Docker Containers](https://hub.docker.com/u/amplitudeinc) which include all necessary dependencies.
 
 ##### amplitudeinc/ampli
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update CI docs to remove deprecated `ampli-swift` docker image.

## Deadline

When do these changes need to be live on the site?

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp

`markdownlint` detects a dead link `https:/https://docs.developers.amplitude.com/data.amplitude.com/`
It looks like some patterns (https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/blob/main/.markdown-link-check.json#L73) incorrectly convert original link `https://data.amplitude.com/` to the incorrect  `https:/https://docs.developers.amplitude.com/data.amplitude.com/`