### PR TITLE
SKY-2567 add delayed exposure event information

### DIFF
--- a/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
+++ b/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
@@ -19,7 +19,7 @@ Exposure without assignment may also affect future experiments, so you should in
 
 !!!note
 
-    Sometimes the exposure event is delayed and is sent on a different day than the assignment event is sent. For example, the assignment event is sent today and the exposure event is sent tomorrow. The thing here to check for is if between the time the assignment event is sent and the exposure event is sent the user's user properties change where they either should not be targeted anymore or shout be targeted then there is an issue. Otherwise, you can ignore this warning.
+    Sometimes the exposure event is delayed and is sent on a different day than the assignment event. For example, the assignment event is sent today and the exposure event is sent tomorrow. You should check for an issue if between the assignment and exposure events being sent, the user's user properties have changed in a way that affects whether they should be targeted. Otherwise, you can ignore this warning.
 
 ## Causes
 

--- a/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
+++ b/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
@@ -19,7 +19,7 @@ Exposure without assignment may also affect future experiments, so you should in
 
 !!!note
 
-    Sometimes the exposure event is delayed and is sent on a different day than the assignment event. For example, the assignment event is sent today and the exposure event is sent tomorrow. You should check for an issue if between the assignment and exposure events being sent, the user's user properties have changed in a way that affects whether they should be targeted. Otherwise, you can ignore this warning.
+    Sometimes the exposure event is delayed and is sent on a different day than the assignment event. For example, the assignment event is sent today and the exposure event is sent tomorrow. There may be an issue if, between the assignment and exposure events being sent, the user's user properties have changed in a way that affects whether they should be targeted. Otherwise, you can ignore this warning.
 
 ## Causes
 

--- a/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
+++ b/docs/experiment/guides/troubleshooting/exposures-without-assignments.md
@@ -17,6 +17,10 @@ Exposure without assignment may also affect future experiments, so you should in
 
     This chart doesn't appear if you selected assignment event as the exposure event or if you are using [local evaluation](../../general/evaluation/local-evaluation.md). 
 
+!!!note
+
+    Sometimes the exposure event is delayed and is sent on a different day than the assignment event is sent. For example, the assignment event is sent today and the exposure event is sent tomorrow. The thing here to check for is if between the time the assignment event is sent and the exposure event is sent the user's user properties change where they either should not be targeted anymore or shout be targeted then there is an issue. Otherwise, you can ignore this warning.
+
 ## Causes
 
 A significant number of users in the Exposures without Assignments chart could be caused by a few different scenarios, such as: 


### PR DESCRIPTION
# Amplitude Developer Docs PR
This is what we talked about today with regards to the delayed exposure event. assignment was before the email is sent and exposure is when the email is opened. https://experiment.amplitude.com/roofr1/328890/config/30409/monitor

## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
