### PR TITLE
DDI 408 [Contextual Doc] GTM Guide - Add EU

### DIFF
--- a/docs/data/sources/google-tag-manager-client-legacy.md
+++ b/docs/data/sources/google-tag-manager-client-legacy.md
@@ -14,3 +14,7 @@ This is the client-side Google Tag Manager Template for Amplitude Analytics. The
 This video tutorial walks through the implementation basics. 
 
 <script src="https://fast.wistia.com/embed/medias/ks4mh1i79u.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_ks4mh1i79u videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/ks4mh1i79u/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+
+## EU data residency 
+
+For EU data residency, you must set up your project inside Amplitude EU and use the API key from Amplitude EU. You can configure the server zone by checking the checkbox **EU Data Residency** under **Tag Configuration** -> **Initialization**.

--- a/docs/data/sources/google-tag-manager-client.md
+++ b/docs/data/sources/google-tag-manager-client.md
@@ -13,3 +13,7 @@ It’s important to create an `init` tag. It's common to fire the `init` tag usi
 This video tutorial walks through the implementation basics. 
 
 <script src="https://fast.wistia.com/embed/medias/n337njhoot.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_n337njhoot videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/n337njhoot/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+
+## EU data residency 
+
+For EU data residency, you must set up your project inside Amplitude EU and use the API key from Amplitude EU. You can configure the server zone by checking the checkbox **EU Data Residency** under **Tag Configuration** -> **Initialization** of the `init` tag. The initialization section only shows up when tag type is set to init. 

--- a/docs/data/sources/google-tag-manager-client.md
+++ b/docs/data/sources/google-tag-manager-client.md
@@ -8,7 +8,7 @@ This is the client-side Google Tag Manager Template for Amplitude Analytics. The
 !!!info Resources
     [:simple-googletagmanager: GTM Template Gallery](https://tagmanager.google.com/gallery/#/owners/amplitude/templates/amplitude-browser-sdk-gtm-template) · [:material-github: GitHub](https://github.com/amplitude/amplitude-browser-sdk-gtm-template)
 
-With this template, you can defer the `init` tag until you receive a signal, like a consent grant. It's also common to fire the `init` tag using `All Pages` or `Initialization - All Pages` triggers. But make sure to fire the `init` tag **before** any other tags. The legacy template automatically calls init, so there's no need to do it yourself.
+It’s important to create an `init` tag. It's common to fire the `init` tag using `All Pages` or `Initialization - All Pages` triggers. With this template, you can also defer the `init` tag until you receive a signal, such as a consent grant. But notice that all other tags wait for the `init` tag to fire before they can be sent to Amplitude. The legacy template automatically calls init, so there's no need to do it yourself.
 
 This video tutorial walks through the implementation basics. 
 

--- a/docs/data/sources/google-tag-manager-client.md
+++ b/docs/data/sources/google-tag-manager-client.md
@@ -8,7 +8,7 @@ This is the client-side Google Tag Manager Template for Amplitude Analytics. The
 !!!info Resources
     [:simple-googletagmanager: GTM Template Gallery](https://tagmanager.google.com/gallery/#/owners/amplitude/templates/amplitude-browser-sdk-gtm-template) · [:material-github: GitHub](https://github.com/amplitude/amplitude-browser-sdk-gtm-template)
 
-It’s important to create an `init` tag. It's common to fire the `init` tag using `All Pages` or `Initialization - All Pages` triggers. With this template, you can also defer the `init` tag until you receive a signal, such as a consent grant. But notice that all other tags wait for the `init` tag to fire before they can be sent to Amplitude. The legacy template automatically calls init, so there's no need to do it yourself.
+It’s important to create an `init` tag. It's common to fire the `init` tag using `All Pages` or `Initialization - All Pages` triggers. With this template, you can also defer the `init` tag until you receive a signal and fire it using customized triggers, such as a consent grant. But notice that all other tags wait for the `init` tag to fire before they can be sent to Amplitude. The legacy template automatically calls init, so there's no need to do it yourself.
 
 This video tutorial walks through the implementation basics. 
 

--- a/docs/data/sources/google-tag-manager-server.md
+++ b/docs/data/sources/google-tag-manager-server.md
@@ -11,3 +11,7 @@ This is the server-side Google Tag Manager Template for Amplitude Analytics. The
 This video tutorial walks through the implementation basics. 
 
 <script src="https://fast.wistia.com/embed/medias/hznp0gi3gj.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:56.25% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_hznp0gi3gj videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/hznp0gi3gj/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
+
+## EU data residency 
+
+For EU data residency, you must set up your project inside Amplitude EU and use the API key from Amplitude EU. You can configure the server zone by and checking the checkbox **Use EU Residency Server** under **Tag Configuration**.

--- a/docs/data/sources/google-tag-manager.md
+++ b/docs/data/sources/google-tag-manager.md
@@ -34,7 +34,10 @@ Use GTM client-side templates to track user interactions on a website. Use serve
 
 ### Create a tag
 
-After installing the template, you can then use that template to create a tag. 
+After installing the template, you can then use that template to create a tag.
+
+!!!note EU data residency
+    Consult the corresponding template document for more information and EU configuration.
 
 1. Go to the **Tags** tab in your Google Tag Manager Workspace and click **New**.
 2. Select the Amplitude GTM Template from the list of available templates under **Tag Configuration**. If you haven't installed an Amplitude GTM Template, [install the template](./#install-the-template) first.


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

- Rephrased the description of `init` tag in GTM. 
- Added EU config instructions

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
