### PR TITLE
Clarify plugins note on Ampli version

### DIFF
--- a/docs/data/ampli/plugin.md
+++ b/docs/data/ampli/plugin.md
@@ -6,7 +6,7 @@ template: guide.html
 ---
 
 !!!note
-    Plugins are supported in the latest version of Ampli. If you are using an older version of Ampli, see **[Middleware](../middleware/)**.
+    Plugins are supported in the latest version of Ampli when used in conjunction with the [new Amlitude browser SDKs](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/). If you are using an older version of Ampli or a [legacy Amplitude SDK](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/), see **[Middleware](../middleware/)**.
 
 Plugins allow you to extend the Amplitude behavior. For example use plugins to modify event properties (enrichment type) or send data to a third-party APIs (destination type). This is a replacement for Middleware in Ampli legacy.
 This pattern is flexible and you can use it to support event enrichment, transformation, filtering, routing to third-party destinations, and more. A plugin is an object with methods `setup()` and `execute()`.


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Users not only need to be on the latest Ampli, but also on the latest Amplitude browser SDK. If you upgrade Ampli without switching to the new Amplitude SDK, plugins are not supported. Linked to the migration doc which explains the difference and how to migrate.

## Deadline

N/A

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp