### PR TITLE
AMP-68179 add legacy android configuration section

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -156,6 +156,7 @@ Accurate session tracking requires that you enable `enableForegroundTracking(ge
     ```
 
 #### Configuration
+
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -155,6 +155,23 @@ Accurate session tracking requires that you enable `enableForegroundTracking(ge
     val sameClient = Amplitude.getInstance("Andy_Client")
     ```
 
+#### Configuration
+???config "Configuration Options"
+    | <div class="big-column">Name</div>  | Description | Default Value |
+    | --- | --- | --- |
+    | `eventUploadPeriodMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `eventUploadThreshold` threshold. | `30000` |
+    | `eventUploadThreshold` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `eventUploadPeriodMillis` interval.  | `30` |
+    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/` |
+    | `identifyBatchIntervalMillis` | The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
+    | `sessionTimeoutMillis` | The amount of time for session timeout if enable foreground tracking. | `1800000` |
+    | `eventUploadMaxBatchSize` | The maximum number of events sent with each upload request. | `50` |
+    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `eventMaxCount` | The maximum number of unsent events to keep on the device. | `1000` |
+    | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
+    | `trackingSessionEvents` | Flushing of unsent events on app close. | `false` |
+    | `useDynamicConfig` |  Find the best server url automatically based on users' geo location. | `false` |
+    | `optOut` | Opt the user out of tracking. | `false` |
+
 #### EU data residency
 
 Beginning with version 2.34.0, you can configure the server zone after initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -162,16 +162,16 @@ Accurate session tracking requires that you enable `enableForegroundTracking(ge
     | --- | --- | --- |
     | `eventUploadPeriodMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `eventUploadThreshold` threshold. | `30000` |
     | `eventUploadThreshold` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `eventUploadPeriodMillis` interval.  | `30` |
-    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/` |
-    | `identifyBatchIntervalMillis` | The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
-    | `sessionTimeoutMillis` | The amount of time for session timeout if enable foreground tracking. | `1800000` |
     | `eventUploadMaxBatchSize` | The maximum number of events sent with each upload request. | `50` |
-    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
     | `eventMaxCount` | The maximum number of unsent events to keep on the device. | `1000` |
+    | `identifyBatchIntervalMillis` | The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
     | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
-    | `trackingSessionEvents` | Flushing of unsent events on app close. | `false` |
-    | `useDynamicConfig` |  Find the best server url automatically based on users' geo location. | `false` |
     | `optOut` | Opt the user out of tracking. | `false` |
+    | `trackingSessionEvents` | Flushing of unsent events on app close. | `false` |
+    | `sessionTimeoutMillis` | The amount of time for session timeout if enable foreground tracking. | `1800000` |
+    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/` |
+    | `useDynamicConfig` |  Find the best server url automatically based on users' geo location. | `false` |
 
 #### EU data residency
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

 - Add configuration section for legacy Android SDK
 - We could discuss further how we prefer this section to be aligned.

## Deadline




## Change type

- [ ] Doc bug fix. Fixes #[AMP-68179]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[AMP-68179]: https://amplitude.atlassian.net/browse/AMP-68179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ