### PR TITLE
Update experiment mgmt api variants

### DIFF
--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -11,7 +11,7 @@ The Experiment management API can be used to programmatically create and control
 
 ## Endpoints
 
-[Experiment Endpoints](#experiment-endpoints)
+[Experiment endpoints](#experiment-endpoints)
 
 | <div class="big-column">Name</div> | Description |
 | --- | --- |
@@ -34,7 +34,7 @@ The Experiment management API can be used to programmatically create and control
 | [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
 | [Rollout weights](#rollout-weights) | Update the rollout weights for an experiment. |
 
-[Flag Endpoints](#flag-endpoints)
+[Flag endpoints](#flag-endpoints)
 
 | <div class="big-column">Name</div> | Description |
 | --- | --- |
@@ -54,7 +54,7 @@ The Experiment management API can be used to programmatically create and control
 | [Edit flag](#edit-flag) | Edit flag. |
 | [Create flag](#create-flag) | Create a new flag. |
 
-[Other Endpoints](#other-endpoints)
+[Other endpoints](#other-endpoints)
 
 | <div class="big-column">Name</div> | Description |
 | --- | --- |
@@ -88,7 +88,7 @@ Endpoints that list resources such as `/experiments/list` will only return a lim
 
 ------
 
-## Experiment Endpoints
+## Experiment endpoints
 
 ## List experiments
 
@@ -100,7 +100,7 @@ Fetch a list of experiments including their configuration details. Results are o
 
 ### Query parameters
 
-| <div class="big-column">Name</div> | Description |
+| Name| Description |
 | --- | --- |
 | `limit` | The max number of experiments to be returned. Capped at 1000. |
 | `cursor` | The offset to start the "page" of results from. |
@@ -131,7 +131,7 @@ Fetch the configuration details of an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+| Name | Description |
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -161,7 +161,7 @@ Fetch a list of all versions for an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -191,7 +191,7 @@ Fetch details of a specific version of an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`versionId`| Required. String. The version's ID.|
@@ -222,7 +222,7 @@ Fetch a list of all variants for an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -252,7 +252,7 @@ Fetch details of a specific variant of an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -283,7 +283,7 @@ Fetch a list of inclusions for a specific variant of an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -314,7 +314,7 @@ Create a new variant for an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -356,7 +356,7 @@ Edit a variant for an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -398,7 +398,7 @@ Remove a variant from an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -429,7 +429,7 @@ Add users (inclusions) to experiment's variant.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -468,7 +468,7 @@ Remove users (inclusions) from experiment's variant.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -531,7 +531,7 @@ Edit an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -700,7 +700,7 @@ Activate an inactive experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -729,7 +729,7 @@ Deactivate an active experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -746,7 +746,7 @@ Deactivate an active experiment.
 
 ## Rollout weights
 
-***Not recommended to use. Use [`Edit experiment variant`](#edit-experiment-variant) instead***
+!!!warn "Not recommended. Use [`edit experiment variant`](#edit-experiment-variant) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/rollout-weights
@@ -758,7 +758,7 @@ Update the rollout weights for an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 
@@ -780,9 +780,7 @@ Update the rollout weights for an experiment.
 
 ------
 
-## Flag Endpoints
-
-------
+## Flag endpoints
 
 ## List flags
 
@@ -794,7 +792,7 @@ Fetch a list of flags including their configuration details. Results are ordered
 
 ### Query parameters
 
-| <div class="big-column">Name</div> | Description |
+|Name|Description|
 | --- | --- |
 | `limit` | The max number of flags to be returned. Capped at 1000. |
 | `cursor` | The offset to start the "page" of results from. |
@@ -823,7 +821,7 @@ Fetch the configuration details of a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 
@@ -853,7 +851,7 @@ Fetch a list of all versions for a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 
@@ -883,7 +881,7 @@ Fetch details of a specific version of a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flags's ID.|
 |`versionId`| Required. String. The version's ID.|
@@ -914,7 +912,7 @@ Fetch a list of all variants for a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 
@@ -944,7 +942,7 @@ Fetch details of a specific variant of a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -975,7 +973,7 @@ Fetch a list of inclusions for a specific variant of a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -1006,7 +1004,7 @@ Create a new variant for a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 
@@ -1048,7 +1046,7 @@ Edit a variant for a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -1091,7 +1089,7 @@ Remove a variant from an experiment.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -1122,7 +1120,7 @@ Add users (inclusions) to flag's variant.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The variant's ID.|
@@ -1161,7 +1159,7 @@ Remove users (inclusions) from flag's variant.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The flag's ID.|
@@ -1193,7 +1191,7 @@ Remove all users (inclusions) from flag's variant.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The flag's ID.|
@@ -1224,7 +1222,7 @@ Edit a flag.
 
 ### Path variables
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
 
@@ -1299,7 +1297,7 @@ A successful request returns a `200 OK` response and a JSON object with the flag
 
 ------
 
-## Other Endpoints
+## Other endpoints
 
 ## List deployments
 
@@ -1311,7 +1309,7 @@ Fetch a list of deployments that experiments or flags can be assigned to.
 
 ### Query parameters
 
-|<div class="big-column">Name</div>|Description|
+|Name|Description|
 |---|----|
 |`limit`| The max number of deployments to be returned. Capped at 1000.|
 |`cursor`| The offset to start the "page" of results from.|

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -684,7 +684,7 @@ A successful request returns a `200 OK` response and a JSON object with the expe
 
 ## Activate experiment
 
-!!!warn "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
+!!!warning "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/activate
@@ -713,7 +713,7 @@ Activate an inactive experiment.
 
 ## Deactivate experiment
 
-!!!warn "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
+!!!warning "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/deactivate
@@ -742,7 +742,7 @@ Deactivate an active experiment.
 
 ## Rollout weights
 
-!!!warn "Not recommended. Use [`edit experiment variant`](#edit-experiment-variant) instead."
+!!!warning "Not recommended. Use [`edit experiment variant`](#edit-experiment-variant) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/rollout-weights
@@ -1245,8 +1245,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request PATCH \
       --url 'https://management-api.experiment.amplitude.com/flags/<id>' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"enabled":<enabled>,"rolloutPercentage":<rolloutPercentage>}'
     ```
 

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -11,11 +11,11 @@ The Experiment management API can be used to programmatically create and control
 
 ## Endpoints
 
+[Experiment Endpoints](#experiment-endpoints)
+
 | <div class="big-column">Name</div> | Description |
 | --- | --- |
 | [List experiments](#list-experiments) | List of experiments including their configuration details. |
-| [List flags](#list-flags) | List of flags including their configuration details. |
-| [List deployments](#list-deployments) | List deployments that experiments can be assigned to. |
 | [Get experiment details](#get-experiment-details) | Get the configuration details of an experiment. |
 | [List experiment versions](#list-experiment-versions) | List all versions for an experiment. |
 | [Get experiment version details](#get-experiment-version-details) | Get a specific version for an experiment. |
@@ -29,6 +29,16 @@ The Experiment management API can be used to programmatically create and control
 | [Remove users from experiment's variant](#remove-users-from-experiments-variant) | Remove users from experiment's variant. |
 | [Remove all users from experiment's variant](#remove-all-users-from-experiments-variant) | Remove all users from experiment's variant. |
 | [Edit experiment](#edit-experiment) | Edit experiment. |
+| [Create experiment](#create-experiment) | Create a new experiment. |
+| [Activate experiment](#activate-experiment) | Activate an inactive experiment. |
+| [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
+| [Rollout weights](#rollout-weights) | Update the rollout weights for an experiment. |
+
+[Flag Endpoints](#flag-endpoints)
+
+| <div class="big-column">Name</div> | Description |
+| --- | --- |
+| [List flags](#list-flags) | List of flags including their configuration details. |
 | [Get flag details](#get-flag-details) | Get the configuration details of a flag. |
 | [List flag versions](#list-flag-versions) | List all versions for a flag. |
 | [Get flag version details](#get-flag-version-details) | Get a specific version for a flag. |
@@ -42,11 +52,13 @@ The Experiment management API can be used to programmatically create and control
 | [Remove users from flag's variant](#remove-users-from-flags-variant) | Remove users from flag's variant. |
 | [Remove all users from flag's variant](#remove-all-users-from-flags-variant) | Remove all users from flag's variant. |
 | [Edit flag](#edit-flag) | Edit flag. |
-| [Create experiment](#create-experiment) | Create a new experiment. |
 | [Create flag](#create-flag) | Create a new flag. |
-| [Activate experiment](#activate-experiment) | Activate a inactive experiment. |
-| [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
-| [Rollout weights](#rollout-weights) | Update the rollout weights for an experiment. |
+
+[Other Endpoints](#other-endpoints)
+
+| <div class="big-column">Name</div> | Description |
+| --- | --- |
+| [List deployments](#list-deployments) | List deployments that experiments or flags can be assigned to. |
 
 ## Authorization
 
@@ -76,6 +88,8 @@ Endpoints that list resources such as `/experiments/list` will only return a lim
 
 ------
 
+## Experiment Endpoints
+
 ## List experiments
 
 ```bash
@@ -101,68 +115,6 @@ A successful request returns a `200 OK` response and a list of experiments encod
     ```bash
     curl --request GET \
       --url 'https://management-api.experiment.amplitude.com/experiments/list?limit=1000' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
-    ```
-
-------
-
-## List flags
-
-```bash
-GET https://management-api.experiment.amplitude.com/flags/list
-```
-
-Fetch a list of flags including their configuration details. Results are ordered with the most recently created flags first.
-
-### Query parameters
-
-| <div class="big-column">Name</div> | Description |
-| --- | --- |
-| `limit` | The max number of flags to be returned. Capped at 1000. |
-| `cursor` | The offset to start the "page" of results from. |
-
-### Response
-
-A successful request returns a `200 OK` response and a list of flags encoded as JSON in the response body.
-
-<!-- TODO example response body -->
-
-!!!example "Example cURL"
-    ```bash
-    curl --request GET \
-      --url 'https://management-api.experiment.amplitude.com/flags/list?limit=1000' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
-    ```
-
-------
-
-## List deployments
-
-```bash
-GET https://management-api.experiment.amplitude.com/deployments/list
-```
-
-Fetch a list of deployments that experiments can be assigned to.
-
-### Query parameters
-
-|<div class="big-column">Name</div>|Description|
-|---|----|
-|`limit`| The max number of deployments to be returned. Capped at 1000.|
-|`cursor`| The offset to start the "page" of results from.|
-
-### Response
-
-A successful request returns a `200 OK` response and a list of deployments encoded as JSON in the response body.
-
-<!-- TODO example response body -->
-
-!!!example "Example cURL"
-    ```bash
-    curl --request GET \
-      --url 'https://management-api.experiment.amplitude.com/deployments/list?limit=1000' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```
@@ -579,7 +531,7 @@ Edit an experiment.
 
 |<div class="big-column">Name</div>|Description|
 |---|----|
-|`id`| Required. String. The flag's ID.|
+|`id`| Required. String. The experiment's ID.|
 
 ### Request body
 
@@ -587,17 +539,17 @@ Edit an experiment.
 |---|---|---|---|
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
 |`bucketingSalt`| Optional | string | Experiment's bucketing salt. |
-|`bucketingUnit`| Optional | string | Experiment's bucketing |
-|`description`| Optional | string | Description of the experiment |
-|`enabled`| Optional | boolean | Property to activate or deactivate the flag|
-|`evaluationMode`| Optional | string | Evaluation mode for the experiment, either 'local' or 'remote' |
-|`name`| Optional | string | Name of the experiment |
-|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users |
-|`experimentType`| Optional | number | Experiment type, either 'no-harm' or 'hypothesis-testing' |
+|`bucketingUnit`| Optional | string | Experiment's bucketing. |
+|`description`| Optional | string | Description of the experiment. |
+|`enabled`| Optional | boolean | Property to activate or deactivate the experiment. |
+|`evaluationMode`| Optional | string | Evaluation mode for the experiment, either `local` or `remote`. |
+|`name`| Optional | string | Name of the experiment. |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. |
+|`experimentType`| Optional | number | Experiment type, either `no-harm` or `hypothesis-testing`. |
 |`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
-|`startDate`| Optional | string | Start date of the experiment in ISO 8601 format |
+|`startDate`| Optional | string | Start date of the experiment in ISO 8601 format. |
 |`endDate`| Optional | string | End date of the experiment in ISO 8601 format. End date can be null. |
-|`exposureEvent`| Optional | object | See the [`exposureEvent`](#exposureevent) table for more information. If set to null, the Amplitude Exposure Event will be used |
+|`exposureEvent`| Optional | object | See the [`exposureEvent`](#exposureevent) table for more information. If set to null, the Amplitude Exposure Event will be use. |
 
 #### `exposureEvent`
 
@@ -615,10 +567,10 @@ The `filters` field contains these objects.
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`group_type`| Optional | string | Group type of the filter; can be null. Currently we only use `USER` value |
+|`group_type`| Optional | string | Group type of the filter; can be null. Currently we only use `USER` value. |
 |`subprop_key`| Required | string | Filter's key; can be null. |
 |`subprop_op`| Required | string | The [operation](#subprop_op) to use in this filter. |
-|`subprop_type`| Required | string | Type of filter; can be null. One of `USER`, `GROUP`, `EVENT` |
+|`subprop_type`| Required | string | Type of filter; can be null. One of `USER`, `GROUP`, `EVENT`. |
 |`subprop_value`| Required | string array | Array of values. |
 
 #### `subprop_op`
@@ -651,6 +603,209 @@ A successful request returns a `200 OK` response.
     ```
 
 ------
+
+## Create experiment
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/new
+```
+
+Create a new experiment.
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`projectId`| Required | string | The project's ID. |
+|`key`| Required | string | The experiment key. |
+|`name`| Optional | string | The experiment name. |
+|`description`| Optional | string | Description for the experiment.|
+|`variants`| Optional | object array | Array of [`variants`](#variants). |
+|`bucketingKey`| Optional | string | The user property to bucket the user by. |
+|`rolloutWeights`| Optional | object | Rollout weights for non-targeted users. The object should be a mapping from variant key to rollout weight as an integer. For example: `{ "control": 1, "treatment": 1 }`. |
+|`targetSegments`| Optional | object | See the [`targetSegments`](#targetsegments) table for more information. |
+|`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
+|`deployments`| Optional | string array | Array of deployments that the experiment should be assigned to. |
+|`experimentType`| Optional | string | Experiment type; options include `hypothesis-testing` or `no-harm`. |
+|`evaluationMode`| Optional | string | Experiment evaluation mode; options include `remote` or `local`. |
+
+#### `variants`
+
+The `variants` field contains these objects.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`key`| Required | string | The key (a.k.a value) of the variant. |
+|`payload`| Optional | string | Optional payload. Value must be a valid JSON element. |
+|`name`| Optional | string | The variant name. |
+|`description`| Optional | string | The variant description. |
+
+#### `targetSegments`
+
+The `targetSegments` field contains these objects.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`name`|Optional | string | The segment name. |
+|`conditions`| Required | object array | Array of [`conditions`](#conditions). |
+|`percentage`| Optional | number | The allocation percentage for users who match a condition. |
+|`rolloutWeights`| Optional | object | A map from variant key to rollout weight. For example: `{ "control": 1, "treatment": 1 }`. |
+
+#### `conditions`
+
+The `conditions` field contains these objects.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`type`| Required | string | **Must have value: `property`** |
+|`prop`| Required | string | The property to use in the condition. |
+|`op`| Required | string | The [operation](#op) to use in this condition. |
+|`values`| Required | string array | The values to use in the operation. |
+
+#### `op`
+
+An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with the experiment's details.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/new' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"projectId":"<projectId>","key":"<key>"}'
+    ```
+
+------
+
+## Activate experiment
+
+***Not recommended to use. Use [`Edit experiment`](#edit-experiment) instead***
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/{id}/activate
+```
+
+<!-- Brian what does activating an experiment do?-->
+
+Activate an inactive experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/activate' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Deactivate experiment
+
+***Not recommended to use. Use [`Edit experiment`](#edit-experiment) instead***
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/{id}/deactivate
+```
+
+<!-- Brian what does deactivating an experiment do? -->
+
+Deactivate an active experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/deactivate' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Rollout weights
+
+***Not recommended to use. Use [`Edit experiment variant`](#edit-experiment-variant) instead***
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/{id}/rollout-weights
+```
+
+<!-- Brian what does this call do?-->
+
+Update the rollout weights for an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`rolloutWeights`| Required | object |A map from variant key to rollout weight. For example:  `{"control": 1,"treatment":1}`. |
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/rollout-weights' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"rolloutWeights":{"control": 1,"treatment":1}}'
+    ```
+
+------
+
+## Flag Endpoints
+
+------
+
+## List flags
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/list
+```
+
+Fetch a list of flags including their configuration details. Results are ordered with the most recently created flags first.
+
+### Query parameters
+
+| <div class="big-column">Name</div> | Description |
+| --- | --- |
+| `limit` | The max number of flags to be returned. Capped at 1000. |
+| `cursor` | The offset to start the "page" of results from. |
+
+### Response
+
+A successful request returns a `200 OK` response and a list of flags encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/list?limit=1000' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
 
 ## Get flag details
 
@@ -1070,12 +1225,12 @@ Edit a flag.
 |---|---|---|---|
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
 |`bucketingSalt`| Optional | string | Flag's bucketing salt. |
-|`bucketingUnit`| Optional | string | Flag's bucketing |
-|`description`| Optional | string | Description of the flag |
-|`enabled`| Optional | boolean | Property to activate or disactivate the flag|
-|`evaluationMode`| Optional | string | Evaluation mode for the flag, either 'local' or 'remote' |
-|`name`| Optional | string | Name of the flag |
-|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users |
+|`bucketingUnit`| Optional | string | Flag's bucketing. |
+|`description`| Optional | string | Description of the flag. |
+|`enabled`| Optional | boolean | Property to activate or deactivate the flag. |
+|`evaluationMode`| Optional | string | Evaluation mode for the flag, either `local` or `remote`. |
+|`name`| Optional | string | Name of the flag. |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. |
 
 ### Response
 
@@ -1090,85 +1245,6 @@ A successful request returns a `200 OK` response.
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
       --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
-    ```
-
-------
-
-## Create experiment
-
-```bash
-POST https://management-api.experiment.amplitude.com/experiments/new
-```
-
-Create a new experiment.
-
-### Request body
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`projectId`| Required | string | The project's ID. |
-|`key`| Required | string | The experiment key. |
-|`name`| Optional | string | The experiment name. |
-|`description`| Optional | string | Description for the experiment.|
-|`variants`| Optional | object array | Array of [`variants`](#variants). |
-|`bucketingKey`| Optional | string | The user property to bucket the user by. |
-|`rolloutWeights`| Optional | object | Rollout weights for non-targeted users. The object should be a mapping from variant key to rollout weight as an integer. For example: `{ "control": 1, "treatment": 1 }`. |
-|`targetSegments`| Optional | object | See the [`targetSegments`](#targetsegments) table for more information. |
-|`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
-|`deployments`| Optional | string array | Array of deployments that the experiment should be assigned to. |
-|`experimentType`| Optional | string | Experiment type; options include `hypothesis-testing` or `no-harm`. |
-|`evaluationMode`| Optional | string | Experiment evaluation mode; options include `remote` or `local`. |
-
-#### `variants`
-
-The `variants` field contains these objects.
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`key`| Required | string | The key (a.k.a value) of the variant |
-|`payload`| Optional | string | Optional payload. Value must be a valid JSON element. |
-|`name`| Optional | string | The variant name. |
-|`description`| Optional | string | The variant description. |
-
-#### `targetSegments`
-
-The `targetSegments` field contains these objects.
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`name`|Optional | string | The segment name. |
-|`conditions`| Required | object array | Array of [`conditions`](#conditions). |
-|`percentage`| Optional | number | The allocation percentage for users who match a condition. |
-|`rolloutWeights`| Optional | object | A map from variant key to rollout weight. For example: `{ "control": 1, "treatment": 1 }`. |
-
-#### `conditions`
-
-The `conditions` field contains these objects.
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`type`| Required | string | **Must have value: `property`** |
-|`prop`| Required | string | The property to use in the condition |
-|`op`| Required | string | The [operation](#op) to use in this condition. |
-|`values`| Required | string array | The values to use in the operation. |
-
-#### `op`
-
-An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
-
-### Response
-
-A successful request returns a `200 OK` response and a JSON object with the experiment's details.
-
-<!-- TODO example response body -->
-
-!!!example "Example cURL"
-    ```bash
-    curl --request POST \
-      --url 'https://management-api.experiment.amplitude.com/experiments/new' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
-      --data '{"projectId":"<projectId>","key":"<key>"}'
     ```
 
 ------
@@ -1213,85 +1289,33 @@ A successful request returns a `200 OK` response and a JSON object with the flag
 
 ------
 
-## Activate experiment
+## Other Ednpoints
+
+## List deployments
 
 ```bash
-POST https://management-api.experiment.amplitude.com/experiments/{id}/activate
+GET https://management-api.experiment.amplitude.com/deployments/list
 ```
 
-<!-- Brian what does activating an experiment do?-->
+Fetch a list of deployments that experiments or flags can be assigned to.
 
-Activate a inactive experiment.
-
-### Path variables
+### Query parameters
 
 |<div class="big-column">Name</div>|Description|
 |---|----|
-|`id`| Required. String. The experiment's ID.|
+|`limit`| The max number of deployments to be returned. Capped at 1000.|
+|`cursor`| The offset to start the "page" of results from.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of deployments encoded as JSON in the response body.
+
+<!-- TODO example response body -->
 
 !!!example "Example cURL"
     ```bash
-    curl --request POST \
-      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/activate' \
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/deployments/list?limit=1000' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
-    ```
-
-------
-
-## Deactivate experiment
-
-```bash
-POST https://management-api.experiment.amplitude.com/experiments/{id}/deactivate
-```
-
-<!-- Brian what does deactivating an experiment do? -->
-
-Deactivate an active experiment.
-
-### Path variables
-
-|<div class="big-column">Name</div>|Description|
-|---|----|
-|`id`| Required. String. The experiment's ID.|
-
-!!!example "Example cURL"
-    ```bash
-    curl --request POST \
-      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/deactivate' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
-    ```
-
-------
-
-## Rollout weights
-
-```bash
-POST https://management-api.experiment.amplitude.com/experiments/{id}/rollout-weights
-```
-
-<!-- Brian what does this call do?-->
-
-Update the rollout weights for an experiment.
-
-### Path variables
-
-|<div class="big-column">Name</div>|Description|
-|---|----|
-|`id`| Required. String. The experiment's ID.|
-
-### Request body
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`rolloutWeights`| Required | object |A map from variant key to rollout weight. For example:  `{"control": 1,"treatment":1}`. |
-
-!!!example "Example cURL"
-    ```bash
-    curl --request POST \
-      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/rollout-weights' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
-      --data '{"rolloutWeights":{"control": 1,"treatment":1}}'
     ```

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -255,7 +255,7 @@ Fetch details of a specific variant of an experiment.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -286,7 +286,7 @@ Fetch a list of inclusions for a specific variant of an experiment.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -322,9 +322,9 @@ Create a new variant for an experiment.
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`key`| Required | string | The experiment key. |
-|`description`| Optional | string | Description for the experiment.|
-|`name`| Optional | string | Name for the experiment.|
+|`key`| Required | string | The variant key. |
+|`description`| Optional | string | Description for the variant.|
+|`name`| Optional | string | Name for the variant.|
 |`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
 |`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
 
@@ -341,7 +341,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":<rolloutWeight>}'
     ```
 
 ------
@@ -359,15 +359,15 @@ Edit a variant for an experiment.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Request body
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`key`| Optional | string | The experiment key. |
-|`description`| Optional | string | Description for the experiment.|
-|`name`| Optional | string | Name for the experiment.|
+|`key`| Optional | string | The variant key. |
+|`description`| Optional | string | Description for the variant.|
+|`name`| Optional | string | Name for the variant.|
 |`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
 |`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
 
@@ -383,7 +383,7 @@ A successful request returns a `200 OK` response.
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":<rolloutWeight>}'
     ```
 
 ------
@@ -401,7 +401,7 @@ Remove a variant from an experiment.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -425,20 +425,20 @@ A successful request returns a `200 OK` response.
 POST https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users
 ```
 
-Add users (inclusions) to experiment's variant.
+Add inclusions (users or devices) to experiment's variant.
 
 ### Path variables
 
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Request body
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`inclusions`| Required | string array | Array of user ids. |
+|`inclusions`| Required | object | Contains an string array of user or device ids. |
 
 ### Response
 
@@ -453,7 +453,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"inclusions":"<[]>"}'
+      --data '{"inclusions":<["id1", "id2", "id3"]>}'
     ```
 
 ------
@@ -464,14 +464,14 @@ A successful request returns a `200 OK` response.
 DELETE https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users/{userIndex}
 ```
 
-Remove users (inclusions) from experiment's variant.
+Remove inclusions (users or devices) from experiment's variant.
 
 ### Path variables
 
 |Name|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 |`userIndex`| Required. String. The user's index.|
 
 ### Response
@@ -496,14 +496,14 @@ A successful request returns a `200 OK` response.
 DELETE https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users
 ```
 
-Remove all users (inclusions) from experiment's variant.
+Remove all inclusions (users or devices) from experiment's variant.
 
 ### Path variables
 
 |<div class="big-column">Name</div>|Description|
 |---|----|
 |`id`| Required. String. The experiment's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -561,7 +561,6 @@ The `exposureEvent` field contains these objects.
 |---|---|---|---|
 |`event_type`| Required | string | Event type. |
 |`filters`| Required | object array | See the [`filters`](#filters) table for more information. |
-|`group_by`| Required | object array | See the [`group_by`](#group_by) table for more information. |
 
 #### `filters`
 
@@ -579,16 +578,6 @@ The `filters` field contains these objects.
 
 An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
 
-#### `group_by`
-
-The `group_by` field contains these objects. Experiment currently does not use these objects, and users should pass an empty array instead.
-
-|<div class="med-big-column">Name</div>|Requirement|Type|Description|
-|---|---|---|---|
-|`group_type`| Optional | string | Group type; can be null. |
-|`type`| Required | string | Type to group by. |
-|`value`| Required | string | Value to group by. |
-
 ### Response
 
 A successful request returns a `200 OK` response.
@@ -602,7 +591,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
+      --data '{"enabled":<enabled>,"rolloutPercentage":<rolloutPercentage>}'
     ```
 
 ------
@@ -945,7 +934,7 @@ Fetch details of a specific variant of a flag.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -976,7 +965,7 @@ Fetch a list of inclusions for a specific variant of a flag.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -1012,9 +1001,9 @@ Create a new variant for a flag.
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`key`| Required | string | The flag key. |
-|`description`| Optional | string | Description for the flag.|
-|`name`| Optional | string | Name for the flag.|
+|`key`| Required | string | The variant key. |
+|`description`| Optional | string | Description for the variant.|
+|`name`| Optional | string | Name for the variant.|
 |`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
 |`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
 
@@ -1031,7 +1020,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":<rolloutWeight>}'
     ```
 
 ------
@@ -1049,15 +1038,15 @@ Edit a variant for a flag.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Request body
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`key`| Optional | string | The flag key. |
-|`description`| Optional | string | Description for the flag.|
-|`name`| Optional | string | Name for the flag.|
+|`key`| Optional | string | The variant key. |
+|`description`| Optional | string | Description for the variant.|
+|`name`| Optional | string | Name for the variant.|
 |`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
 |`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
 
@@ -1074,7 +1063,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":<rolloutWeight>}'
     ```
 
 ------
@@ -1092,7 +1081,7 @@ Remove a variant from an experiment.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Response
 
@@ -1116,20 +1105,20 @@ A successful request returns a `200 OK` response.
 POST https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users
 ```
 
-Add users (inclusions) to flag's variant.
+Add inclusions (users or devices) to flag's variant.
 
 ### Path variables
 
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The variant's ID.|
+|`variantKey`| Required. String. The variant's key.|
 
 ### Request body
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`inclusions`| Required | string array | Array of user ids. |
+|`inclusions`| Required | object | Contains an string array of user or device ids. |
 
 ### Response
 
@@ -1144,7 +1133,7 @@ A successful request returns a `200 OK` response.
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
-      --data '{"inclusions":"<[]>"}'
+      --data '{"inclusions":<["id1", "id2", "id3"]>}'
     ```
 
 ------
@@ -1162,7 +1151,7 @@ Remove users (inclusions) from flag's variant.
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The flag's key.|
 |`userIndex`| Required. String. The user's index.|
 
 ### Response
@@ -1187,14 +1176,14 @@ A successful request returns a `200 OK` response.
 DELETE https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users
 ```
 
-Remove all users (inclusions) from flag's variant.
+Remove all inclusion (users or devices) from flag's variant.
 
 ### Path variables
 
 |Name|Description|
 |---|----|
 |`id`| Required. String. The flag's ID.|
-|`variantKey`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The flag's key.|
 
 ### Response
 
@@ -1251,7 +1240,7 @@ A successful request returns a `200 OK` response.
       --url 'https://management-api.experiment.amplitude.com/flags/<id>' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
-      --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
+      --data '{"enabled":<enabled>,"rolloutPercentage":<rolloutPercentage>}'
     ```
 
 ------

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -28,6 +28,7 @@ The Experiment management API can be used to programmatically create and control
 | [Add users to experiment's variant](#add-users-to-experiments-variant) | Add users to experiment's variant. |
 | [Remove users from experiment's variant](#remove-users-from-experiments-variant) | Remove users from experiment's variant. |
 | [Remove all users from experiment's variant](#remove-all-users-from-experiments-variant) | Remove all users from experiment's variant. |
+| [Edit experiment](#edit-experiment) | Edit experiment. |
 | [Get flag details](#get-flag-details) | Get the configuration details of a flag. |
 | [List flag versions](#list-flag-versions) | List all versions for a flag. |
 | [Get flag version details](#get-flag-version-details) | Get a specific version for a flag. |
@@ -40,7 +41,9 @@ The Experiment management API can be used to programmatically create and control
 | [Add users to flag's variant](#add-users-to-flags-variant) | Add users to flag's variant. |
 | [Remove users from flag's variant](#remove-users-from-flags-variant) | Remove users from flag's variant. |
 | [Remove all users from flag's variant](#remove-all-users-from-flags-variant) | Remove all users from flag's variant. |
+| [Edit flag](#edit-flag) | Edit flag. |
 | [Create experiment](#create-experiment) | Create a new experiment. |
+| [Create flag](#create-flag) | Create a new flag. |
 | [Activate experiment](#activate-experiment) | Activate a inactive experiment. |
 | [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
 | [Rollout weights](#rollout-weights) | Update the rollout weights for an experiment. |
@@ -564,6 +567,91 @@ A successful request returns a `200 OK` response.
 
 ------
 
+## Edit experiment
+
+```bash
+PATCH https://management-api.experiment.amplitude.com/experiments/{id}
+```
+
+Edit an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`bucketingKey`| Optional | string | The user property to bucket the user by. |
+|`bucketingSalt`| Optional | string | Experiment's bucketing salt. |
+|`bucketingUnit`| Optional | string | Experiment's bucketing |
+|`description`| Optional | string | Description of the experiment |
+|`enabled`| Optional | boolean | Property to activate or deactivate the flag|
+|`evaluationMode`| Optional | string | Evaluation mode for the experiment, either 'local' or 'remote' |
+|`name`| Optional | string | Name of the experiment |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users |
+|`experimentType`| Optional | number | Experiment type, either 'no-harm' or 'hypothesis-testing' |
+|`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
+|`startDate`| Optional | string | Start date of the experiment in ISO 8601 format |
+|`endDate`| Optional | string | End date of the experiment in ISO 8601 format. End date can be null. |
+|`exposureEvent`| Optional | object | See the [`exposureEvent`](#exposureevent) table for more information. If set to null, the Amplitude Exposure Event will be used |
+
+#### `exposureEvent`
+
+The `exposureEvent` field contains these objects.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`event_type`| Required | string | Event type. |
+|`filters`| Required | object array | See the [`filters`](#filters) table for more information. |
+|`group_by`| Required | object array | See the [`group_by`](#group_by) table for more information. |
+
+#### `filters`
+
+The `filters` field contains these objects.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`group_type`| Optional | string | Group type of the filter; can be null. Currently we only use `USER` value |
+|`subprop_key`| Required | string | Filter's key; can be null. |
+|`subprop_op`| Required | string | The [operation](#subprop_op) to use in this filter. |
+|`subprop_type`| Required | string | Type of filter; can be null. One of `USER`, `GROUP`, `EVENT` |
+|`subprop_value`| Required | string array | Array of values. |
+
+#### `subprop_op`
+
+An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
+
+#### `group_by`
+
+The `group_by` field contains these objects. Experiment currently does not use these objects, and users should pass an empty array instead.
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`group_type`| Optional | string | Group type; can be null. |
+|`type`| Required | string | Type to group by. |
+|`value`| Required | string | Value to group by. |
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request PATCH \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
+    ```
+
+------
+
 ## Get flag details
 
 ```bash
@@ -962,6 +1050,50 @@ A successful request returns a `200 OK` response.
 
 ------
 
+## Edit flag
+
+```bash
+PATCH https://management-api.experiment.amplitude.com/flags/{id}
+```
+
+Edit a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`bucketingKey`| Optional | string | The user property to bucket the user by. |
+|`bucketingSalt`| Optional | string | Flag's bucketing salt. |
+|`bucketingUnit`| Optional | string | Flag's bucketing |
+|`description`| Optional | string | Description of the flag |
+|`enabled`| Optional | boolean | Property to activate or disactivate the flag|
+|`evaluationMode`| Optional | string | Evaluation mode for the flag, either 'local' or 'remote' |
+|`name`| Optional | string | Name of the flag |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users |
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request PATCH \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
+    ```
+
+------
+
 ## Create experiment
 
 ```bash
@@ -975,7 +1107,8 @@ Create a new experiment.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`projectId`| Required | string | The project's ID. |
-|`key`| Required | string | The flag or experiment key. |
+|`key`| Required | string | The experiment key. |
+|`name`| Optional | string | The experiment name. |
 |`description`| Optional | string | Description for the experiment.|
 |`variants`| Optional | object array | Array of [`variants`](#variants). |
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
@@ -983,6 +1116,8 @@ Create a new experiment.
 |`targetSegments`| Optional | object | See the [`targetSegments`](#targetsegments) table for more information. |
 |`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
 |`deployments`| Optional | string array | Array of deployments that the experiment should be assigned to. |
+|`experimentType`| Optional | string | Experiment type; options include `hypothesis-testing` or `no-harm`. |
+|`evaluationMode`| Optional | string | Experiment evaluation mode; options include `remote` or `local`. |
 
 #### `variants`
 
@@ -1031,6 +1166,46 @@ A successful request returns a `200 OK` response and a JSON object with the expe
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/new' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"projectId":"<projectId>","key":"<key>"}'
+    ```
+
+------
+
+## Create flag
+
+```bash
+POST https://management-api.experiment.amplitude.com/flags/new
+```
+
+Create a new flag.
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`projectId`| Required | string | The project's ID. |
+|`key`| Required | string | The flag key. |
+|`name`| Optional | string | The flag name. |
+|`description`| Optional | string | Description for the flag.|
+|`variants`| Optional | object array | Array of [`variants`](#variants). |
+|`bucketingKey`| Optional | string | The user property to bucket the user by. |
+|`rolloutWeights`| Optional | object | Rollout weights for non-targeted users. The object should be a mapping from variant key to rollout weight as an integer. For example: `{ "control": 1, "treatment": 1 }`. |
+|`targetSegments`| Optional | object | See the [`targetSegments`](#targetsegments) table for more information. |
+|`deployments`| Optional | string array | Array of deployments that the experiment should be assigned to. |
+|`evaluationMode`| Optional | string | Experiment evaluation mode; options include `remote` or `local`. |
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with the flag's details.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/flags/new' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
       --data '{"projectId":"<projectId>","key":"<key>"}'

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -567,7 +567,7 @@ The `exposureEvent` field contains these objects.
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
 |`event_type`| Required | string | Event type. |
-|`filters`| Required | object array | See the [`filters`](#filters) table for more information. |
+|`filters`| Required | object array | A list of property filters. See the [`filters`](#filters) table for more information. |
 
 #### `filters`
 
@@ -575,15 +575,26 @@ The `filters` field contains these objects.
 
 |<div class="med-big-column">Name</div>|Requirement|Type|Description|
 |---|---|---|---|
-|`group_type`| Optional | string | Group type of the filter; can be null. Currently we only use `USER` value. |
+|`group_type`| Optional | string | Group type of the filter; can be null. Can be `User` value or one of the group values, eg `org _id`, `org name` |
 |`subprop_key`| Required | string | Filter's key; can be null. |
 |`subprop_op`| Required | string | The [operation](#subprop_op) to use in this filter. |
-|`subprop_type`| Required | string | Type of filter; can be null. One of `USER`, `GROUP`, `EVENT`. |
-|`subprop_value`| Required | string array | Array of values. |
+|`subprop_type`| Required | string | Either `event`, `user` or `group` indicating that the property is either an event, user or group property, respectively. |
+|`subprop_value`| Required | string array | A list of values to filter the event property by. |
 
 #### `subprop_op`
 
-An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
+A string value representing operations on a property value. Possible values are:
+
+- `is`
+- `is not`
+- `contains`
+- `does not contain`
+- `less`
+- `less or equal`
+- `greater`
+- `greater or equal`
+- `glob match`
+- `glob does not match`
 
 ### Response
 
@@ -662,7 +673,18 @@ The `conditions` field contains these objects.
 
 #### `op`
 
-An string value representing operations on a property value. Possible values are: `is`, `is not`, `contains`, `does not contain`, `less`, `less or equal`, `greater`, `greater or equal`, `glob match`, `glob does not match`
+A string value representing operations on a property value. Possible values are:
+
+- `is`
+- `is not`
+- `contains`
+- `does not contain`
+- `less`
+- `less or equal`
+- `greater`
+- `greater or equal`
+- `glob match`
+- `glob does not match`
 
 ### Response
 

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -1289,7 +1289,7 @@ A successful request returns a `200 OK` response and a JSON object with the flag
 
 ------
 
-## Other Ednpoints
+## Other Endpoints
 
 ## List deployments
 

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -60,6 +60,13 @@ The Experiment management API can be used to programmatically create and control
 | --- | --- |
 | [List deployments](#list-deployments) | List deployments that experiments or flags can be assigned to. |
 
+## Regions
+
+| Region | Endpoint |
+| --- | --- |
+| Standard Server | [https://management-api.experiment.amplitude.com](https://management-api.experiment.amplitude.com) |
+| EU Residency Server | [https://management-api.experiment.eu.amplitude.com](https://management-api.experiment.eu.amplitude.com) |
+
 ## Authorization
 
 The management API uses the HTTP Authorization header for authentication.

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -479,7 +479,7 @@ Remove inclusions (users or devices) from experiment's variant.
 |---|----|
 |`id`| Required. String. The experiment's ID.|
 |`variantKey`| Required. String. The variant's key.|
-|`userIndex`| Required. String. The user's index.|
+|`userIndex`| Required. String. The user's index. Zero-indexed.|
 
 ### Response
 
@@ -553,12 +553,12 @@ Edit an experiment.
 |`enabled`| Optional | boolean | Property to activate or deactivate the experiment. |
 |`evaluationMode`| Optional | string | Evaluation mode for the experiment, either `local` or `remote`. |
 |`name`| Optional | string | Name of the experiment. |
-|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. |
-|`experimentType`| Optional | number | Experiment type, either `no-harm` or `hypothesis-testing`. |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. Range 0 - 100. |
+|`experimentType`| Optional | string | Experiment type, options include `no-harm` or `hypothesis-testing`. |
 |`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
 |`startDate`| Optional | string | Start date of the experiment in ISO 8601 format. |
 |`endDate`| Optional | string | End date of the experiment in ISO 8601 format. End date can be null. |
-|`exposureEvent`| Optional | object | See the [`exposureEvent`](#exposureevent) table for more information. If set to null, the Amplitude Exposure Event will be use. |
+|`exposureEvent`| Optional | object | See the [`exposureEvent`](#exposureevent) table for more information. If set to null, the Amplitude Exposure Event will be used. |
 
 #### `exposureEvent`
 
@@ -1159,7 +1159,7 @@ Remove users (inclusions) from flag's variant.
 |---|----|
 |`id`| Required. String. The flag's ID.|
 |`variantKey`| Required. String. The flag's key.|
-|`userIndex`| Required. String. The user's index.|
+|`userIndex`| Required. String. The user's index. Zero-indexed.|
 
 ### Response
 
@@ -1233,7 +1233,7 @@ Edit a flag.
 |`enabled`| Optional | boolean | Property to activate or deactivate the flag. |
 |`evaluationMode`| Optional | string | Evaluation mode for the flag, either `local` or `remote`. |
 |`name`| Optional | string | Name of the flag. |
-|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. |
+|`rolloutPercentage`| Optional | number | Rollout percentage for non-targeted users. Range 0 - 100. |
 
 ### Response
 

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -19,9 +19,27 @@ The Experiment management API can be used to programmatically create and control
 | [Get experiment details](#get-experiment-details) | Get the configuration details of an experiment. |
 | [List experiment versions](#list-experiment-versions) | List all versions for an experiment. |
 | [Get experiment version details](#get-experiment-version-details) | Get a specific version for an experiment. |
+| [List experiment variants](#list-experiment-variants) | List all variants for an experiment. |
+| [Get experiment variant details](#get-experiment-variant-details) | Get a specific variant for an experiment. |
+| [Get experiment variant inclusions](#get-experiment-variant-inclusions) | Get all inclusions (users) for an experiment's variant. |
+| [Create experiment variant](#create-experiment-variant) | Create a new variant for an experiment. |
+| [Edit experiment variant](#edit-experiment-variant) | Edit a variant for an experiment. |
+| [Remove experiment variant](#remove-experiment-variant) | Remove a variant from an experiment. |
+| [Add users to experiment's variant](#add-users-to-experiments-variant) | Add users to experiment's variant. |
+| [Remove users from experiment's variant](#remove-users-from-experiments-variant) | Remove users from experiment's variant. |
+| [Remove all users from experiment's variant](#remove-all-users-from-experiments-variant) | Remove all users from experiment's variant. |
 | [Get flag details](#get-flag-details) | Get the configuration details of a flag. |
 | [List flag versions](#list-flag-versions) | List all versions for a flag. |
 | [Get flag version details](#get-flag-version-details) | Get a specific version for a flag. |
+| [List flag variants](#list-flag-variants) | List all variants for a flag. |
+| [Get flag variant details](#get-flag-variant-details) | Get a specific variant for a flag. |
+| [Get flag variant inclusions](#get-flag-variant-inclusions) | Get all inclusions (users) for a flag's variant. |
+| [Create flag variant](#create-flag-variant) | Create a new variant for a flag. |
+| [Edit flag variant](#edit-flag-variant) | Edit a variant for a flag. |
+| [Remove flag variant](#remove-flag-variant) | Remove a variant from a flag. |
+| [Add users to flag's variant](#add-users-to-flags-variant) | Add users to flag's variant. |
+| [Remove users from flag's variant](#remove-users-from-flags-variant) | Remove users from flag's variant. |
+| [Remove all users from flag's variant](#remove-all-users-from-flags-variant) | Remove all users from flag's variant. |
 | [Create experiment](#create-experiment) | Create a new experiment. |
 | [Activate experiment](#activate-experiment) | Activate a inactive experiment. |
 | [Deactivate experiment](#deactivate-experiment) | Deactivate an active experiment. |
@@ -239,6 +257,313 @@ A successful request returns a `200 OK` response and a JSON object with details 
 
 ------
 
+## List experiment variants
+
+```bash
+GET https://management-api.experiment.amplitude.com/experiments/{id}/variants
+```
+
+Fetch a list of all variants for an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of experiment's variants encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Get experiment variant details
+
+```bash
+GET https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}
+```
+
+Fetch details of a specific variant of an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with details of experiment's variant.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Get experiment variant inclusions
+
+```bash
+GET https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users
+```
+
+Fetch a list of inclusions for a specific variant of an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with a list of inclusions of experiment's variant.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>/users' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Create experiment variant
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/{id}/variants
+```
+
+Create a new variant for an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`key`| Required | string | The experiment key. |
+|`description`| Optional | string | Description for the experiment.|
+|`name`| Optional | string | Name for the experiment.|
+|`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
+|`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+    ```
+
+------
+
+## Edit experiment variant
+
+```bash
+PATCH https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}
+```
+
+Edit a variant for an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`key`| Optional | string | The experiment key. |
+|`description`| Optional | string | Description for the experiment.|
+|`name`| Optional | string | Name for the experiment.|
+|`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
+|`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request PATCH \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+    ```
+
+------
+
+## Remove experiment variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}
+```
+
+Remove a variant from an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Add users to experiment's variant
+
+```bash
+POST https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users
+```
+
+Add users (inclusions) to experiment's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`inclusions`| Required | string array | Array of user ids. |
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>/users' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"inclusions":"<[]>"}'
+    ```
+
+------
+
+## Remove users from experiment's variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users/{userIndex}
+```
+
+Remove users (inclusions) from experiment's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+|`userIndex`| Required. String. The user's index.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>/users/{<userIndex>}' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Remove all users from experiment's variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/experiments/{id}/variants/{variantKey}/users
+```
+
+Remove all users (inclusions) from experiment's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The experiment's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>/users' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
 ## Get flag details
 
 ```bash
@@ -324,6 +649,313 @@ A successful request returns a `200 OK` response and a JSON object with details 
     ```bash
     curl --request GET \
       --url 'https://management-api.experiment.amplitude.com/flags/<id>/versions/<versionId>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## List flag variants
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}/variants
+```
+
+Fetch a list of all variants for a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a list of flag's variants encoded as JSON in the response body.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Get flag variant details
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}
+```
+
+Fetch details of a specific variant of a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with details of flag's variant.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Get flag variant inclusions
+
+```bash
+GET https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users
+```
+
+Fetch a list of inclusions for a specific variant of a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response and a JSON object with a list of inclusions of flag's variant.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request GET \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>/users' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Create flag variant
+
+```bash
+POST https://management-api.experiment.amplitude.com/flags/{id}/variants
+```
+
+Create a new variant for a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`key`| Required | string | The flag key. |
+|`description`| Optional | string | Description for the flag.|
+|`name`| Optional | string | Name for the flag.|
+|`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
+|`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+    ```
+
+------
+
+## Edit flag variant
+
+```bash
+PATCH https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}
+```
+
+Edit a variant for a flag.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`key`| Optional | string | The flag key. |
+|`description`| Optional | string | Description for the flag.|
+|`name`| Optional | string | Name for the flag.|
+|`payload`| Optional | string | Optional payload. Value must be a valid JSON element.|
+|`rolloutWeight`| Optional | number | Rollout weight for non-targeted users.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request PATCH \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
+    ```
+
+------
+
+## Remove flag variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}
+```
+
+Remove a variant from an experiment.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Add users to flag's variant
+
+```bash
+POST https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users
+```
+
+Add users (inclusions) to flag's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The variant's ID.|
+
+### Request body
+
+|<div class="med-big-column">Name</div>|Requirement|Type|Description|
+|---|---|---|---|
+|`inclusions`| Required | string array | Array of user ids. |
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request POST \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>/users' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+      --data '{"inclusions":"<[]>"}'
+    ```
+
+------
+
+## Remove users from flag's variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users/{userIndex}
+```
+
+Remove users (inclusions) from flag's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The flag's ID.|
+|`userIndex`| Required. String. The user's index.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>/users/{<userIndex>}' \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Bearer <management-api-key>'
+    ```
+
+------
+
+## Remove all users from flag's variant
+
+```bash
+DELETE https://management-api.experiment.amplitude.com/flags/{id}/variants/{variantKey}/users
+```
+
+Remove all users (inclusions) from flag's variant.
+
+### Path variables
+
+|<div class="big-column">Name</div>|Description|
+|---|----|
+|`id`| Required. String. The flag's ID.|
+|`variantKey`| Required. String. The flag's ID.|
+
+### Response
+
+A successful request returns a `200 OK` response.
+
+<!-- TODO example response body -->
+
+!!!example "Example cURL"
+    ```bash
+    curl --request DELETE \
+      --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>/users' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -624,7 +624,6 @@ Create a new experiment.
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
 |`rolloutWeights`| Optional | object | Rollout weights for non-targeted users. The object should be a mapping from variant key to rollout weight as an integer. For example: `{ "control": 1, "treatment": 1 }`. |
 |`targetSegments`| Optional | object | See the [`targetSegments`](#targetsegments) table for more information. |
-|`stickyBucketing`| Optional | boolean | If true, the experiment uses [sticky bucketing](../general/evaluation/implementation.md#sticky-bucketing). |
 |`deployments`| Optional | string array | Array of deployments that the experiment should be assigned to. |
 |`experimentType`| Optional | string | Experiment type; options include `hypothesis-testing` or `no-harm`. |
 |`evaluationMode`| Optional | string | Experiment evaluation mode; options include `remote` or `local`. |

--- a/docs/experiment/apis/management-api.md
+++ b/docs/experiment/apis/management-api.md
@@ -338,8 +338,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
     ```
 
@@ -381,7 +382,7 @@ A successful request returns a `200 OK` response.
     curl --request PATCH \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
     ```
 
@@ -449,8 +450,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/variants/<variantKey>/users' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"inclusions":"<[]>"}'
     ```
 
@@ -539,7 +541,7 @@ Edit an experiment.
 |---|---|---|---|
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
 |`bucketingSalt`| Optional | string | Experiment's bucketing salt. |
-|`bucketingUnit`| Optional | string | Experiment's bucketing. |
+|`bucketingUnit`| Optional | string | Experiment's bucketing unit represented by a group type from the accounts add-on. Used for group level bucketing and analysis. |
 |`description`| Optional | string | Description of the experiment. |
 |`enabled`| Optional | boolean | Property to activate or deactivate the experiment. |
 |`evaluationMode`| Optional | string | Evaluation mode for the experiment, either `local` or `remote`. |
@@ -597,8 +599,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request PATCH \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"enabled":"<true>","rolloutPercentage":"<10>"}'
     ```
 
@@ -675,8 +678,9 @@ A successful request returns a `200 OK` response and a JSON object with the expe
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/new' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"projectId":"<projectId>","key":"<key>"}'
     ```
 
@@ -684,7 +688,7 @@ A successful request returns a `200 OK` response and a JSON object with the expe
 
 ## Activate experiment
 
-***Not recommended to use. Use [`Edit experiment`](#edit-experiment) instead***
+!!!warn "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/activate
@@ -704,6 +708,7 @@ Activate an inactive experiment.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/activate' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```
@@ -712,7 +717,7 @@ Activate an inactive experiment.
 
 ## Deactivate experiment
 
-***Not recommended to use. Use [`Edit experiment`](#edit-experiment) instead***
+!!!warn "Not recommended. Use [`edit experiment`](#edit-experiment) instead."
 
 ```bash
 POST https://management-api.experiment.amplitude.com/experiments/{id}/deactivate
@@ -732,6 +737,7 @@ Deactivate an active experiment.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/deactivate' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>'
     ```
@@ -766,8 +772,9 @@ Update the rollout weights for an experiment.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/experiments/<id>/rollout-weights' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"rolloutWeights":{"control": 1,"treatment":1}}'
     ```
 
@@ -1023,8 +1030,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
     ```
 
@@ -1065,8 +1073,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request PATCH \
       --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"key":"<key>","name":"<name>","description":"<description>","payload":"<payload>","rolloutWeight":"<rolloutWeight>"}'
     ```
 
@@ -1134,8 +1143,9 @@ A successful request returns a `200 OK` response.
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/flags/<id>/variants/<variantKey>/users' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"inclusions":"<[]>"}'
     ```
 
@@ -1224,7 +1234,7 @@ Edit a flag.
 |---|---|---|---|
 |`bucketingKey`| Optional | string | The user property to bucket the user by. |
 |`bucketingSalt`| Optional | string | Flag's bucketing salt. |
-|`bucketingUnit`| Optional | string | Flag's bucketing. |
+|`bucketingUnit`| Optional | string | Flag's bucketing unit represented by a group type from the accounts add-on. Used for group level bucketing. |
 |`description`| Optional | string | Description of the flag. |
 |`enabled`| Optional | boolean | Property to activate or deactivate the flag. |
 |`evaluationMode`| Optional | string | Evaluation mode for the flag, either `local` or `remote`. |
@@ -1281,8 +1291,9 @@ A successful request returns a `200 OK` response and a JSON object with the flag
     ```bash
     curl --request POST \
       --url 'https://management-api.experiment.amplitude.com/flags/new' \
+      --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
-      --header 'Authorization: Bearer <management-api-key>'
+      --header 'Authorization: Bearer <management-api-key>' \
       --data '{"projectId":"<projectId>","key":"<key>"}'
     ```
 

--- a/docs/experiment/index.md
+++ b/docs/experiment/index.md
@@ -67,7 +67,7 @@ Client-side SDKs work in a single-user context. Server-side SDKs work in a multi
 | API | Description |
 | --- | --- |
 | [Evaluation API](apis/evaluation-api.md) | Evaluate a user for the feature flags and experiments assigned to the deployment used to authorize the request |
-| [Management API (Beta)](https://developers.experiment.amplitude.com/reference/management-api) | Manage or list flags and experiments within your organization. |
+| [Management API (Beta)](apis/management-api.md) | Manage or list flags and experiments within your organization. |
 
 ## System overview
 <!-- vale Amplitude.Contractions = NO-->


### PR DESCRIPTION
# Amplitude Developer Docs PR

- rearrange existing sections so it is easier to read documentation
- add new parameters to `/experiments/new` and `flags/new` endpoints
- add the followings endpoints for both flags/:id and experiments/:id
-- PATCH 
-- POST /variants/:variantKey/users
-- POST /variants
-- PATCH /variants/:variantKey
-- DELETE variants/:variantKey
-- DELETE variants/:variantKey/users/:userIndex


## Description

Describe your changes. 

## Deadline

Once we deploy the appropriate backend changes (scheduled for week of 1/23/23).


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [x] New documentation.
- [x] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp