### PR TITLE
fix the go get url

### DIFF
--- a/docs/data/sdks/go/index.md
+++ b/docs/data/sdks/go/index.md
@@ -19,7 +19,7 @@ The Go SDK lets you send events to Amplitude. This library is open-source, check
 Install `analytics-go` using `go get`:
 
 ```bash
-go get https://github.com/amplitude/analytics-go
+go get github.com/amplitude/analytics-go
 ```
 
 ## Usage


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

fix the go get url
Before
![Screen Shot 2023-01-24 at 11 42 20 AM](https://user-images.githubusercontent.com/52427478/214392513-7de6dff8-5130-4952-9569-69e0b9d92dc4.png)

After
![Screen Shot 2023-01-24 at 11 43 02 AM](https://user-images.githubusercontent.com/52427478/214392671-cc516384-3eee-48ad-be9f-a71619e2397e.png)


## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp