### PR TITLE
DDI:367: Add index for Experiment getting started

### DIFF
--- a/docs/experiment/guides/getting-started/create-a-deployment.md
+++ b/docs/experiment/guides/getting-started/create-a-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Create a Deployment
 description: How to create a deployment for delivering your feature flags and experiments.
-template: guide-first.html
+template: guide.html
 ---
 
 Before creating a [feature-flag or experiment](../../general/data-model.md#flags-and-experiments), you'll need to first create a [deployment](../../general/data-model.md#deployments). In Amplitude Experiment, a deployment serves a group of flags or experiments for use in an application. Deployments have an associated key which is used to authorize requests to Amplitude Experiment's evaluation servers.

--- a/docs/experiment/guides/getting-started/fetch-variants.md
+++ b/docs/experiment/guides/getting-started/fetch-variants.md
@@ -4,7 +4,7 @@ description: How to fetch flag and experiment variants for a user using various 
 template: guide.html
 ---
 
-To evaluate a user for you flag you'll want to **fetch** variants from Experiment's [remote evaluation](../../general/evaluation/remote-evaluation.md) servers. You can fetch variants for a user using either the [Evaluation REST API](../../apis/evaluation-api.md) or one of the [SDKs](../../index.md#sdks).
+To evaluate a user for your flag,  **fetch** variants from Experiment's [remote evaluation](../../general/evaluation/remote-evaluation.md) servers. You can fetch variants for a user using either the [Evaluation REST API](../../apis/evaluation-api.md) or one of the [SDKs](../../index.md#sdks).
 
 ### Evaluation REST API
 

--- a/docs/experiment/guides/getting-started/index.md
+++ b/docs/experiment/guides/getting-started/index.md
@@ -6,7 +6,7 @@ template: guide-first.html
 
 This guide walks through getting started with Amplitude Experiment. For the best experience, read the guide in this order. You can use the navigation at the bottom of each page to move to the next section.
 
-1. [Create a deployment](/experiment/guides/getting-started/create-a-deployment/). A deployment serves a group of flags or experiments for use in an application.
-2. [Create a flag](/experiment/guides/getting-started/create-a-flag/), and add a deployment. Flags alone are used for standard feature flagging without user analysis. Experiments are used for feature experimentation on users. Learn more about [flags and experiments](../general/data-model/#flags-and-experiments).
-3. [Fetch variants](/fetch-variants) to evaluate a user for a flag.
-4. [Track exposure](/track-exposure) to find out whether a user viewed the variable experience from your feature flag. Exposure tracking is optional for feature flags which don't require analysis, but it's essential when running experiment.
+1. [Create a deployment](../getting-started/create-a-deployment/). A deployment serves a group of flags or experiments for use in an application.
+2. [Create a flag](../getting-started/create-a-flag/), and add a deployment. Flags alone are used for standard feature flagging without user analysis. Experiments are used for feature experimentation on users. Learn more about [flags and experiments](../general/data-model/#flags-and-experiments).
+3. [Fetch variants](../fetch-variants) to evaluate a user for a flag.
+4. [Track exposure](../track-exposure) to find out whether a user viewed the variable experience from your feature flag. Exposure tracking is optional for feature flags which don't require analysis, but it's essential when running experiment.

--- a/docs/experiment/guides/getting-started/index.md
+++ b/docs/experiment/guides/getting-started/index.md
@@ -1,0 +1,12 @@
+---
+title: Get Started with Experiment
+description: Use this guide to get started with Amplitude Experiment.
+template: guide-first.html
+---
+
+This guide walks through getting started with Amplitude Experiment. For the best experience, read the guide in this order. You can use the navigation at the bottom of each page to move to the next section.
+
+1. [Create a deployment](/experiment/guides/getting-started/create-a-deployment/). A deployment serves a group of flags or experiments for use in an application.
+2. [Create a flag](/experiment/guides/getting-started/create-a-flag/), and add a deployment. Flags alone are used for standard feature flagging without user analysis. Experiments are used for feature experimentation on users. Learn more about [flags and experiments](../general/data-model/#flags-and-experiments).
+3. [Fetch variants](/fetch-variants) to evaluate a user for a flag.
+4. [Track exposure](/track-exposure) to find out whether a user viewed the variable experience from your feature flag. Exposure tracking is optional for feature flags which don't require analysis, but it's essential when running experiment.

--- a/docs/experiment/index.md
+++ b/docs/experiment/index.md
@@ -12,9 +12,9 @@ Welcome to Amplitude Experiment. This page acts as a quick reference as well as 
 
     ---
 
-    Step-by-step guide to get started developing with Amplitude Experiment.
+    Read the step-by-step guide to get started developing with Amplitude Experiment.
 
-    [:octicons-arrow-right-24: Start developing](#getting-started)
+    [:octicons-arrow-right-24: Start developing](../experiment/guides/getting-started/index.md)
 
 - :material-hexagon-multiple:{ .lg .middle } __System overview__
 
@@ -41,15 +41,6 @@ Welcome to Amplitude Experiment. This page acts as a quick reference as well as 
     [:octicons-arrow-right-24: See the APIs](#rest-apis)
 
 </div>
-
-## Getting started
-
-Guide to getting started developing for Amplitude Experiment.
-
-1. [Create a deployment](guides/getting-started/create-a-deployment.md)
-2. [Create and configure a feature flag](guides/getting-started/create-a-flag.md)
-3. [Fetch variants for a user](guides/getting-started/fetch-variants.md)
-4. [Track an exposure event](guides/getting-started/track-exposure.md)
 
 ## SDKs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -349,6 +349,7 @@ nav:
         - experiment/general/exposure-tracking.md
       - Guides:
         - Getting Started:
+          - experiment/guides/getting-started/index.md
           - experiment/guides/getting-started/create-a-deployment.md
           - experiment/guides/getting-started/create-a-flag.md
           - experiment/guides/getting-started/fetch-variants.md


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds an index page to introduce reader to the guide and to make breadcrumb nav useful. 

## Deadline

🤷 

## Change type

- [X] New documentation.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.
