### PR TITLE
Update destination-event-streaming-overview.md

### DIFF
--- a/docs/data/destination-event-streaming-overview.md
+++ b/docs/data/destination-event-streaming-overview.md
@@ -13,7 +13,7 @@ Event streaming includes powerful, no-code, configuration-based tools that give 
 - The following keywords can't be used as event names when streaming events from Amplitude:
     - _all
     - _identify
-- We track volume as distinct events streamed out so the same event going to multiple event streaming destinations will only be counted once for billing purposes.
+- Amplitude tracks event volume as distinct events streamed out. The same event going to multiple event streaming destinations is only counted once for billing purposes.
 
 ## Event streaming destinations
 

--- a/docs/data/destination-event-streaming-overview.md
+++ b/docs/data/destination-event-streaming-overview.md
@@ -13,6 +13,7 @@ Event streaming includes powerful, no-code, configuration-based tools that give 
 - The following keywords can't be used as event names when streaming events from Amplitude:
     - _all
     - _identify
+- We track volume as distinct events streamed out so the same event going to multiple event streaming destinations will only be counted once for billing purposes.
 
 ## Event streaming destinations
 


### PR DESCRIPTION
Wanted to put a note as we've been getting a few questions from GTM about how we count event volume streamed out.
- We track volume as distinct events streamed out, so if an app has 2 syncs sending out all events the same event will not count as 2 for billing purposes, it will count as 1 no matter the number of syncs setup

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp