### PR TITLE
Update accounts-instrumentation-guide.md

### DIFF
--- a/docs/guides/accounts-instrumentation-guide.md
+++ b/docs/guides/accounts-instrumentation-guide.md
@@ -143,7 +143,7 @@ Validate your test instrumentation using the [Taxonomy & Data QA](https://docs.g
 
 Group values must be unique and because of this are typically numeric. Amplitude recommends that you send a group property that's human-readable and clearly distinguishes the group from others so you can segment and group by this property in Amplitude.
 
-!!!example "Group prop
+!!!example "Group prop"
 
     Consider this example where an "Account Name" group property is sent. You can use the "Account Name" property for a human-readable version of the group value.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Adds missing double quote to example Group prop

## Deadline

N/A. Simple bug fix.


## Change type

- [x] Doc bug fix. Fixes #[AMP-69222]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.

@amplitude-dev-docs


[AMP-69222]: https://amplitude.atlassian.net/browse/AMP-69222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ