### PR TITLE
AMP-63980 Update User Privacy API doc to reference managing user privacy notifications instruction

### DIFF
--- a/docs/analytics/apis/user-privacy-api.md
+++ b/docs/analytics/apis/user-privacy-api.md
@@ -22,7 +22,7 @@ The User Privacy API helps you comply with end-user data deletion requests manda
 
 Keep these considerations in mind when using the User Privacy API.
 
-- When you make a deletion request, Amplitude emails all account admins with the deletion details.
+- When you make a deletion request, Amplitude [emails all account admins](https://help.amplitude.com/hc/en-us/articles/360031965572-Manage-user-privacy-notifications-in-Amplitude) with the deletion details.
 - Amplitude deletes all events and user properties added up until the time that job runs for each Amplitude ID in a deletion job.
 - Running a deletion job for a user doesn't block new events for that user. Amplitude accepts new events from a deleted user.
 - If Amplitude receives events for a deleted user, then it counts the deleted user as a new user.


### PR DESCRIPTION
Update User Privacy API doc to reference managing user privacy notifications instruction

# Amplitude Developer Docs PR


## Description

Link to managing user privacy notifications instruction so that users using User Privacy API knows how to manage user privacy notifications.

![Screen Shot 2023-01-06 at 12 15 17 PM](https://user-images.githubusercontent.com/116029942/211670513-b7906a1f-3f98-42c9-96f6-b85450353172.png)


## Deadline

N/A


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [*] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [*] My documentation follows the style guidelines of this project.
- [*] I previewed my documentation on a local server using `mkdocs serve`.
- [*] Running `mkdocs serve` didn't generate any failures.
- [*] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp