### PR TITLE
DDI-360 Adds missing Optional identifiers to some params

### DIFF
--- a/docs/analytics/apis/identify-api.md
+++ b/docs/analytics/apis/identify-api.md
@@ -52,23 +52,23 @@ You can send these parameters as query parameter in a GET request. In a POST req
 | --- | --- | --- |
 | `user_id` | <span class="required">Required unless `device_id` is present</span>. String. A UUID (unique user ID) specified by you. If you send a request with a `user_id` that's not in the Amplitude system yet, then the user tied to the `user_id` isn't marked new until their first event. |
 | `device_id` | <span class="required">Required unless `user_id` is present</span>. String. A device specific identifier, such as the Identifier for Vendor (IDFV) on iOS. |
-| `user_properties` |  Dictionary. A dictionary of key-value pairs that represent data tied to the user. Each distinct value appears as a user segment on the Amplitude dashboard. Object depth may not exceed 40 layers. You can store property values in an array and date values are transformed into string values. |
-| `groups` | Dictionary. This feature is only available to Enterprise customers who have purchased the [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115001765532). A dictionary of key-value pairs that represent groups of users. Setting groups allows you to use [account-level reporting](https://help.amplitude.com/hc/en-us/articles/115001765532). You can track up to 5 unique group types and 10 total groups. |
-| `app_version` |String. The version of the app the user is on. |
-| `platform`[^1] |String. The platform that's sending the data. |
-| `os_name`[^1] |String. The mobile operating system or browser the user is on. |
-| `os_version`[^1] |String. The version of the mobile operating system or browser the user is on. |
-| `device_brand`[^1] |String. The device brand the user is on. |
-| `device_manufacturer`[^1] |String. The device manufacturer of the device that the user is on. |
-| `device_model`[^1] |String. The device model the user is on. |
-| `carrier`[^1] |String. The carrier the user has. |
-| `country`[^2] |String. The country that the user is in. |
-| `region`[^2] | String. The geographical region the user is in. |
-| `city`[^2]|String. The city the user is in. |
-| `dma`[^2] |String. The Designated Market Area of the user. |
-| `language` |String. The language the user has set. |
-| `paying` |String. Whether the user is paying. |
-| `start_version`  | String. The version of the app the user was on first. |
+| `user_properties` | <span class="optional">Optional</span>. Dictionary. A dictionary of key-value pairs that represent data tied to the user. Each distinct value appears as a user segment on the Amplitude dashboard. Object depth may not exceed 40 layers. You can store property values in an array and date values are transformed into string values. |
+| `groups` |<span class="optional">Optional</span>. Dictionary. This feature is only available to Enterprise customers who have purchased the [Accounts add-on](https://help.amplitude.com/hc/en-us/articles/115001765532). A dictionary of key-value pairs that represent groups of users. Setting groups allows you to use [account-level reporting](https://help.amplitude.com/hc/en-us/articles/115001765532). You can track up to 5 unique group types and 10 total groups. |
+| `app_version` |<span class="optional">Optional</span>. String. The version of the app the user is on. |
+| `platform`[^1] |<span class="optional">Optional</span>. String. The platform that's sending the data. |
+| `os_name`[^1] |<span class="optional">Optional</span>. String. The mobile operating system or browser the user is on. |
+| `os_version`[^1] |<span class="optional">Optional</span>. String. The version of the mobile operating system or browser the user is on. |
+| `device_brand`[^1] |<span class="optional">Optional</span>. String. The device brand the user is on. |
+| `device_manufacturer`[^1] |<span class="optional">Optional</span>. String. The device manufacturer of the device that the user is on. |
+| `device_model`[^1] |<span class="optional">Optional</span>. String. The device model the user is on. |
+| `carrier`[^1] |<span class="optional">Optional</span>. String. The carrier the user has. |
+| `country`[^2] |<span class="optional">Optional</span>. String. The country that the user is in. |
+| `region`[^2] |<span class="optional">Optional</span>. String. The geographical region the user is in. |
+| `city`[^2]|<span class="optional">Optional</span>. String. The city the user is in. |
+| `dma`[^2] |<span class="optional">Optional</span>. String. The Designated Market Area of the user. |
+| `language` |<span class="optional">Optional</span>. String. The language the user has set. |
+| `paying` |<span class="optional">Optional</span>. String. Whether the user is paying. |
+| `start_version`  |<span class="optional">Optional</span>. String. The version of the app the user was on first. |
 
 #### `user_properties` supported operations
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds missing optional identifiers to optional params in Identify API doc. 

## Deadline

ASAP

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.

