### PR TITLE
AMP-67032 added flush documentation to Ampli node docs

### DIFF
--- a/docs/data/sdks/android-kotlin/ampli.md
+++ b/docs/data/sdks/android-kotlin/ampli.md
@@ -320,6 +320,10 @@ Send event objects using the generic track method.
       ), options);
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-java.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/docs/data/sdks/android/ampli.md
+++ b/docs/data/sdks/android/ampli.md
@@ -290,6 +290,10 @@ Send event objects using the generic track method.
     );
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-java.md"
+
 ## Verify implementation status
 
 Verify that events are implemented in your code with the status command:

--- a/docs/data/sdks/go/ampli.md
+++ b/docs/data/sdks/go/ampli.md
@@ -209,6 +209,8 @@ ampli.Instance.Track("user-id", SongPlayed().Builder()
 )
 ```
 
+--8<-- "includes/ampli/flush/ampli-flush-snippet-go.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/docs/data/sdks/ios/ampli.md
+++ b/docs/data/sdks/ios/ampli.md
@@ -297,6 +297,11 @@ You can send all Even objects using the generic track method.
     ]];
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-ios.md"
+
+
 ## Verify implementation status
 
 Verify events are implemented in your code with the status command:

--- a/docs/data/sdks/ios/ampli.md
+++ b/docs/data/sdks/ios/ampli.md
@@ -301,7 +301,6 @@ You can send all Even objects using the generic track method.
 
 --8<-- "includes/ampli/flush/ampli-flush-snippet-ios.md"
 
-
 ## Verify implementation status
 
 Verify events are implemented in your code with the status command:

--- a/docs/data/sdks/java/ampli.md
+++ b/docs/data/sdks/java/ampli.md
@@ -10,9 +10,8 @@ In Java, the tracking library exposes a type-safe function for every event in yo
 The function’s arguments correspond to the event’s properties and are strongly typed to allow for code completion and compile-time checks.
 
 !!!info "Ampli JRE Resources"
-<!--vale off-->
     [:material-language-kotlin: Ampli JRE Kotlin Example](https://github.com/amplitude/ampli-examples/tree/main/jre/kotlin/AmpliApp) · [:material-language-java: Ampli JRE Java Example](https://github.com/amplitude/ampli-examples/tree/main/jre/java/AmpliApp) · [:material-code-tags-check: Releases](https://www.npmjs.com/package/@amplitude/ampli?activeTab=versions)
-<!-- vale on-->
+
 !!!note "Deprecated Itly runtime"
     This page covers the JRE Java and Kotlin runtimes. All (Itly) runtimes have been deprecated.
      If you are still using an (Itly) runtime, see the **[migration guide](#migrate-from-an-itly-jre-runtime)** to upgrade to the newest runtime. Docs for the Itly version are available **[here](../../deprecated-sdks/jre.md)**.
@@ -306,6 +305,10 @@ Send Event objects using the generic track method.
       songFavorited = true, // Boolean
     );
     ```
+
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-java.md"
 
 ## Verify implementation status
 

--- a/docs/data/sdks/javascript/ampli.md
+++ b/docs/data/sdks/javascript/ampli.md
@@ -304,6 +304,10 @@ Track Event objects using Ampli `track`:
     }));
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ## Verify implementation status
 
 Verify that events are implemented in your code with the status command:

--- a/docs/data/sdks/node/ampli.md
+++ b/docs/data/sdks/node/ampli.md
@@ -321,6 +321,10 @@ Track Event objects using Ampli `track`:
 
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ## Verify implementation status
 
 Verify events are implemented in your code with the status command:

--- a/docs/data/sdks/python/ampli.md
+++ b/docs/data/sdks/python/ampli.md
@@ -170,6 +170,10 @@ ampli.track('user_id', SongPlayed(
 ), EventOptions(device_id="device_id"))
 ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-python.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/docs/data/sdks/react-native/ampli.md
+++ b/docs/data/sdks/react-native/ampli.md
@@ -308,6 +308,10 @@ Track Event objects using Ampli `track`:
     }));
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ## Verify implementation status
 
 Verify that events are implemented in your code with the status command:

--- a/docs/data/sdks/typescript-browser/ampli.md
+++ b/docs/data/sdks/typescript-browser/ampli.md
@@ -297,6 +297,10 @@ Track Event objects using Ampli `track`:
     }));
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/docs/data/sdks/typescript-node/ampli.md
+++ b/docs/data/sdks/typescript-node/ampli.md
@@ -304,6 +304,10 @@ Track Event objects using Ampli `track`:
     }));
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/docs/data/sdks/typescript-react-native/ampli.md
+++ b/docs/data/sdks/typescript-react-native/ampli.md
@@ -300,6 +300,10 @@ Track Event objects using Ampli `track`:
     }));
     ```
 
+--8<-- "includes/ampli/flush/ampli-flush-section.md"
+
+--8<-- "includes/ampli/flush/ampli-flush-snippet-typescript.md"
+
 ### Plugin
 
 Plugins allow you to extend the Amplitude behavior, for example, modifying event properties (enrichment type) or sending to a third-party APIs (destination type).

--- a/includes/ampli/flush/ampli-flush-section.md
+++ b/includes/ampli/flush/ampli-flush-section.md
@@ -1,9 +1,8 @@
 ### Flush
 
-Call `flush()` to immediately send any pending events.
+The Ampli wrapper queues events and sends them on an interval based on the configuration.
 
-The Amplitude SDK queues events and sends them on an interval based on the configuration. By default, the SDK will flush
-every 10 events or 30 seconds, which ever happens first.
+Call `flush()` to immediately send any pending events.
 
 The `flush()` method returns a promise that can be used to ensure all pending events have been sent before continuing.
 This can be useful to call prior to application exit.

--- a/includes/ampli/flush/ampli-flush-section.md
+++ b/includes/ampli/flush/ampli-flush-section.md
@@ -1,0 +1,9 @@
+### Flush
+
+Call `flush()` to immediately send any pending events.
+
+The Amplitude SDK queues events and sends them on an interval based on the configuration. By default, the SDK will flush
+every 10 events or 30 seconds, which ever happens first.
+
+The `flush()` method returns a promise that can be used to ensure all pending events have been sent before continuing.
+This can be useful to call prior to application exit.

--- a/includes/ampli/flush/ampli-flush-snippet-go.md
+++ b/includes/ampli/flush/ampli-flush-snippet-go.md
@@ -1,0 +1,14 @@
+### Flush
+
+The Ampli wrapper queues events and sends them on an interval based on the configuration.
+
+Call `Flush()` to immediately send any pending events.
+
+The `Flush()` method returns a promise that can be used to ensure all pending events have been sent before continuing.
+This can be useful to call prior to application exit.
+
+=== "Go"
+
+    ```golang
+    ampli.Instance.Flush()
+    ```

--- a/includes/ampli/flush/ampli-flush-snippet-ios.md
+++ b/includes/ampli/flush/ampli-flush-snippet-ios.md
@@ -1,0 +1,11 @@
+=== "Swift"
+
+    ```swift
+    Ampli.instance.flush()
+    ```
+
+=== "Objective-C"
+
+    ```python
+    [ampli flush]
+    ```

--- a/includes/ampli/flush/ampli-flush-snippet-java.md
+++ b/includes/ampli/flush/ampli-flush-snippet-java.md
@@ -1,0 +1,11 @@
+=== "Java"
+
+    ```java
+    ampli.flush()
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+    ampli.flush()
+    ```

--- a/includes/ampli/flush/ampli-flush-snippet-python.md
+++ b/includes/ampli/flush/ampli-flush-snippet-python.md
@@ -1,0 +1,5 @@
+=== "Python"
+
+    ```python
+    ampli.flush();
+    ```

--- a/includes/ampli/flush/ampli-flush-snippet-typescript.md
+++ b/includes/ampli/flush/ampli-flush-snippet-typescript.md
@@ -1,0 +1,13 @@
+=== "TypeScript"
+
+    ```typescript
+    ampli.flush();
+    await ampli.flush().promise;
+    ```
+
+=== "JavaScript"
+
+    ```typescript
+    ampli.flush();
+    await ampli.flush().promise;
+    ```


### PR DESCRIPTION
# Amplitude Developer Docs PR
https://amplitude.atlassian.net/browse/AMP-67032

## Description
Add flush section to Ampli docs

## Screenshots
<img width="987" alt="image" src="https://user-images.githubusercontent.com/5790872/212186290-a941efd7-59f8-475c-b4ac-63092bb6fa60.png">

## Change type
- [x] Doc update.
- [x] New documentation.


@amplitude-dev-docs
@caseyamp