### PR TITLE
Adding Time-based import section explainer

### DIFF
--- a/docs/data/sources/bigquery.md
+++ b/docs/data/sources/bigquery.md
@@ -56,6 +56,14 @@ To add BigQuery as a data source in your Amplitude project, follow these steps.
 
 If you have any issues or questions while following this flow, contact the Amplitude team.
 
+## Time-based import
+
+For Amplitude's time-based import option, it's best practice to use a monotonically increasing timestamp value. This value should indicate **when** the record was loaded into the source table the SQL configuration is querying from (often referred to as a "server upload time"). The warehouse import tool brings data into Amplitude is by continually updating the maximum value of the column referenced in the *Timestamp Column Name* input within the Import Config UI with each subsequent import.
+
+!!!example
+
+    Upon first import, Amplitude imports all the data returned from the query configured in the Import Config. Amplitude saves a reference of the maximum timestamp referenced in the *Timestamp Column Name*: `timestamp_1`. Upon subsequent import, Amplitude imports all data from the previously saved timestamp (`timestamp_1`), to what's now the new maximum timestamp (`timestamp_2`). After that import, Amplitude saves `timestamp_2` as the new maximum timestamp.
+
 ## Mandatory data fields
 
 You must include the mandatory fields for the data type when creating the SQL query. These tables outline the mandatory and optional fields for each data type. You can include other columns beyond those listed here.


### PR DESCRIPTION
adding a section to explain how time-based import works for BigQuery; similar to what we have for Snowflake–might make sense to make into a snippet eventually...

# Amplitude Developer Docs PR


## Description

Describe your changes. 
adding a section to explain how time-based import works for BigQuery; similar to what we have for Snowflake–might make sense to make into a snippet eventually...

## Deadline

When do these changes need to be live on the site?
ASAP :)

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
