### PR TITLE
Amp 67569 Update doc for Snowflake time-based import that requires TIMESTAMP_NTZ format

### DIFF
--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -150,4 +150,5 @@ Converting milliseconds to TIMESTAMP_NTZ format needed for time-based import. Th
 `TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS, 3) as "update_time_column"`
 
 Converting a timestamp column with a timezone to TIMESTAMP_NTZ format needed for time-based import.
+
 `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', TIMESTAMP_TZ_COLUMN)) as "update_time_column"`

--- a/docs/data/sources/snowflake.md
+++ b/docs/data/sources/snowflake.md
@@ -81,7 +81,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 | `time` | Yes | Milliseconds since epoch (Timestamp) | 1396381378123 |
 | `event_properties` | Yes | VARIANT (JSON Object) | {"source":"notification", "server":"host-us"} |
 | `user_properties` | No | VARIANT (JSON Object) | {"city":"chicago", "gender":"female"} |
-| `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
+| `update_time_column` | No (Yes if using time based import) | TIMESTAMP_NTZ | 2013-04-05 01:02:03.000 |
 
 ### User properties
 
@@ -89,7 +89,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 |---|---|---|---|
 | `user_id` | Yes | VARCHAR | datamonster@gmail.com |
 | `user_properties` | Yes | VARIANT (JSON Object) | {"city":"chicago", "gender":"female"} |
-| `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
+| `update_time_column` | No (Yes if using time based import) | TIMESTAMP_NTZ | 2013-04-05 01:02:03.000 |
 <!--vale on-->
 ### Group properties
 
@@ -97,7 +97,7 @@ You must include the mandatory fields for the data type when creating the SQL qu
 |---|---|---|---|
 | `groups` | Yes | VARIANT (JSON Object) | {"company":"amplitude", "team":["marketing", "sales"]} |
 | `group_properties` | Yes | VARIANT (JSON Object) | {"location":"seattle", "active":"true"} |
-| `update_time_column` | No (Yes if using time based import) | TIMESTAMP | 2013-04-05 01:02:03.000 |
+| `update_time_column` | No (Yes if using time based import) | TIMESTAMP_NTZ | 2013-04-05 01:02:03.000 |
 
 Each group property in `group_properties` would be applied to every group in `groups`
 
@@ -145,7 +145,9 @@ Converting timestamp column to milliseconds:
 
 `DATE_PART('EPOCH_MILLISECOND', TIMESTAMP_COLUMN) as "time"`
 
-Converting milliseconds to timestamp needed for time-based import. This example uses the `scale` argument set to `3` to convert to milliseconds. See the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html) for more details.
+Converting milliseconds to TIMESTAMP_NTZ format needed for time-based import. This example uses the `scale` argument set to `3` to convert to milliseconds. See the [Snowflake documentation](https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html) for more details.
 
-`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS, 3) as "timestamp_column"`
- 
+`TO_TIMESTAMP_NTZ(TIME_COLUMN_IN_MILLIS, 3) as "update_time_column"`
+
+Converting a timestamp column with a timezone to TIMESTAMP_NTZ format needed for time-based import.
+`TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', TIMESTAMP_TZ_COLUMN)) as "update_time_column"`


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update dev docs that Snowflake time-based import requires timestamp without timezone (TIMESTAMP_NTZ format). Also update the code snippet for the common conversion from TIMESTAMP_TZ -> TIMESTAMP_NTZ.

<img width="1123" alt="Screen Shot 2023-01-21 at 10 34 38 PM" src="https://user-images.githubusercontent.com/116029942/213903946-cf15fd40-979d-4e1f-b9f9-8cbb05b75e27.png">
<img width="1121" alt="Screen Shot 2023-01-21 at 10 34 27 PM" src="https://user-images.githubusercontent.com/116029942/213903947-70fd9a44-67cc-42da-9f9c-c8978969637f.png">

## Deadline

N/A, ASAP


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp