### PR TITLE
Update npm version badge logo

### DIFF
--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -5,7 +5,7 @@ icon: simple/typescript
 ---
 
 
-![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-browser.svg)
+![npm version](https://badge.fury.io/js/amplitude.svg)
 
 The Browser SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 


### PR DESCRIPTION
Update npm version badge with correct URL: https://badge.fury.io/js/amplitude.svg

# Amplitude Developer Docs PR


## Description

Update npm logo link, as per: https://badge.fury.io/for/js/amplitude

## Deadline

Soon, as the current link is broken

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [x] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
