### PR TITLE
Add fix for TOC depth and better anchorlink tooltip text

### DIFF
--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -79,7 +79,7 @@ init(API_KEY, 'user@amplitude.com', {
 
 --8<-- "includes/sdk-ts/client-debugging.md"
 
-#### EU data residency
+### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 

--- a/insiders.mkdocs.yml
+++ b/insiders.mkdocs.yml
@@ -30,6 +30,9 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+      title: "On this page"
+      toc_depth: 3
+      permalink_title: Link to this section
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,8 @@ plugins:
   - git-revision-date # enables the git revision date functionality
   #- glightbox # leave this commented out -- it enables image lightboxing but it also increases build time by 30 seconds so you don't want it messing with you locally. This plugin is enabled on insiders.
 
-# Extensions
+# Extensions 
+# Make sure to mirror changes in insiders.mkdocs.yml. 
 markdown_extensions:
   - admonition
   - abbr

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ markdown_extensions:
   - toc:
       permalink: true
       title: "On this page"
+      toc_depth: 3
+      permalink_title: Link to this section
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:


### PR DESCRIPTION
# Amplitude Developer Docs PR

Limited TOC depth to L3 headings to make tocs easier to navigate and less hideous on longer articles. Also fixes tooltip text for anchor links. 

## Deadline

ASAP

## Change type

- [X] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
