### PR TITLE
AMP-68175: add identify volume reduction in Android doc

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -276,7 +276,8 @@ To force the SDK to upload unsent events, the use the method `uploadEvents`.
 
 Identify is for setting the user properties of a particular user without sending any event.
  The SDK supports these operations on individual user properties: `set`, `setOnce`, `unset`, `add`, `append`, `prepend`, `preInsert`, `postInsert`, and `remove`. Declare the operations via a provided Identify interface. You can chain together multiple operations in a single Identify object.
-  The Identify object is passed to the Amplitude client to send to the server.
+  The Identify object is passed to the Amplitude client to send to the server. Starting from release v2.29.0, identify events with set operations would be batched and sent with fewer events. This change wouldn't affect running the set operations. There is a config `identifyBatchIntervalMillis` managing the interval
+  to flush the batched identify intercepts.
 
 !!!note
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- add identify volume reduction in developer doc

## Deadline




## Change type

- [ ] Doc bug fix. Fixes #[AMP-68175]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[AMP-68175]: https://amplitude.atlassian.net/browse/AMP-68175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ