### PR TITLE
DDI 415 [Contextual Doc] Documentation Home Page 

### DIFF
--- a/docs/documentation-home.md
+++ b/docs/documentation-home.md
@@ -28,7 +28,7 @@ The Amplitude Developer Center has everything you need to instrument Amplitude. 
 
     ---
 
-    Amplitude Data lets you integrate, resolve and manage a complete, comprehensive view of your customer and product data. 
+    Amplitude Data lets you collect and govern user data, build customer profiles with CDP integrated with analytics.
 
     [:octicons-arrow-right-24: See the Data docs](../data/)
 

--- a/docs/documentation-home.md
+++ b/docs/documentation-home.md
@@ -28,7 +28,7 @@ The Amplitude Developer Center has everything you need to instrument Amplitude. 
 
     ---
 
-    Amplitude Data lets you collect and govern user data, build customer profiles with CDP integrated with analytics.
+    Amplitude Data lets you capture, manage, and improve the quality of your customer and product data across Amplitude.
 
     [:octicons-arrow-right-24: See the Data docs](../data/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ toplevel: true
 
     ---
 
-    Amplitude Data lets you integrate, resolve and manage a complete, comprehensive view of your customer and product data. 
+    Amplitude Data lets you collect and govern user data, build customer profiles with CDP integrated with analytics. 
 
     [:octicons-arrow-right-24: See the Data docs](../data/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ toplevel: true
 
     ---
 
-    Amplitude Data lets you collect and govern user data, build customer profiles with CDP integrated with analytics. 
+    Amplitude Data lets you capture, manage, and improve the quality of your customer and product data across Amplitude.
 
     [:octicons-arrow-right-24: See the Data docs](../data/)
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

The Amplitude Data Section misses import parts of Amplitude Data: data collection, and data governance/ CDP. 

Altered the sentence for context of what Amplitude Data is from 
>  Amplitude Data lets you integrate, resolve and manage a complete, comprehensive view of your customer and product data. 

to 

> Amplitude Data lets you capture, manage, and improve the quality of your customer and product data across Amplitude.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
