### PR TITLE
DDI-422 Add Dedupe Section to Amazon S3 import

### DIFF
--- a/.github/styles/Vocab/dev/accept.txt
+++ b/.github/styles/Vocab/dev/accept.txt
@@ -29,6 +29,7 @@ deduplicated
 deduplicate
 deduplicates
 deduplication
+Deduplication
 enqueued
 Enterpret
 Fastly

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -57,7 +57,7 @@ For each Amplitude project, AWS S3 import can ingest:
 
 ### Deduplication with `insert_id`
 
-Amplitude uses a unique identifier, `insert_id`, to match against incoming events to prevent duplicates. If a new event with an `insert_id` is uploaded to Amplitude within 7 days of a previous event with the same `insert_id`, Amplitude drops the new event.
+Amplitude uses a unique identifier, `insert_id`, to match against incoming events to prevent duplicates. If a new event with a specific `insert_id` is uploaded to Amplitude within 7 days of a previous event with the same `insert_id`, Amplitude drops the new event.
 
 Amplitude highly recommends that you set a custom `insert_id` for each event to prevent duplication. To set a custom `insert_id`, create a field that holds unique values, like random alphanumeric strings, in your dataset. Map the field as an additional property named `insert_id` in the guided converter configuration.
 

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -55,6 +55,12 @@ For each Amplitude project, AWS S3 import can ingest:
 - Up to 50 files per second.
 - Up to 30k events per second.
 
+### Deduplication with `insert_id`
+
+Amplitude uses a unique identifier, `insert_id`, to match against incoming events to prevent duplicates. If a new event with an `insert_id` is uploaded to Amplitude within 7 days of a previous event with the same `insert_id`, Amplitude drops the new event.
+
+Amplitude highly recommends that you set a custom `insert_id` for each event to prevent duplication. To set a custom `insert_id`, create a field that holds unique values, like random alphanumeric strings, in your dataset. Map the field as an additional property named `insert_id` in the guided converter configuration.
+
 ## Set up Amazon S3 Import in Amplitude
 
 When your dataset is ready for ingestion, you can set up Amazon S3 Import in Amplitude.


### PR DESCRIPTION
# Amplitude Developer Docs PR

Adds dedupe section for using `insert_id`

## Deadline

ASAP

## Change type

- [X] Doc update.


# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.

