### PR TITLE
AMP-69871 add identify volume reduction and configuration in android kotlin

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -60,7 +60,7 @@ amplitude.track(
 ### `identify`
 
 Identify is for setting the user properties of a particular user without sending any event. The SDK supports the operations `set`, `setOnce`, `unset`, `add`, `append`, `prepend`, `preInsert`, `postInsert`, and `remove` on individual user properties. Declare the operations via a provided Identify interface. You can chain together multiple operations in a single Identify object. The Identify object is then passed to the Amplitude client to send to the server.
-Starting from release v1.7.0, identify events with set operations would be batched and sent with fewer events. This change wouldn't affect running the set operations. There is a config `identifyBatchIntervalMillis` managing the interval to flush the batched identify intercepts.
+Starting from release v1.7.0, identify events with only set operations will be batched and sent with fewer events. This change won't affect running the set operations. There is a config `identifyBatchIntervalMillis` managing the interval to flush the batched identify intercepts.
 
 !!!note
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -22,6 +22,30 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
 
 ## Usage
 
+### `Configuration`
+
+???config "Configuration Options"
+    | <div class="big-column">Name</div>  | Description | Default Value |
+    | --- | --- | --- |
+    | `flushIntervalMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
+    | `flushQueueSize` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
+    | `flushMaxRetries` | Maximum retry times.  | `5` |
+    | `minIdLength` | The minimum length for user id or device id. | `5` |
+    | `partnerId` | The partner id for partner integration. | `null` |
+    | `identifyBatchIntervalMillis` | The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
+    | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
+    | `callback` | Callback function after event sent. | `null` |
+    | `optOut` | Opt the user out of tracking. | `false` |
+    | `trackingSessionEvents` | Flushing of unsent events on app close. | `false` |
+    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
+    | `serverZone` |  The server zone to send to, will adjust server url based on this config. | `US` |
+    | `useBatch` |  Whether to use batch api. | `false` |
+    | `useAdvertisingIdForDeviceId` |  Whether to use advertising id as device id. Need to include the module and permission. | `false` |
+    | `useAppSetIdForDeviceId` |  Whether to use app ser id as device id. Need to include the module and permission. | `false` |
+    | `trackingOptions` |  Options to control the values tracked in SDK. | `enable` |
+    | `enableCoppaControl` |  Whether to enable coppa control for tracking options. | `false` |'
+
 ### `track`
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
@@ -36,6 +60,7 @@ amplitude.track(
 ### `identify`
 
 Identify is for setting the user properties of a particular user without sending any event. The SDK supports the operations `set`, `setOnce`, `unset`, `add`, `append`, `prepend`, `preInsert`, `postInsert`, and `remove` on individual user properties. Declare the operations via a provided Identify interface. You can chain together multiple operations in a single Identify object. The Identify object is then passed to the Amplitude client to send to the server.
+Starting from release v1.7.0, identify events with set operations would be batched and sent with fewer events. This change wouldn't affect running the set operations. There is a config `identifyBatchIntervalMillis` managing the interval to flush the batched identify intercepts.
 
 !!!note
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- add doc about identify volume eduction
- add configuration section

## Deadline



## Change type

- [ ] Doc bug fix. Fixes #[AMP-69871]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[AMP-69871]: https://amplitude.atlassian.net/browse/AMP-69871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ