### PR TITLE
Removes beta label from new react native sdk

### DIFF
--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -11,7 +11,7 @@ icon: simple/react
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
 !!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) available in Beta. The new SDK offers an improved code architecture which supports plugins and React Native Web.
+    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) available. The new SDK offers an improved code architecture which supports plugins and React Native Web.
 
 !!!info "SDK Resources"
     - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -11,7 +11,7 @@ icon: simple/react
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
 !!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) available. The new SDK offers an improved code architecture which supports plugins and React Native Web.
+    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) is available. The new SDK offers an improved code architecture which supports plugins and React Native Web.
 
 !!!info "SDK Resources"
     - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -948,7 +948,7 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
 
 === "React Native"
 
-    The React Native SDK lets you send events to Amplitude. See the full documentation at [React Native SDK](../react-native/).
+    The React Native SDK lets you send events to Amplitude. See the full documentation at [React Native SDK](../typescript-react-native/).
 
     !!!info "Table of Contents"
         1. [Initialize the library](#initialize-the-library_6)

--- a/docs/data/sdks/typescript-react-native/ampli.md
+++ b/docs/data/sdks/typescript-react-native/ampli.md
@@ -7,7 +7,7 @@ description: The Ampli Wrapper - React Native Installation & Quick Start guide.
 
 Amplitude Data supports tracking analytics events from React Native apps written in JavaScript (ES6 and higher) and TypeScript (2.1 and higher). The generated tracking library is packaged as a CJS module.
 
-!!!beta "Ampli React Native Resources"
+!!!info "Ampli React Native Resources"
     [:material-language-typescript: TypeScript Example](https://github.com/amplitude/ampli-examples/tree/main/react-native/typescript/v2/AmpliApp) · [:material-nodejs: JavaScript Example](https://github.com/amplitude/ampli-examples/tree/main/react-native/javascript/v2/AmpliApp) · [:material-code-tags-check: Releases](https://www.npmjs.com/package/@amplitude/ampli?activeTab=versions)
 
 --8<-- "includes/ampli-vs-amplitude-link-to-core-sdk.md"

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -1,5 +1,5 @@
 ---
-title: React Native SDK (Beta)
+title: React Native SDK
 description: The Amplitude React Native SDK Installation & Quick Start guide.
 icon: simple/react
 ---
@@ -8,7 +8,7 @@ icon: simple/react
 
 The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native).
 
-!!!beta "React Native SDK Resources (Beta)"
+!!!info "React Native SDK Resources"
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
 
 --8<-- "includes/ampli-vs-amplitude.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -431,7 +431,7 @@ nav:
         - Ampli Codegen: data/sdks/java/ampli.md
       - React Native:
         - data/sdks/typescript-react-native/index.md
-        - Ampli Codegen (Beta): data/sdks/typescript-react-native/ampli.md
+        - Ampli Codegen: data/sdks/typescript-react-native/ampli.md
       - Flutter:
         - data/sdks/flutter/index.md
       - Python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -429,7 +429,7 @@ nav:
       - Java:
         - data/sdks/java/index.md
         - Ampli Codegen: data/sdks/java/ampli.md
-      - React Native (Beta):
+      - React Native:
         - data/sdks/typescript-react-native/index.md
         - Ampli Codegen (Beta): data/sdks/typescript-react-native/ampli.md
       - Flutter:


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Removes beta label from new react native sdk

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
@caseyamp