### PR TITLE
DDI-402: Adding community help link in footers

### DIFF
--- a/docs/all-resources.md
+++ b/docs/all-resources.md
@@ -5,6 +5,7 @@ hide:
   - toc
   - navigation
 #template: resources.html
+toplevel: true
 ---
 
 <!-- markdownlint-disable MD030 -->

--- a/docs/analytics/apis/index.md
+++ b/docs/analytics/apis/index.md
@@ -3,6 +3,7 @@ title: Amplitude APIs
 description: Use Amplitude APIs to send and receive data, and extend Amplitude.
 hide:
   - toc
+toplevel: true
 ---
 
 Use Amplitude APIs to send and receive information and extend Amplitude. 

--- a/docs/analytics/index.md
+++ b/docs/analytics/index.md
@@ -5,6 +5,7 @@ hide:
   - tags
   - feedback
   - toc
+toplevel: true
 ---
 
 Amplitude Analytics is the leading product analytics tool. It helps you gather and democratize data about how users engage with your apps.

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -3,6 +3,7 @@ title: Amplitude Data Overview
 description: Get started with Amplitude Data.
 hide:
   - toc
+toplevel: true
 ---
 
 Amplitude Data makes it easy for you to configure Sources and Destinations. Sources send data into Amplitude, and Destinations receive data from Amplitude. You can use the data that you send to Amplitude for Analytics, Experiment, and Audiences. 

--- a/docs/data/sdks/index.md
+++ b/docs/data/sdks/index.md
@@ -1,6 +1,7 @@
 ---
 title: Amplitude SDKs
 description: Use Amplitude SDKs to send event data from your apps into Amplitude.
+toplevel: true
 ---
 
 Use Amplitude SDKs to send event data from your apps into Amplitude.

--- a/docs/documentation-home.md
+++ b/docs/documentation-home.md
@@ -3,6 +3,7 @@ title: Amplitude Developer Docs
 description: Amplitude gives your teams a self-service digital analytics platform to understand your users, drive conversions, and increase engagement, growth, and revenue.
 hide:
   - toc
+toplevel: true
 ---
 
 Amplitude gives your teams a self-service digital analytics platform to understand your users, drive conversions, and increase engagement, growth, and revenue. It helps you proactively improve data quality, discover new audiences, and sync behavioral data across your stack.

--- a/docs/experiment/index.md
+++ b/docs/experiment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Amplitude Experiment Overview
 description: Learn about Amplitude's experimentation and feature-flagging platform.
+toplevel: true
 ---
 
 Welcome to Amplitude Experiment. This page acts as a quick reference as well as a high level system overview of Experiment's end-to-end feature-flagging and experimentation platform.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,6 +4,7 @@ description: Learn more about using Amplitude with our guides.
 hide:
   - toc
   - navigation
+toplevel: true
 ---
 
 Getting started with Amplitude can be daunting. These guides break down sophisticated concepts to help you make the most of Amplitude. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hide:
   - navigation
   - toc
 title: Amplitude Developer Center
-
+toplevel: true
 ---
 
 <!-- partially overridden by overrides/home.html -->

--- a/docs/partners/index.md
+++ b/docs/partners/index.md
@@ -1,6 +1,7 @@
 ---
 title: Amplitude Partner Hub
-description: Get started building an integration with Amplitude Data. 
+description: Get started building an integration with Amplitude Data.
+toplevel: true
 ---
 <!-- vale Amplitude.We = NO-->
 Welcome to Amplitude Partner documentation. Building an integration with Amplitude is an easy way to deliver better business outcomes for our joint customers. To build integrations, become a Technology Partner.

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -34,6 +34,20 @@ as the main headline.
 {{ page.content }}
 
 <!-- Was this page helpful? -->
+{% if page and page.meta and not(
+  page.meta.toplevel
+  ) %}
+  <hr>
+  <!-- Tracks link clicks out to the community for doc improvements-->
+<script>
+    var eventProperties = {
+        name: "community_help",
+        url: window.location.href,
+    };
+</script>
+  <p>Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="amplitude.getInstance().logEvent('Link Click', eventProperties)">Community</a>.
+
+  {% endif %}
 
 <!-- Source file information -->
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds a link to the community in article footers. 

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
