### PR TITLE
Updates docs for plugin to specify correct return type

### DIFF
--- a/docs/data/ampli/plugin.md
+++ b/docs/data/ampli/plugin.md
@@ -17,7 +17,7 @@ This method contains logic for preparing the plugin for use and has config as a 
 
 ### Plugin.execute
 
-This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is `undefined`. This method is called for each event, including Identify, GroupIdentify and Revenue) instrumented using the client interface.
+This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event, including Identify, GroupIdentify and Revenue) instrumented using the client interface.
 
 Add plugin to Ampli via `ampli.client.add()`. You can add as many plugin as you like. Each plugin runs in the order based on the plugin type.
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -194,7 +194,7 @@ This method contains logic for preparing the plugin for use and has `amplitude` 
 
 ### Plugin.execute
 
-This method contains the logic for processing events and has `event` instance as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is `null`. This method is called for each event, including Identify, GroupIdentify and Revenue events, that's instrumented using the client interface.
+This method contains the logic for processing events and has `event` instance as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event, including Identify, GroupIdentify and Revenue events, that's instrumented using the client interface.
 
 ### Plugin examples
 

--- a/docs/data/sdks/go/index.md
+++ b/docs/data/sdks/go/index.md
@@ -307,7 +307,7 @@ This method contains logic for preparing the plugin for use and has `Config` str
 
 ### `Plugin.Execute`
 
-This method contains the logic for processing events and has `*Event` as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is `nil`. This method is called for each event instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
+This method contains the logic for processing events and has `*Event` as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
 
 ### Plugin examples
 

--- a/docs/data/sdks/python/index.md
+++ b/docs/data/sdks/python/index.md
@@ -349,7 +349,7 @@ This method contains logic for preparing the plugin for use and has `client` ins
 
 ### `Plugin.execute`
 
-This method contains the logic for processing events and has `event` instance as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is `None`. This method is called for each event that's instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
+This method contains the logic for processing events and has `event` instance as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event that's instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
 
 ### Plugin examples
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -479,7 +479,7 @@ This method contains logic for preparing the plugin for use and has config as a 
 
 ##### Plugin.execute
 
-This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is undefined. This method is called for each event that's instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
+This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event that's instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
 
 #### Plugin examples
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -414,7 +414,7 @@ This method contains logic for preparing the plugin for use and has config as a 
 
 #### Plugin.execute
 
-This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is undefined. This method is called for each event instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
+This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event. If used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event instrumented using the client interface, including Identify, GroupIdentify and Revenue events.
 
 #### Plugin examples
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -488,7 +488,7 @@ This method contains logic for preparing the plugin for use and has config as a 
 
 #### Plugin.execute
 
-This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event; while if used as a destination type plugin, the expected return value is undefined. This method is called for each event, including Identify, GroupIdentify and Revenue events, that's instrumented using the client interface.
+This method contains the logic for processing events and has event as parameter. If used as enrichment type plugin, the expected return value is the modified/enriched event; while if used as a destination type plugin, the expected return value is a map with keys: `event` (BaseEvent), `code` (number), and `message` (string). This method is called for each event, including Identify, GroupIdentify and Revenue events, that's instrumented using the client interface.
 
 #### Plugin examples
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Updates docs for plugin to specify correct return type. Previously it stated null or undefined which is incorrect. Fixes https://github.com/amplitude/Amplitude-TypeScript/issues/308

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp