### PR TITLE
AMP-66979 add python supported version and shutdown behavior update

### DIFF
--- a/docs/data/sdks/python/index.md
+++ b/docs/data/sdks/python/index.md
@@ -12,6 +12,9 @@ The Python SDK lets you send events to Amplitude. This library is open-source, c
 !!!info "Python SDK Resources"
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-Python) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Python/releases) · [:material-book: API Reference](https://github.com/amplitude/Amplitude-Python)
 
+!!!info "Supported Python Versions"
+    Python SDK supports Python version 3.6+. Python SDK repository runs tests on all supported versions.
+
 --8<-- "includes/ampli-vs-amplitude.md"
 
 ## Getting started
@@ -334,6 +337,7 @@ client.remove(plugin_obj)
 ### `shutdown`
 
 Use the `shutdown` method to close the instance. A closed instance doesn't accept new events and tries to flush events left in the buffer. Then the client instance shuts down running threads.
+Starting from version v1.1.1, `shutdown` method is automatically registered to be called when main thread exits.
 
 ```py
 client.shutdown()


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- Add python supported version information for Python SDK. 
- Add new shutdown behavior

## Deadline




## Change type

- [x] Doc bug fix. Fixes #[AMP-66979]. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp

[AMP-66979]: https://amplitude.atlassian.net/browse/AMP-66979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ