### PR TITLE
DDI-399: Fix home page links to open in same tab

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ markdown_extensions:
 
 extra:
   support_contact: https://amplitude.com
-  docs_home: https://docs.developers.amplitude.com/documentation-home
+  docs_home: /documentation-home
   community: https://community.amplitude.com/?utm_source=devdocs&utm_medium=helpcontent&utm_campaign=devdocswebsite
   product_updates: https://community.amplitude.com/product-updates?utm_source=devdocs&utm_medium=helpcontent&utm_campaign=devdocswebsite
   help_site: https://help.amplitude.com
@@ -126,7 +126,7 @@ extra:
   postman_workspace: https://www.postman.com/amplitude-developer-docs/workspace/amplitude-developers/overview
   report_issue: https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/issues/new/?title=[Feedback]+{{page.title}}+-+{{page.url}}
   getting_started_guide: https://docs.developers.amplitude.com/getting-started
-  sdk_quickstart: https://www.docs.developers.amplitude.com/data/sdks/
+  sdk_quickstart: /data/sdks/sdk-quickstart/
   more_resources: all-resources
   status:
     new: Recently added


### PR DESCRIPTION
Make links to dev doc pages on home page relative so they open in same tab. 

Not sure this is supported with our template setup, but I need to find some solution for this. 

## Deadline

ASAP: suboptimal user experience. 

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
