### PR TITLE
update ampli.md with rn-async-storage

### DIFF
--- a/docs/data/sdks/typescript-react-native/ampli.md
+++ b/docs/data/sdks/typescript-react-native/ampli.md
@@ -26,7 +26,7 @@ Amplitude Data supports tracking analytics events from React Native apps written
 1. [Install the Amplitude SDK](#install-the-amplitude-sdk)
 
     ```shell
-    npm install @amplitude/analytics-react-native
+    npm install @amplitude/analytics-react-native @react-native-async-storage/async-storage
     ```
 
 2. [Install the Ampli CLI](#install-the-ampli-cli)
@@ -85,13 +85,13 @@ If you haven't already, install the core Amplitude SDK dependencies.
 === "npm"
 
     ```bash
-    npm install @amplitude/analytics-react-native
+    npm install @amplitude/analytics-react-native @react-native-async-storage/async-storage
     ```
 
 === "yarn"
 
     ```bash
-    yarn add @amplitude/analytics-react-native
+    yarn add @amplitude/analytics-react-native @react-native-async-storage/async-storage
     ```
 
 --8<-- "includes/ampli/cli-install-simple.md"


### PR DESCRIPTION


# Amplitude Developer Docs PR
- Update the React Native Ampli Wrapper doc to include react native async storage installation

## Description

Added the @react-native-async-storage/async-storage library to the React Native Ampli Wrapper installation guide, since it is required for the React Native SDK to work properly

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
