### PR TITLE
Adding TTL Config. self-serve instructions

### DIFF
--- a/docs/data/ttl-configuration.md
+++ b/docs/data/ttl-configuration.md
@@ -17,19 +17,25 @@ Amplitude Data's Time-to-Live (TTL) feature lets you have control over how long 
 
 - The retention period can't be set for a subset of event data or a single project. The retention period is set at the **Amplitude Organization** level and impacts *all* event data. Using the TTL feature doesn't impact user data that you have sent to Amplitude.
 - When you enabled TTL and set a retention period, Amplitude deletes all event data sent to Amplitude prior to your retention period.
+- You can configure the retention period by number of months. Amplitude's default month is 30 days. For example, if you set your organization’s retention period to 4 months, all event data for the last 120 days is retained. 
 - Enabling TTL affects your existing Amplitude reports. After TTL is set up, charts that query data outside the retention period that you have set are zeroed out. They appear as if the data for that period never existed within Amplitude.
+- The initial deletion may take longer than daily deletions. Depending on an organization’s historical event volume, it may take up to 30 days.
 - Amplitude Support can help you retrieve deleted data within **5 days** following the first time that you enable TTL. After the 5 days, your data is permanently deleted and irretrievable. To retrieve deleted data within the first 5 days after you enable TTL for the first time, [contact Amplitude Support](https://help.amplitude.com/hc/en-us/requests/new).
 
 ## Enable TTL 
 
-To have TTL controls enabled for your organization, please reach out to your Account Manager at Amplitude or fill out a support request [here](https://help.amplitude.com/hc/en-us/requests/new).
+To have TTL controls enabled for your organization, reach out to your Account Manager at Amplitude or fill out a [support request](https://help.amplitude.com/hc/en-us/requests/new).
 
-## Configuring TTL for your Organization
+## Configure TTL for your organization
 
-The TTL feature is only accessible by Admins of your organization. You can find the controls in the Analytics Settings page in the “Time-to-Live” tab.
+Amplitude admins can configure TTL. 
 
-Admins can configure the retention period for the organization by number of months. By default, Amplitude sets a month to 30 days. For example, if you set your organization’s retention period to 4 months, it will retain all event data within the last 120 days. Once you have selected the retention period, you will see a modal which specifies details of how TTL works along with a second stage confirmation for setting up TTL at the organization. 
+1. Navigate to **Analytics Settings** and select the **Time-to-Live** tab.
+2. Choose the retention period.
+3. Confirm your changes.
 
-Once you confirm, deletion of your event data will start in 24 hours. In the case where you want to cancel TTL, Admins have the ability to rescind this request within this 24 hour period. After the 24 hour period passes, the deletion of events outside the retention window will begin. 
+After you confirm, deletion of your event data starts in 24 hours. 
 
-Note: The initial deletion process, in most cases, will take longer than daily deletions. Depending on an organization’s historical event volume, it may take up to 30 days.
+!!!warning "Canceling TTL"
+
+    If you want to cancel TTL, an admin can rescind the request in the 24 hour period before data deletion begins. After 24 hours, the deletion begins and is irreversible.

--- a/docs/data/ttl-configuration.md
+++ b/docs/data/ttl-configuration.md
@@ -22,4 +22,14 @@ Amplitude Data's Time-to-Live (TTL) feature lets you have control over how long 
 
 ## Enable TTL 
 
-To enable or disable TTL, reach out to your Account Manager at Amplitude or fill out a support request [here](https://help.amplitude.com/hc/en-us/requests/new).
+To have TTL controls enabled for your organization, please reach out to your Account Manager at Amplitude or fill out a support request [here](https://help.amplitude.com/hc/en-us/requests/new).
+
+## Configuring TTL for your Organization
+
+The TTL feature is only accessible by Admins of your organization. You can find the controls in the Analytics Settings page in the “Time-to-Live” tab.
+
+Admins can configure the retention period for the organization by number of months. By default, Amplitude sets a month to 30 days. For example, if you set your organization’s retention period to 4 months, it will retain all event data within the last 120 days. Once you have selected the retention period, you will see a modal which specifies details of how TTL works along with a second stage confirmation for setting up TTL at the organization. 
+
+Once you confirm, deletion of your event data will start in 24 hours. In the case where you want to cancel TTL, Admins have the ability to rescind this request within this 24 hour period. After the 24 hour period passes, the deletion of events outside the retention window will begin. 
+
+Note: The initial deletion process, in most cases, will take longer than daily deletions. Depending on an organization’s historical event volume, it may take up to 30 days.

--- a/docs/data/ttl-configuration.md
+++ b/docs/data/ttl-configuration.md
@@ -5,17 +5,14 @@ description: Amplitude Data's Time-to-Live (TTL) feature lets you have control o
 
 Amplitude Data's Time-to-Live (TTL) feature lets you have control over how long event data lives in your Amplitude instance. You set the retention period for event data in Amplitude at the Amplitude organization level. When TTL is enabled, a job runs daily to make sure that Amplitude retains your event data according to your organization's TTL policy.
 
-!!!note "How Amplitude calculates retention period"
-
-    Amplitude uses the date the event data reaches the Amplitude server when determining the retention period for event data and therefore any backfill or migration of event data may affect the retention period for that event data.
-
 ## Considerations
 
-!!!warning "Irreversible data loss"
+!!!warning "Read carefully: TTL causes irreversible data loss"
 
     After TTL is enabled, data outside of the retention period is deleted. Read these considerations before you get started with TTL. 
 
 - The retention period can't be set for a subset of event data or a single project. The retention period is set at the **Amplitude Organization** level and impacts *all* event data. Using the TTL feature doesn't impact user data that you have sent to Amplitude.
+- Amplitude uses the date the event data reaches the Amplitude server when determining the retention period. Therefore, any backfill or migration of event data may affect the retention period for that event data.
 - When you enabled TTL and set a retention period, Amplitude deletes all event data sent to Amplitude prior to your retention period.
 - You can configure the retention period by number of months. Amplitude's default month is 30 days. For example, if you set your organization’s retention period to 4 months, all event data for the last 120 days is retained. 
 - Enabling TTL affects your existing Amplitude reports. After TTL is set up, charts that query data outside the retention period that you have set are zeroed out. They appear as if the data for that period never existed within Amplitude.

--- a/docs/data/ttl-configuration.md
+++ b/docs/data/ttl-configuration.md
@@ -34,7 +34,7 @@ Amplitude admins can configure TTL.
 2. Choose the retention period.
 3. Confirm your changes.
 
-After you confirm, deletion of your event data starts in 24 hours. 
+After you confirm, deletion of your event data starts in 24 hours. It may take up to 30 days for the initial deletion. 
 
 !!!warning "Canceling TTL"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -328,6 +328,7 @@ nav:
       - DataGrail: data/pii/datagrail.md
       - Osano: data/pii/osano.md
       - Transcend: data/pii/transcend.md
+    - Time-to-Live: data/ttl-configuration.md
   - Experiment:
       - experiment/index.md
       - Overview: experiment/index.md


### PR DESCRIPTION
There are a handful of orgs who have TTL self-serve, so I think it makes sense to add the self-serve instructions

# Amplitude Developer Docs PR


## Description

Updating TTL docs to include self-serve instructions

## Deadline

Whenever possible, but not pressing.


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp