### PR TITLE
DDI 424 [Contextual Doc] Use "maintenance" over "legacy"

### DIFF
--- a/docs/data/ampli/plugin.md
+++ b/docs/data/ampli/plugin.md
@@ -6,7 +6,7 @@ template: guide.html
 ---
 
 !!!note
-    Plugins are supported in the latest version of Ampli when used in conjunction with the [new Amlitude browser SDKs](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/). If you are using an older version of Ampli or a [legacy Amplitude SDK](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/), see **[Middleware](../middleware/)**.
+    Plugins are supported in the latest version of Ampli when used in conjunction with the [new Amplitude browser SDKs](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/). If you are using an older version of Ampli or a [Maintenance Amplitude SDK](https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/), see **[Middleware](../middleware/)**.
 
 Plugins allow you to extend the Amplitude behavior. For example use plugins to modify event properties (enrichment type) or send data to a third-party APIs (destination type). This is a replacement for Middleware in Ampli legacy.
 This pattern is flexible and you can use it to support event enrichment, transformation, filtering, routing to third-party destinations, and more. A plugin is an object with methods `setup()` and `execute()`.

--- a/docs/data/deprecated-sdks/android.md
+++ b/docs/data/deprecated-sdks/android.md
@@ -153,7 +153,7 @@ The new Android SDK enjoys a simpler deployment model and introduces several new
 
 ### Tracking Plan Changes
 
-- Update your source's runtime from **Android — Kotlin (Legacy)** to **Android — Kotlin**
+- Update your source's runtime from **Android — Kotlin (Maintenance)** to **Android — Kotlin**
 
 ### Android Studio Changes
 

--- a/docs/data/deprecated-sdks/browser.md
+++ b/docs/data/deprecated-sdks/browser.md
@@ -497,7 +497,7 @@ The new Browser SDK introduces several new features to help developers implement
 
 ### Tracking Plan Changes
 
-- Update your source's runtime to **Browser — JavaScript** or **Browser — TypeScript** (from **Browser — JavaScript (Legacy)** or **Browser — TypeScript (Legacy)**, respectively)
+- Update your source's runtime to **Browser — JavaScript** or **Browser — TypeScript** (from **Browser — JavaScript (Maintenance)** or **Browser — TypeScript (Maintenance)**, respectively)
 
 ### CLI & Code Changes
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -1,5 +1,5 @@
 ---
-title: Android SDK (Legacy)
+title: Android SDK (Maintenance)
 description: The Amplitude Android SDK installation and quick start guide.
 icon: simple/android
 ---
@@ -10,10 +10,10 @@ icon: simple/android
 
 This is the official documentation for the Amplitude Analytics Android SDK.
 
-!!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. Upgrade to the [Android Kotlin SDK](../android-kotlin) which supports plugins, SDK integrations, and more.
+!!!deprecated "Maintenance SDK"
+    This is a maintenance SDK and will only receive bug fixes until deprecation. Upgrade to the [Android Kotlin SDK](../android-kotlin) which supports plugins, SDK integrations, and more.
 
-!!!info "Android SDK Resources (Legacy)"
+!!!info "Android SDK Resources (Maintenance)"
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-Android) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Android/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-Android)
 
 --8<-- "includes/ampli-vs-amplitude.md"

--- a/docs/data/sdks/ios-swift/migration.md
+++ b/docs/data/sdks/ios-swift/migration.md
@@ -1,6 +1,6 @@
 ---
 title: iOS SDK Migration Guide
-description: Use this guide to easily migrate from Amplitude's legacy iOS SDK (Amplitude-iOS) to the new SDK (Amplitude-Swift).
+description: Use this guide to easily migrate from Amplitude's maintenance iOS SDK (Amplitude-iOS) to the new SDK (Amplitude-Swift).
 ---
 
 The new version of Amplitude's iOS SDK (`Amplitude-Swift`) features a plugin architecture, built-in type definition and broader support for front-end frameworks. The new version isn't backwards compatible with `Amplitude-iOS`. 
@@ -9,7 +9,7 @@ To migrate to `Amplitude-Swift`, update your dependencies and instrumentation.
 
 ## Terminology
 
-* `Amplitude-iOS`: Legacy iOS SDK
+* `Amplitude-iOS`: Maintenance iOS SDK
 * `Amplitude-Swift`: New iOS SDK
 
 ## Dependency
@@ -57,7 +57,7 @@ This SDK offers an API to instrument events. To migrate to the new SDK, you need
 
 ### Initialization
 
-Like all other calls, `instance()` has been removed. Configuration is handled differently between the legacy iOS and new iOS SDK. The new iOS SDKs use the Configuration object to set the configuration. See [Configuration](#configuration).
+Like all other calls, `instance()` has been removed. Configuration is handled differently between the maintenance iOS and new iOS SDK. The new iOS SDKs use the Configuration object to set the configuration. See [Configuration](#configuration).
 
 === "Amplitude-iOS"
 
@@ -124,7 +124,7 @@ The configurations for the new SDK are simpler and more consistent across runtim
 
 ### Tracking events
 
-The legacy iOS SDK offered a variety of `logEvent` APIs with `withEventProperties`, `withApiProperties`, `withUserProperties`, `withGroup`, `withGroupProperties`, `withTimestamp`, `outOfSession`, to override specific properties in the event payload. Amplitude has simplified all these variations into a unified `track` API.
+The maintenance iOS SDK offered a variety of `logEvent` APIs with `withEventProperties`, `withApiProperties`, `withUserProperties`, `withGroup`, `withGroupProperties`, `withTimestamp`, `outOfSession`, to override specific properties in the event payload. Amplitude has simplified all these variations into a unified `track` API.
 
 #### `logEvent()`
 

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -1,5 +1,5 @@
 ---
-title: JavaScript SDK (Legacy)
+title: JavaScript SDK (Maintenance)
 description: The Amplitude JavaScript SDK installation and quick start guide.
 icon: simple/javascript
 ---
@@ -9,10 +9,10 @@ icon: simple/javascript
 
 This is the official documentation for the Amplitude Analytics JavaScript SDK.
 
-!!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. Upgrade to the latest [Browser SDK](../typescript-browser/) which supports plugins and more. See the [Migration Guide](../../sdks/typescript-browser/migration) for more help.
+!!!deprecated "Maintenance SDK"
+    This is a maintenance SDK and will only receive bug fixes until deprecation. Upgrade to the latest [Browser SDK](../typescript-browser/) which supports plugins and more. See the [Migration Guide](../../sdks/typescript-browser/migration) for more help.
 
-!!!info "Browser SDK Resources (Legacy)"
+!!!info "Browser SDK Resources (Maintenance)"
     - [JavaScript Browser SDK Reference :material-book:](https://amplitude.github.io/Amplitude-JavaScript/)
     - [JavaScript Browser SDK Repository :material-github:](https://github.com/amplitude/Amplitude-JavaScript)
     - [JavaScript Browser SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Javascript/releases)

--- a/docs/data/sdks/node/index.md
+++ b/docs/data/sdks/node/index.md
@@ -1,5 +1,5 @@
 ---
-title: Node.js SDK (Legacy)
+title: Node.js SDK (Maintenance)
 description: The Amplitude Node.js SDK installation and quick start guide.
 icon: simple/nodedotjs
 ---
@@ -18,12 +18,12 @@ The Node SDK provides:
 
 By default, the Node SDK uses the [HTTP API V2](../../../analytics/apis/http-v2-api).
 
-!!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for Node.js](../typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins. 
+!!!deprecated "Maintenance SDK"
+    This is a Maintenance SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for Node.js](../typescript-node/) available in Beta. The new SDK offers an improved code architecture which supports plugins. 
     
     The Beta SDK does not yet support the [Ampli Wrapper](/data/ampli/sdk/). If you use Ampli please continue to use the non-Beta SDK at this time.
 
-!!!info "Node SDK Resources (Legacy)"
+!!!info "Node SDK Resources (Maintenance)"
     - [Node.js SDK Repository :material-github:](https://github.com/amplitude/Amplitude-Node)
     - [Node.js SDK Releases :material-code-tags-check:](https://github.com/amplitude/Amplitude-Node/releases)
 

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -1,5 +1,5 @@
 ---
-title: React Native SDK (Legacy)
+title: React Native SDK (Maintenance)
 description: The Amplitude React Native SDK installation and quick start guide.
 icon: simple/react
 ---
@@ -10,8 +10,8 @@ icon: simple/react
 
 This is the official documentation for the Amplitude Analytics React Native SDK.
 
-!!!deprecated "Legacy SDK"
-    This is a legacy SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) is available. The new SDK offers an improved code architecture which supports plugins and React Native Web.
+!!!deprecated "Maintenance SDK"
+    This is a maintenance SDK and will only receive bug fixes until deprecation. A new [Analytics SDK for React Native](../typescript-react-native/) is available. The new SDK offers an improved code architecture which supports plugins and React Native Web.
 
 !!!info "SDK Resources"
     - [React Native SDK Reference :material-book:](https://amplitude.github.io/Amplitude-ReactNative/)

--- a/docs/data/sdks/sdk-overview.md
+++ b/docs/data/sdks/sdk-overview.md
@@ -3,7 +3,7 @@ title: SDK Catalog
 description: Browse all of Amplitude's current SDK offerings.
 ---
 
-Browse all Amplitude's current SDK offerings. Legacy SDKs are listed in the side navigation. 
+Browse all Amplitude's current SDK offerings. Maintenance SDKs are listed in the side navigation. 
 
 !!!tip "Quickstart Guide"
 

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -1,6 +1,6 @@
 ---
 title: Browser SDK Migration Guide
-description: Use this guide to easily migrate from Amplitude's legacy browser SDK (amplitude-js) to the new SDK (@amplitude/analytics-browser).
+description: Use this guide to easily migrate from Amplitude's maintenance browser SDK (amplitude-js) to the new SDK (@amplitude/analytics-browser).
 ---
 
 The new version of Amplitude's Browser SDK (`@amplitude/analytics-browser`) features a plugin architecture, built-in type definition and broader support for front-end frameworks. The new version isn't backwards compatible with `amplitude-js`. 
@@ -9,7 +9,7 @@ To migrate to `@amplitude/analytics-browser`, update your dependencies and instr
 
 ### Terminology
 
-* `amplitude-js`: Legacy Browser SDK
+* `amplitude-js`: Maintenance Browser SDK
 * `@amplitude/analytics-browser`: New Browser SDK
 
 ## Dependency
@@ -120,7 +120,7 @@ The new Browser SDK configuration comes in a different shape. The configurations
 
 ### Tracking events
 
-The legacy Browser SDK offered a variety of `logEvent` APIs like `logEventWithTimestamp`, `logEventWithGroups` to override specific properties in the event payload. Amplitude has simplified all these variations into a unified `track` API in `@amplitude/analytics-browser`.
+The maintenance Browser SDK offered a variety of `logEvent` APIs like `logEventWithTimestamp`, `logEventWithGroups` to override specific properties in the event payload. Amplitude has simplified all these variations into a unified `track` API in `@amplitude/analytics-browser`.
 
 #### `logEvent()`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -370,7 +370,7 @@ nav:
         - JVM SDK: experiment/sdks/jvm-sdk.md
         - Go SDK: experiment/sdks/go-sdk.md
         - Python SDK: experiment/sdks/python-sdk.md
-        - Legacy:
+        - Maintenance:
           - React Native SDK: experiment/sdks/react-native-sdk-legacy.md
       - REST APIs:
         - Evaluation API: experiment/apis/evaluation-api.md
@@ -449,7 +449,7 @@ nav:
       - Go:
         - data/sdks/go/index.md
         - Ampli Codegen: data/sdks/go/ampli.md
-    - Legacy SDKs:
+    - Maintenance SDKs:
       - Browser:
         - data/sdks/javascript/index.md
         - Ampli Codegen: data/sdks/javascript/ampli.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Currently we use “legacy” in our dev doc for old version SDKs. It sounds too negative and customers usually don’t want to use it. But actually we still support bug fixes for these old SDKs. So after [discussion](https://amplitude.slack.com/archives/C04J4LN147Q/p1676323676183759), we agree to use “maintenance” over “legacy”.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
