### PR TITLE
DDI-317 Adding Client-side vs Server-side doc

### DIFF
--- a/docs/data/sdks/index.md
+++ b/docs/data/sdks/index.md
@@ -7,7 +7,14 @@ Use Amplitude SDKs to send event data from your apps into Amplitude.
 
 ## Data SDKs
 
---8<-- "includes/data-sources-sdks.md"
+### Data client-side SDKs
+
+--8<-- "includes/data-sources-sdks-client-side.md"
+
+### Data server-side SDKs
+
+
+--8<-- "includes/data-sources-sdks-server-side.md"
 
 ## Experiment SDKs
 

--- a/docs/data/sdks/index.md
+++ b/docs/data/sdks/index.md
@@ -5,14 +5,13 @@ description: Use Amplitude SDKs to send event data from your apps into Amplitude
 
 Use Amplitude SDKs to send event data from your apps into Amplitude.
 
-## Data SDKs
+## Analytics SDKs
 
-### Data client-side SDKs
+### Analytics client-side SDKs
 
 --8<-- "includes/data-sources-sdks-client-side.md"
 
-### Data server-side SDKs
-
+### Analytics server-side SDKs
 
 --8<-- "includes/data-sources-sdks-server-side.md"
 

--- a/docs/data/sources.md
+++ b/docs/data/sources.md
@@ -28,7 +28,13 @@ For detailed instructions, see the documentation for the source you want to add.
 
 <!-- This content is used in several places. Make changes to includes/data-sources-sdks.md -->
 
---8<-- "includes/data-sources-sdks.md"
+#### Client-side
+
+--8<-- "includes/data-sources-sdks-client-side.md"
+
+#### Server-side
+
+--8<-- "includes/data-sources-sdks-server-side.md"
 
 ### Cloud storage
 

--- a/docs/data/sources/client-side-vs-server-side.md
+++ b/docs/data/sources/client-side-vs-server-side.md
@@ -34,3 +34,12 @@ See the [Analytics server-side SDKs](/data/sdks/#data-server-side-sdks) and the 
 ## Third-party sources
 
 Third-party is another kind of source. These sources let you import data from other platforms into Amplitude. These sources all require that you have an account with the third-party sources, and each have different setup requirements. You can see all third-party sources in the [Source catalog](/data/sources).
+
+## How to choose
+
+Choosing the kinds of sources you need to use can be daunting, so here's a basic guide to help you make a decision.
+
+- **Client-side**: Choose client-side sources for the simplest initial instrumentation.
+- **Server-side**: Choose server-side sources if you want track server-side events and leverage existing user data tracking workflows.
+- **Hybrid**: Choose a hybrid approach that includes both client-side and server-side sources to get the benefits of simpler implementation and ability to track server-side events. 
+- **Third party**: Choose these sources if you already have a third-party data layer such as ad networks or marketing automation tools.

--- a/docs/data/sources/client-side-vs-server-side.md
+++ b/docs/data/sources/client-side-vs-server-side.md
@@ -1,6 +1,7 @@
 ---
 title: Client-side vs Server-side Sources
 description: Learn the difference between Amplitude's client-side and server-side sources.
+status: new
 ---
 
 Client-side and server-side are terms that describe where an app's code runs: either on the user's device (client-side), or on a server (server-side). Amplitude has several types of sources to cover each of your needs. This doc primarily describes the differences between client-side and server-side sources, and gives a brief overview of third-party sources. 

--- a/docs/data/sources/client-side-vs-server-side.md
+++ b/docs/data/sources/client-side-vs-server-side.md
@@ -1,0 +1,36 @@
+---
+title: Client-side vs Server-side Sources
+description: Learn the difference between Amplitude's client-side and server-side sources.
+---
+
+Client-side and server-side are terms that describe where an app's code runs: either on the user's device (client-side), or on a server (server-side). Amplitude has several types of sources to cover each of your needs. This doc primarily describes the differences between client-side and server-side sources, and gives a brief overview of third-party sources. 
+
+## Client-side sources
+
+Use client-side sources in apps that your users run on their own devices, like mobile, web browser, and desktop apps. In these types of sources, code runs on the user's device.
+
+Amplitude's client-side sources include these SDKs:
+
+- Web: Browser, Marketing Analytics Browser, React Native
+- Mobile: Android, iOS, Unity Plugin, Flutter, React Native
+  
+See the [Data client-side SDKs](/data/sdks/#data-client-side-sdks) and the [Experiment client-side SDKs](/data/sdks/#experiment-client-side-sdks)
+
+## Server-side sources
+
+Use server-side sources in secure, multi-user environments like web servers and services that you run on your own servers. In these types of sources, code runs on the server. 
+
+Amplitude's server-side sources include these SDKs and APIs:
+
+- Node.js SDK
+- Go SDK
+- Python SDK
+- Java SDK
+- HTTP V2 API 
+- Batch Event Upload API
+
+See the [Data server-side SDKs](/data/sdks/#data-server-side-sdks) and the [Experiment server-side SDKs](/data/sdks/#experiment-server-side-sdks)
+
+## Third-party sources
+
+Third-party is another kind of source. These sources let you import data from other platforms into Amplitude. These sources all require that you have an account with the third-party sources, and each have different setup requirements. You can see all third-party sources in the [Source catalog](/data/sources).

--- a/docs/data/sources/client-side-vs-server-side.md
+++ b/docs/data/sources/client-side-vs-server-side.md
@@ -14,7 +14,7 @@ Amplitude's client-side sources include these SDKs:
 - Web: Browser, Marketing Analytics Browser, React Native
 - Mobile: Android, iOS, Unity Plugin, Flutter, React Native
   
-See the [Data client-side SDKs](/data/sdks/#data-client-side-sdks) and the [Experiment client-side SDKs](/data/sdks/#experiment-client-side-sdks)
+See the [Analytics client-side SDKs](/data/sdks/#data-client-side-sdks) and the [Experiment client-side SDKs](/data/sdks/#experiment-client-side-sdks)
 
 ## Server-side sources
 
@@ -29,7 +29,7 @@ Amplitude's server-side sources include these SDKs and APIs:
 - HTTP V2 API 
 - Batch Event Upload API
 
-See the [Data server-side SDKs](/data/sdks/#data-server-side-sdks) and the [Experiment server-side SDKs](/data/sdks/#experiment-server-side-sdks)
+See the [Analytics server-side SDKs](/data/sdks/#data-server-side-sdks) and the [Experiment server-side SDKs](/data/sdks/#experiment-server-side-sdks)
 
 ## Third-party sources
 

--- a/includes/data-sources-sdks-client-side.md
+++ b/includes/data-sources-sdks-client-side.md
@@ -1,0 +1,14 @@
+<!-- To add an entry, first add an SVG logo in overrides/.icons, then add a new line item in the table. Wrap the icon filename in colons to reference it. -->
+
+<div class="grid cards" markdown>
+
+- :android: [Android](../../data/sdks/android-kotlin/)
+- :typescript: [Browser](../../data/sdks/typescript-browser/)
+- :typescript: [Marketing Analytics Browser](../../data/sdks/marketing-analytics-browser/)
+- :material-apple-ios: [iOS Swift (Beta)](../../data/sdks/ios-swift/)
+- :material-apple-ios: [iOS](../../data/sdks/ios/)
+- :flutter: [Flutter](../..data/sdks/flutter)
+- :react: [React Native](../../data/sdks/typescript-react-native/)
+- :unity: [Unity](../../data/sdks/unity/)
+- :unreal: [Unreal](../../data/sdks/unreal/)
+</div>

--- a/includes/data-sources-sdks-server-side.md
+++ b/includes/data-sources-sdks-server-side.md
@@ -5,7 +5,6 @@
 - :java: [Java](../../data/sdks/java/)
 - :node: [Node.js](../../data/sdks/typescript-node/)
 - :python: [Python](../../data/sdks/python/)
-- :react: [React Native](../../data/sdks/typescript-react-native/)
 - :go: [Go (Beta)](../../data/sdks/go/index)
 
 </div>

--- a/includes/data-sources-sdks-server-side.md
+++ b/includes/data-sources-sdks-server-side.md
@@ -1,0 +1,11 @@
+<!-- To add an entry, first add an SVG logo in overrides/.icons, then add a new line item in the table. Wrap the icon filename in colons to reference it. -->
+
+<div class="grid cards" markdown>
+
+- :java: [Java](../../data/sdks/java/)
+- :node: [Node.js](../../data/sdks/typescript-node/)
+- :python: [Python](../../data/sdks/python/)
+- :react: [React Native](../../data/sdks/typescript-react-native/)
+- :go: [Go (Beta)](../../data/sdks/go/index)
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,10 +160,11 @@ nav:
       - Use AMP with Amplitude: analytics/use-amp-pages.md
   - Data:
     - data/index.md
-    - Overview: data/index.md
+    - Overview: data/index.md  
     - Getting Started: "getting-started.md"
     - Sources:
       - Overview: data/sources.md
+      - Client-side vs Server-side: data/sources/client-side-vs-server-side.md
       - Ampli:
         - data/ampli/index.md
         - data/ampli/cli.md


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds client vs server side explainer doc and reorganizes SDK catalogs for client side versus server side. 

## Deadline

Whenever

## Change type

- [X] Doc update.
- [X] New documentation.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.