### PR TITLE
DDI-359 Adds examples to user profile API doc

### DIFF
--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -2,7 +2,7 @@
 title: User Profile API
 description: The User Profile API serves Amplitude User Profiles, which includes user properties, computed user properties, a list of cohort IDs of cohorts that the user is in, and recommendations.
 ---
-
+<!-- markdownlint-disable MD036 -->
 The User Profile API serves Amplitude user profiles, which include user properties, computed user properties, a list of cohort IDs of cohorts that the user is in, and recommendations.
 
 !!!note "Some features require Amplitude Audiences"
@@ -21,24 +21,24 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
 ## Considerations
 
-### Default experiences
+**Default experiences**
 
 - If you don't serve your default user experience for users with `is_control=true`, Amplitude can't measure performance.
 - Serve a default experience in case there is an error.
 - If Amplitude is unavailable and returns a 500 response, you can retry or serve the default experience.
 
-### Authentication errors
+**Authentication errors**
 
 - If the secret key is correct but user IDs are improperly formatted, or are user IDs from a different project, you get this error: `{"error":"User id and device id not seen before"}`
 - If the secret key is wrong, you get an HTTP 401 response: `Invalid Api-Key`
 - If the authorization header is missing or malformed you get an HTTP 401 response: `Missing Api-Key in Authorization header`
 
-### Configuration errors
+**Configuration errors**
 
 - If the endpoint or path are wrong, you get an empty error (HTTP 404) response.
 - If an insecure HTTP request is sent, it's redirected to the HTTPs endpoint (HTTPS 301) with an HTML body - the Location header contains the proper protocol and URL.
 
-### Throttling errors
+**Throttling errors**
 
 - Amplitude orgs have a limit of 100,000 recommendation requests per minute. If you go above this limit, the API returns the following error response:
     - `{"error":"Number of requests per minute exceeds system limit. Contact Support if you need this limit raised"}` 

--- a/docs/analytics/apis/user-profile-api.md
+++ b/docs/analytics/apis/user-profile-api.md
@@ -9,7 +9,7 @@ The User Profile API serves Amplitude user profiles, which include user properti
 
     To get cohort IDs or recommendation IDs, you must have a plan with Audiences. 
 
---8<-- "includes/postman.md"
+--8<-- "includes/postman-interactive.md"
 
 --8<-- "includes/auth-secret-key.md"
 
@@ -50,7 +50,7 @@ The User Profile API serves Amplitude user profiles, which include user properti
 | <div class= "big-column">Parameter</div> | Description |
 | --- | --- |
 | `user_id`[^1] | <span class="optional">Optional</span>, but <span class="required">required unless `device_id` is set</span>. The user ID (external database ID) to be queried. |
-| `device_id`[^1] | Optional, but <span class="required">required unless `user_id` is set</span>. The device ID (anonymous ID) to be queried. |
+| `device_id`[^1] | <span class="optional">Optional</span>, but <span class="required">required unless `user_id` is set</span>. The device ID (anonymous ID) to be queried. |
 | `get_recs` | <span class="optional">Optional</span>. Return a recommendation result for this user. Defaults to `false`.|
 | `rec_id`| <span class="optional">Optional</span>. Recommendations to retrieve, required if `get_recs` is true. Fetch multiple recommendations by separating the `rec_ids` with commas. |
 | `rec_type` | <span class="optional">Optional</span>. Overrides the default experimental control setting and `rec_type=model` returns modeled recommendations and `rec_type=random` returns random recommendations. |
@@ -62,33 +62,59 @@ The User Profile API serves Amplitude user profiles, which include user properti
 [^1]:
     Requests must include either a `user_id` or a `device_id`.
 
-## Examples
+## Get a recommendation
 
-### Get a recommendation
-
-!!!note
+!!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
 Retrieve a single recommendation by ID.
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?user_id=12345&get_recs=true&rec_id=testRecId HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+=== "cURL"
 
-#### Response
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_recs=true&rec_id=testRecId' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_recs=true&rec_id=testRecId HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get a specific recommendation (click to expand)"
+
+    This example retrieves the recommendation with ID `98765` for the user with ID `12345`.
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_recs=true&rec_id=98765' \
+        --header 'Authorization: Api-Key 1234567890'
+        ```
+
+    === "HTTP"
+
+        ```bash
+        GET /v1/userprofile?user_id=12345&get_recs=true&rec_id=98765 HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 1234567890
+        ```
+
+### Response
 
 ```json
 {
   "userData":{
     "recommendations":[
       {
-        "rec_id":"testRecId",
-        "child_rec_id":"testRecId",
+        "rec_id":"98765",
+        "child_rec_id":"98765",
         "items":[
           "cookie",
           "cracker",
@@ -101,7 +127,7 @@ Authorization: Api-Key INSERT SECRET KEY
         "last_updated":1608670720
       }
     ],
-    "user_id":"testUser",
+    "user_id":"12345",
     "device_id":"ffff-ffff-ffff-ffff",
     "amp_props":null,
     "cohort_ids":null
@@ -118,23 +144,51 @@ Authorization: Api-Key INSERT SECRET KEY
 | `recommendation_source` | Name of the model used to generate this recommendation. |
 | `last_updated` | Timestamp of when this recommendation was last generated and synced. |
 
-### Get multiple recommendations
+## Get multiple recommendations
 
-!!!note
+!!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
 Retrieves multiple recommendations for a user.
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?user_id=12345&get_recs=true&rec_id=testRecId,testRecId2 HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+=== "cURL"
 
-#### Response
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_recs=true&rec_id=testRecId,testRecID2' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_recs=true&rec_id=testRecId,testRecId2 HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get multiple recommendations (click to expand)"
+
+    This example retrieves the recommendation with ID `98765` and `56789` for the user with ID `12345`.
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_recs=true&rec_id=98765,56789' \
+        --header 'Authorization: Api-Key 1234567890'
+        ```
+
+    === "HTTP"
+
+        ```bash
+        GET /v1/userprofile?user_id=12345&get_recs=true&rec_id=98765,56789 HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 1234567890
+        ```
+
+### Response
 
 ```json
 {
@@ -169,7 +223,7 @@ Authorization: Api-Key INSERT SECRET KEY
         "last_updated": 1608670658
       }
     ],
-    "user_id": "testUser",
+    "user_id": "12345",
     "device_id": "ffff-ffff-ffff-ffff",
     "amp_props": null,
     "cohort_ids": null
@@ -177,25 +231,53 @@ Authorization: Api-Key INSERT SECRET KEY
 }
 ```
 
-### Get user properties
+## Get user properties
 
 Retrieves the user's properties.
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?user_id=12345&get_amp_props=true HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+=== "cURL"
 
-#### Response
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_amp_props=true' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_amp_props=true HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get user properties for a user ID (click to expand)"
+
+    This example retrieves the user properties for the user with ID `12345`.
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_amp_props=true' \
+        --header 'Authorization: Api-Key 1234567890'
+        ```
+
+    === "HTTP"
+
+        ```bash
+        GET /v1/userprofile?user_id=12345&get_amp_props=true HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 1234567890
+        ```
+
+### Response
 
 ```json
 {
   "userData": {
     "recommendations": null,
-    "user_id": "testUser",
+    "user_id": "12345",
     "device_id": "ffff-ffff-ffff-ffff",
     "amp_props": {
       "library": "http/1.0",
@@ -209,19 +291,47 @@ Authorization: Api-Key INSERT SECRET KEY
 }
 ```
 
-### Get cohort IDs
+## Get cohort IDs
 
 Retrieves a user's cohort IDs.
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?user_id=&get_cohort_ids=true HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+=== "cURL"
 
-#### Response
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_cohort_ids=true' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP"
+
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_cohort_ids=true HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get cohort IDs for a user (click to expand)"
+
+    This example gets cohort IDs for user ID `12345`
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_cohort_ids=true' \
+        --header 'Authorization: Api-Key 123456789'
+        ```
+
+    === "HTTP"
+
+        ```bash
+        GET /v1/userprofile?user_id=12345&get_cohort_ids=true HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 123456789
+        ```
+
+### Response
 
 ```json
 {
@@ -235,9 +345,9 @@ Authorization: Api-Key INSERT SECRET KEY
 }
 ```
 
-### Get all computations
+## Get all computations
 
-!!!note
+!!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
@@ -246,15 +356,45 @@ Computations convert events into a new user property you can use to segment your
 Computations work by transforming an event or event property into a computed user property. 
 You can use the computed property as a configurable filter in any Amplitude chart for analysis, or as a personalization tool by syncing it to an external destination.
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?get_computations=&comp_id= HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+Retrieve all computations for a user.
 
-#### Response
+=== "cURL"
+
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?get_computations=true&user_id=USER_ID' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP" 
+
+    ```bash
+    GET /v1/userprofile?get_computations=true&user_id=USER_ID HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get all computations for a user (click to expand)"
+
+    This example retrieves all computations for user ID `12345`.
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_computations=true'        
+        --header 'Authorization: Api-Key 123456789'
+        ```
+
+    === "HTTP" 
+
+        ```bash
+        GET /v1/userprofile?get_computations=true&user_id=1234 HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 123456789
+        ```
+
+### Response
 
 ```json
 {
@@ -272,9 +412,9 @@ Authorization: Api-Key INSERT SECRET KEY
 
 ```
 
-### Get a single computation
+## Get a single computation
 
-!!!note
+!!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
@@ -282,15 +422,45 @@ Retrieves a single computation by ID. Find the computation ID by navigating to t
 
 <recommend.amplitude.com/org/00000/computations/**t14bqib**>
 
-#### Request
+### Request
 
-```bash
-GET /v1/userprofile?user_id=12345&get_computations=true&comp_id=1 HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+Retrieve a computation for a user by ID.
 
-#### Response
+=== "cURL"
+
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_computations=true&comp_id=COMP_ID' \
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
+
+=== "HTTP" 
+
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_computations=true&comp_id=COMP_ID HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
+
+???code-example "Example: Get a computation by ID for a specific user (click to expand)"
+
+    This example retrieves the computation with ID `t14bqib` for user ID `12345`.
+
+    === "cURL"
+
+        ```bash
+        curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_computations=true&comp_id=t14bqib'        
+        --header 'Authorization: Api-Key 123456789'
+        ```
+
+    === "HTTP" 
+
+        ```bash
+        GET /v1/userprofile?get_computations=true&user_id=1234&comp_id=t14bqib HTTP/1.1
+        Host: profile-api.amplitude.com
+        Authorization: Api-Key 123456789
+        ```
+
+### Response
 
 ```json
 {
@@ -306,15 +476,15 @@ Authorization: Api-Key INSERT SECRET KEY
 }
 ```
 
-### Get prediction propensity
+## Get prediction propensity
 
-!!!note
+!!!note "Feature availability"
 
     This feature is available in accounts with Amplitude Audiences.
 
 When you create a prediction in Amplitude Audiences, you can sync the prediction score to the Profile API. A prediction propensity is the probability that a user will perform a predicted action.
 
-To fetch a user's prediction propensity, send a request that includes a `prediction_id` and `propensity_type`. The propensity type can be either the raw score or a percentile.
+To fetch a user's prediction propensity, send a request that includes a `prediction_id` and `propensity_type`. The propensity type can be either the raw score (`score`) or a percentile (`pct`).
 
 Percentile is useful to understand users in comparison to each other. For example, is this user in the 80% of users likely to do an action?
 
@@ -324,50 +494,90 @@ Find the `prediction_id` by navigating to the prediction in the Audiences web ap
 
 recommend.amplitude.com/0000/predictions/**0x10x**
 
-#### Request (prediction propensity score)
+### Request
 
-```bash
-GET /v1/userprofile?user_id=&get_propensity=&prediction_id=null&propensity_type=score HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+=== "cURL"
 
-#### Response (prediction propensity score)
+    ```bash
+    curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=USER_ID&get_propensity=true&prediction_id=PREDICTION_ID&propensity_type=PROPENSITY_TYPE'
+    --header 'Authorization: Api-Key <SECRET KEY>'
+    ```
 
-```json
-{
-  "userData": {
-    "recommendations": null,
-    "user_id": "testUser",
-    "device_id": "ffff-ffff-ffff-ffff",
-    "amp_props": {
-      "computed-prop-2": "3"
-    },
-    "propensity": 0.500001
-  }
-}
-```
+=== "HTTP"
 
-#### Request (prediction propensity percentile)
+    ```bash
+    GET /v1/userprofile?user_id=USER_ID&get_propensity=&prediction_id=PREDICTION_ID&propensity_type=PROPENSITY_TYPE HTTP/1.1
+    Host: profile-api.amplitude.com
+    Authorization: Api-Key <SECRET KEY>
+    ```
 
-```bash
-GET /v1/userprofile?user_id=&get_propensity=&prediction_id=null&propensity_type=pct HTTP/1.1
-Host: profile-api.amplitude.com
-Authorization: Api-Key INSERT SECRET KEY
-```
+???example "More examples (click to expand)"
 
-#### Response (prediction propensity percentile)
+    ???code-example "Propensity score example"
 
-```json
-{
-  "userData": {
-    "recommendations": null,
-    "user_id": "testUser",
-    "device_id": "ffff-ffff-ffff-ffff",
-    "amp_props": {
-      "computed-prop-2": "3"
-    },
-    "propensity": 83
-  }
-}
-```
+        This example requests a propensity score for prediction ID `0x10x` for the user ID `12345`.
+
+        === "cURL"
+
+            ```bash
+            curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_propensity=true&prediction_id=0x10x&propensity_type=score'
+            --header 'Authorization: Api-Key 123456789'
+            ```
+        === "HTTP"
+
+            ```bash
+            GET /v1/userprofile?user_id=12345&get_propensity=&prediction_id=0x10x&propensity_type=score HTTP/1.1
+            Host: profile-api.amplitude.com
+            Authorization: Api-Key 123456789
+            ```
+    ???code-example "Propensity percentage example"
+
+        This example requests a propensity percentage for prediction ID `0x10x` for the user ID `12345`.
+
+        === "cURL"
+
+            ```bash
+            curl --location --request GET 'https://profile-api.amplitude.com/v1/userprofile?user_id=12345&get_propensity=true&prediction_id=0x10x&propensity_type=pct'
+            --header 'Authorization: Api-Key 123456789'
+            ```
+        === "HTTP"
+
+            ```bash
+            GET /v1/userprofile?user_id=12345&get_propensity=&prediction_id=0x10x&propensity_type=pct HTTP/1.1
+            Host: profile-api.amplitude.com
+            Authorization: Api-Key 123456789
+            ```
+
+### Response 
+
+=== "Prediction propensity score response"
+
+    ```json
+    {
+      "userData": {
+        "recommendations": null,
+        "user_id": "testUser",
+        "device_id": "ffff-ffff-ffff-ffff",
+        "amp_props": {
+          "computed-prop-2": "3"
+        },
+        "propensity": 0.500001
+      }
+    }
+    ```
+
+=== "Prediction propensity percentile response"
+
+    ```json
+    {
+      "userData": {
+        "recommendations": null,
+        "user_id": "testUser",
+        "device_id": "ffff-ffff-ffff-ffff",
+        "amp_props": {
+          "computed-prop-2": "3"
+        },
+        "propensity": 83
+      }
+    }
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+      title: "On this page"
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds new-format examples to User Profile API doc.  

## Deadline

Whenever

## Change type

- [X] Doc update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp