### PR TITLE
Adds docs for default event tracking

### DIFF
--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -49,77 +49,35 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
 
     --8<-- "includes/sdk-quickstart/quickstart-initialization.md"
 
-    === "Classic script"
-
-        ```ts
-        amplitude.init(AMPLITUDE_API_KEY);
-        ```
-
-    === "Module script"
-
-        ```js
-        import * as amplitude from '@amplitude/analytics-browser';
-
-        amplitude.init(AMPLITUDE_API_KEY);
-        ```
+    ```ts
+    amplitude.init(AMPLITUDE_API_KEY);
+    ```
 
     --8<-- "includes/sdk-quickstart/quickstart-send-data.md"
 
-    === "Classic script"
-
-        ```ts
-        const eventProperties = {
-          buttonColor: 'primary',
-        };
-        amplitude.track('Button Clicked', eventProperties);
-        ```
-
-    === "Module script"
-
-        ```js
-        import * as amplitude from '@amplitude/analytics-browser';
-
-        const eventProperties = {
-          buttonColor: 'primary',
-        };
-        amplitude.track('Button Clicked', eventProperties);
-        ```
+    ```ts
+    const eventProperties = {
+        buttonColor: 'primary',
+    };
+    amplitude.track('Button Clicked', eventProperties);
+    ```
 
     --8<-- "includes/sdk-quickstart/quickstart-check-for-success.md"
 
     --8<-- "includes/sdk-quickstart/quickstart-complete-code-example.md"
 
-    === "Classic script"
+    ```ts
+    amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com');
+    const eventProperties = {
+        buttonColor: 'primary',
+    };
 
-        ```ts
-        amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com');
-        const eventProperties = {
-            buttonColor: 'primary',
-        };
+    const identifyObj = new Identify();
+    identifyObj.set('location', 'LAX');
+    amplitude.identify(identifyObj);
 
-        const identifyObj = new Identify();
-        identifyObj.set('location', 'LAX');
-        amplitude.identify(identifyObj);
-
-        amplitude.track('Button Clicked', eventProperties);
-        ```
-
-    === "Module script"
-
-        ```js
-        import * as amplitude from '@amplitude/analytics-browser';
-
-        amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com');
-        const eventProperties = {
-            buttonColor: 'primary',
-        };
-
-        const identifyObj = new Identify();
-        identifyObj.set('location', 'LAX');
-        amplitude.identify(identifyObj);
-
-        amplitude.track('Button Clicked', eventProperties);
-        ```
+    amplitude.track('Button Clicked', eventProperties);
+    ```
 
     Learn more available functionalities in [Browser SDK](../typescript-browser/).
 

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -27,6 +27,14 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
         
     Install the dependency using NPM, YARN, or script loader.
 
+    === "Script loader"
+        This package is also distributed through a CDN. Copy and paste this script in your HTML file.
+        ```html
+
+        <script type="text/javascript">
+        !function(){"use strict";!function(e,t){var r=e.amplitude||{_q:[],_iq:[]};if(r.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var n=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},s=function(e,t,r){return function(n){e._q.push({name:t,args:Array.prototype.slice.call(r,0),resolve:n})}},o=function(e,t,r){e[t]=function(){if(r)return{promise:new Promise(s(e,t,Array.prototype.slice.call(arguments)))}}},i=function(e){for(var t=0;t<y.length;t++)o(e,y[t],!1);for(var r=0;r<g.length;r++)o(e,g[r],!0)};r.invoked=!0;var c=t.createElement("script");c.type="text/javascript",c.integrity="sha384-lyGcqRAilM5YOiZT3ktByF3Mv52pltOelJ66zwfcAZ/4s8cB1sSo7yMF2XWh+bzX",c.crossOrigin="anonymous",c.async=!0,c.src="https://cdn.amplitude.com/libs/analytics-browser-1.6.8-min.js.gz",c.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var a=t.getElementsByTagName("script")[0];a.parentNode.insertBefore(c,a);for(var u=function(){return this._q=[],this},l=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],p=0;p<l.length;p++)n(u,l[p]);r.Identify=u;for(var d=function(){return this._q=[],this},v=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],f=0;f<v.length;f++)n(d,v[f]);r.Revenue=d;var y=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset"],g=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];i(r),r.createInstance=function(){var e=r._iq.push({_q:[]})-1;return i(r._iq[e]),r._iq[e]},e.amplitude=r}}(window,document)}();
+        </script>
+        ```
     === "NPM"
         ```bash
 
@@ -39,121 +47,92 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
         yarn add @amplitude/analytics-browser
         ```
 
-    === "Script loader"
-        This package is also distributed through a CDN. Copy and paste this script in your HTML file.
-        ```html
-
-        <script type="text/javascript">
-        !function(){"use strict";!function(e,t){var r=e.amplitude||{_q:[],_iq:[]};if(r.invoked)e.console&&console.error&&console.error("Amplitude snippet has been loaded.");else{var n=function(e,t){e.prototype[t]=function(){return this._q.push({name:t,args:Array.prototype.slice.call(arguments,0)}),this}},s=function(e,t,r){return function(n){e._q.push({name:t,args:Array.prototype.slice.call(r,0),resolve:n})}},o=function(e,t,r){e[t]=function(){if(r)return{promise:new Promise(s(e,t,Array.prototype.slice.call(arguments)))}}},i=function(e){for(var t=0;t<y.length;t++)o(e,y[t],!1);for(var r=0;r<g.length;r++)o(e,g[r],!0)};r.invoked=!0;var c=t.createElement("script");c.type="text/javascript",c.integrity="sha384-lyGcqRAilM5YOiZT3ktByF3Mv52pltOelJ66zwfcAZ/4s8cB1sSo7yMF2XWh+bzX",c.crossOrigin="anonymous",c.async=!0,c.src="https://cdn.amplitude.com/libs/analytics-browser-1.6.8-min.js.gz",c.onload=function(){e.amplitude.runQueuedFunctions||console.log("[Amplitude] Error: could not load SDK")};var a=t.getElementsByTagName("script")[0];a.parentNode.insertBefore(c,a);for(var u=function(){return this._q=[],this},l=["add","append","clearAll","prepend","set","setOnce","unset","preInsert","postInsert","remove","getUserProperties"],p=0;p<l.length;p++)n(u,l[p]);r.Identify=u;for(var d=function(){return this._q=[],this},v=["getEventProperties","setProductId","setQuantity","setPrice","setRevenue","setRevenueType","setEventProperties"],f=0;f<v.length;f++)n(d,v[f]);r.Revenue=d;var y=["getDeviceId","setDeviceId","getSessionId","setSessionId","getUserId","setUserId","setOptOut","setTransport","reset"],g=["init","add","remove","track","logEvent","identify","groupIdentify","setGroup","revenue","flush"];i(r),r.createInstance=function(){var e=r._iq.push({_q:[]})-1;return i(r._iq[e]),r._iq[e]},e.amplitude=r}}(window,document)}();
-        </script>
-        ```
-
     --8<-- "includes/sdk-quickstart/quickstart-initialization.md"
 
-    === "TypeScript"
+    === "Classic script"
 
         ```ts
-        import { init } from '@amplitude/analytics-browser';
-
-        init(AMPLITUDE_API_KEY);
+        amplitude.init(AMPLITUDE_API_KEY);
         ```
 
-    === "JavaScript"
+    === "Module script"
 
         ```js
-        import { init } from '@amplitude/analytics-browser';
+        import * as amplitude from '@amplitude/analytics-browser';
 
-        init(AMPLITUDE_API_KEY);
+        amplitude.init(AMPLITUDE_API_KEY);
         ```
 
     --8<-- "includes/sdk-quickstart/quickstart-send-data.md"
 
-    === "TypeScript"
+    === "Classic script"
 
         ```ts
-        import { track } from '@amplitude/analytics-browser';
-
         const eventProperties = {
           buttonColor: 'primary',
         };
-        track('Button Clicked', eventProperties);
+        amplitude.track('Button Clicked', eventProperties);
         ```
 
-    === "JavaScript"
+    === "Module script"
 
         ```js
-        import { track } from '@amplitude/analytics-browser';
+        import * as amplitude from '@amplitude/analytics-browser';
 
         const eventProperties = {
           buttonColor: 'primary',
         };
-        track('Button Clicked', eventProperties);
+        amplitude.track('Button Clicked', eventProperties);
         ```
 
     --8<-- "includes/sdk-quickstart/quickstart-check-for-success.md"
 
     --8<-- "includes/sdk-quickstart/quickstart-complete-code-example.md"
 
-    === "TypeScript"
+    === "Classic script"
 
         ```ts
-        import { init, identify, Identify, track } from '@amplitude/analytics-browser';
-
-        init(AMPLITUDE_API_KEY, 'user@amplitude.com');
+        amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com');
         const eventProperties = {
             buttonColor: 'primary',
         };
 
         const identifyObj = new Identify();
         identifyObj.set('location', 'LAX');
-        identify(identifyObj);
+        amplitude.identify(identifyObj);
 
-        track('Button Clicked', eventProperties);
+        amplitude.track('Button Clicked', eventProperties);
         ```
 
-    === "JavaScript"
+    === "Module script"
 
         ```js
-        import { init, identify, Identify, track } from '@amplitude/analytics-browser';
+        import * as amplitude from '@amplitude/analytics-browser';
 
-        init(AMPLITUDE_API_KEY, 'user@amplitude.com');
+        amplitude.init(AMPLITUDE_API_KEY, 'user@amplitude.com');
         const eventProperties = {
             buttonColor: 'primary',
         };
 
         const identifyObj = new Identify();
         identifyObj.set('location', 'LAX');
-        identify(identifyObj);
+        amplitude.identify(identifyObj);
 
-        track('Button Clicked', eventProperties);
+        amplitude.track('Button Clicked', eventProperties);
         ```
 
     Learn more available functionalities in [Browser SDK](../typescript-browser/).
 
     --8<-- "includes/sdk-quickstart/quickstart-enforce-event-schema-intro.md"
 
-    === "TypeScript"
+    ```ts
+    import { ampli } from './ampli';
+    ampli.load({ environment: 'production' });
 
-        ```ts
-
-        import { ampli } from './ampli';
-        ampli.load({ environment: 'production' });
-
-        ampli.buttonClicked({
-            buttonColor: 'primary',
-        });
-        ```
-
-    === "JavaScript"
-
-        ```js
-        import { ampli } from './ampli';
-        ampli.load({ environment: 'production' });
-
-        ampli.buttonClicked({
-            buttonColor: 'primary',
-        });
-        ```
+    ampli.buttonClicked({
+        buttonColor: 'primary',
+    });
+    ```
 
     Learn more about and set up the [Browser Ampli](../typescript-browser/ampli/).
 

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -43,7 +43,7 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
         Import Amplitude to your project
 
         ```ts
-        import * as amplitude from '@amplitude/analytics-browser;
+        import * as amplitude from '@amplitude/analytics-browser';
         ```
 
     === "YARN"
@@ -55,7 +55,7 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
         Import Amplitude to your project
 
         ```ts
-        import * as amplitude from '@amplitude/analytics-browser;
+        import * as amplitude from '@amplitude/analytics-browser';
         ```
 
     --8<-- "includes/sdk-quickstart/quickstart-initialization.md"

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -37,14 +37,25 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
         ```
     === "NPM"
         ```bash
-
         npm install @amplitude/analytics-browser
-
         ```
+
+        Import Amplitude to your project
+
+        ```ts
+        import * as amplitude from '@amplitude/analytics-browser;
+        ```
+
     === "YARN"
         ```bash
 
         yarn add @amplitude/analytics-browser
+        ```
+
+        Import Amplitude to your project
+
+        ```ts
+        import * as amplitude from '@amplitude/analytics-browser;
         ```
 
     --8<-- "includes/sdk-quickstart/quickstart-initialization.md"

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -109,10 +109,10 @@ Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK ca
 
 |<div class="big-column">Name</div>|Value|Description|
 |-|-|-|
-`config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See Tracking page views for more information.|
-`config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See Tracking sessions for more information.|
-`config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See Tracking form interactions for more information.|
-`config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See Tracking file downloads for more information.|
+`config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
+`config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
+`config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
+`config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
 
 You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep them disabled.
 
@@ -264,7 +264,7 @@ You can enable Amplitude to start tracking session events by setting `config.def
     });
     ```
 
-By setting `config.defaultEvents.sessions` to `true`, you enable Amplitude to track session start and session end events. When a new session starts, Amplitude tracks a session start event is and is the first event of the session. The event type for session start is "[Amplitude] Start Session". When an existing session ends, a session start end is tracked and is the last event of the session. The event type for session end is "[Amplitude] End Session".
+By setting `config.defaultEvents.sessions` to `true`, you enable Amplitude to track session start and session end events. A session is the period of time a user has your website open. See [How Amplitude defines sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions-in-Amplitude#how-amplitude-defines-sessions) for more information. When a new session starts, Amplitude tracks a session start event is and is the first event of the session. The event type for session start is "[Amplitude] Start Session". When an existing session ends, a session start end is tracked and is the last event of the session. The event type for session end is "[Amplitude] End Session".
 
 #### Tracking form interactions
 
@@ -292,7 +292,7 @@ You can enable Amplitude to start tracking form interaction events by setting co
     });
     ```
 
-By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit".
+By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit". If a form is submitted with no initial change to any form fields, both [Amplitude] Form Start and [Amplitude] Form Submit are tracked.
 
 Amplitude can track forms that are constructed with `<form>` tags and `<input>` tags nested. For example:
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -292,7 +292,7 @@ You can enable Amplitude to start tracking form interaction events by setting co
     });
     ```
 
-By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit". If a form is submitted with no initial change to any form fields, both [Amplitude] Form Start and [Amplitude] Form Submit are tracked.
+By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit". If a form is submitted with no initial change to any form fields, both "[Amplitude] Form Start" and "[Amplitude] Form Submit" are tracked.
 
 Amplitude can track forms that are constructed with `<form>` tags and `<input>` tags nested. For example:
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -107,12 +107,13 @@ Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK ca
 * Form interactions
 * File downloads
 
-|<div class="big-column">Name</div>|Value|Description|
-|-|-|-|
-`config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
-`config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
-`config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
-`config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
+???config "Tracking default events options"
+    |<div class="big-column">Name</div>|Value|Description|
+    |-|-|-|
+    `config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
+    `config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
+    `config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
+    `config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
 
 You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep them disabled.
 
@@ -200,11 +201,11 @@ By setting `config.defaultEvents.pageViews` to `true`, you enable Amplitude to u
 
 You can also use advanced configuration for better control of when page views event are sent.
 
-
-|<div class="big-column">Name</div>|Value|Description|
-|-|-|-|
-`defaultTracking.pageViews.trackOn` | Optional. `"attribution"` or `() => boolean` | Provides advanced control on when page view events are tracked.<br /><br />You can omit or set the value to `undefined`,  and configure page view events to be tracked on initialization.<br /><br />You can set the value to `"attribution"` and configure page view events to be tracked only when web attribution are tracked.<br /><br />You can set the value to a function that returns a boolean (`true` or `false`) and configure page view events to be tracked based on your criteria.|
-`defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Track the page view only on the path changes, track all URL changes by defaultProvides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
+???config "Tracking page views options"
+    |<div class="big-column">Name</div>|Value|Description|
+    |-|-|-|
+    `defaultTracking.pageViews.trackOn` | Optional. `"attribution"` or `() => boolean` | Provides advanced control on when page view events are tracked.<br /><br />You can omit or set the value to `undefined`,  and configure page view events to be tracked on initialization.<br /><br />You can set the value to `"attribution"` and configure page view events to be tracked only when web attribution are tracked.<br /><br />You can set the value to a function that returns a boolean (`true` or `false`) and configure page view events to be tracked based on your criteria.|
+    `defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Track the page view only on the path changes, track all URL changes by defaultProvides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
 
 For example, you can configure Amplitude to track page views only when the URL path contains a certain substring, let’s say “home”. Refer to the code sample for how to achieve this.
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -71,7 +71,7 @@ amplitude.track('Button Clicked', eventProperties);
 
 ### Tracking default events
 
-Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK can be configured to track the following events automatically:
+Starting version 1.9.1, Browser SDK now tracks default events. Browser SDK can be configured to track the following events automatically:
 
 * Page views
 * Sessions

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -81,10 +81,10 @@ Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK ca
 ???config "Tracking default events options"
     |<div class="big-column">Name</div>|Value|Description|
     |-|-|-|
-    `config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: `page_domain`, `page_location`, `page_path`, `page_title`, `page_url`<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
+    `config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: `[Amplitude] Page Domain`, `[Amplitude] Page Location`, `[Amplitude] Page Path`, `[Amplitude] Page Title`, `[Amplitude] Page URL`<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
     `config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
-    `config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: `form_id`, `form_name`, `form_destination`<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
-    `config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: `file_extension`, `file_name`, `link_id`, `link_text`, `link_url`<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
+    `config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: `[Amplitude]  Form ID`, `[Amplitude] Form Name`, `[Amplitude] Form Destination`<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
+    `config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: `[Amplitude] File Extension`, `[Amplitude] File Name`, `[Amplitude] Link ID`, `[Amplitude] Link Text`, `[Amplitude] Link URL`<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
 
 You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep them disabled.
 
@@ -122,7 +122,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-By setting `config.defaultEvents.pageViews` to `true`, you enable Amplitude to use default page view tracking behavior. The default behavior sends a page view event on initialization. The event type for this event is "[Amplitude] Page View".
+By setting `config.defaultEvents.pageViews` to `true`, you enable Amplitude to use default page view tracking behavior. The default behavior sends a page view event on initialization. The event type for this event is "[Amplitude] Page Viewed".
 
 ##### Advanced configuration for tracking page views
 
@@ -174,7 +174,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit". If a form is submitted with no initial change to any form fields, both "[Amplitude] Form Start" and "[Amplitude] Form Submit" are tracked.
+By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Started". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submitted". If a form is submitted with no initial change to any form fields, both "[Amplitude] Form Started" and "[Amplitude] Form Submitted" are tracked.
 
 Amplitude can track forms that are constructed with `<form>` tags and `<input>` tags nested. For example:
 
@@ -197,7 +197,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-By setting `config.defaultEvents.fileDownloads` to `true`, you enable Amplitude to track file download events. A file download event is tracked when an anchor or `<a>` tag linked to a file is clicked. The event type for file download is "[Amplitude] File Download". Amplitude determines that the anchor or `<a>` tag linked to a file if the file extension matches the following regex:
+By setting `config.defaultEvents.fileDownloads` to `true`, you enable Amplitude to track file download events. A file download event is tracked when an anchor or `<a>` tag linked to a file is clicked. The event type for file download is "[Amplitude] File Downloaded". Amplitude determines that the anchor or `<a>` tag linked to a file if the file extension matches the following regex:
 
 `pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma`
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -46,30 +46,292 @@ You can configure the server zone when initializing the client for sending data 
 !!!note
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
-```ts
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  serverZone: amplitude.Types.ServerZone.EU,
-});
-```
+=== "Classic script"
 
-### Track an event
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      serverZone: amplitude.Types.ServerZone.EU,
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      serverZone: amplitude.Types.ServerZone.EU,
+    });
+    ```
+
+### Tracking an event
 
 --8<-- "includes/sdk-httpv2-notice.md"
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 
-```ts
-import { track } from '@amplitude/analytics-browser';
+=== "Classic script"
 
-// Track a basic event
-track('Button Clicked');
+    ```ts
+    // Track a basic event
+    amplitude.track('Button Clicked');
 
-// Track events with optional properties
-const eventProperties = {
-  buttonColor: 'primary',
-};
-track('Button Clicked', eventProperties);
+    // Track events with optional properties
+    const eventProperties = {
+      buttonColor: 'primary',
+    };
+    amplitude.track('Button Clicked', eventProperties);
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    // Track a basic event
+    amplitude.track('Button Clicked');
+
+    // Track events with optional properties
+    const eventProperties = {
+      buttonColor: 'primary',
+    };
+    amplitude.track('Button Clicked', eventProperties);
+    ```
+
+### Tracking default events
+
+Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK can be configured to track the following events automatically:
+
+* Page views
+* Sessions
+* Form interactions
+* File downloads
+
+|<div class="big-column">Name</div>|Value|Description|
+|-|-|-|
+`config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See Tracking page views for more information.|
+`config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See Tracking sessions for more information.|
+`config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See Tracking form interactions for more information.|
+`config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See Tracking file downloads for more information.|
+
+You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep them disabled.
+
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: true,
+        sessions: true,
+        formInteractions: true,
+        fileDownloads: true,
+      },
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: true,
+        sessions: true,
+        formInteractions: true,
+        fileDownloads: true,
+      },
+    });
+    ```
+
+Alternatively, you can enable Amplitude to track all events mentioned above by setting `config.defaultEvents` to `true`.
+
+!!!note
+    Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: true,
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: true,
+    });
+    ```
+
+
+#### Tracking page views
+
+You can enable Amplitude to start tracking page view events by setting `config.defaultEvents.pageViews` to `true`. Refer to the code sample below.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: true,
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: true,
+      },
+    });
+    ```
+
+By setting `config.defaultEvents.pageViews` to `true`, you enable Amplitude to use default page view tracking behavior. The default behavior sends a page view event on initialization. The event type for this event is "[Amplitude] Page View".
+
+##### Advanced configuration for tracking page views
+
+You can also use advanced configuration for better control of when page views event are sent.
+
+
+|<div class="big-column">Name</div>|Value|Description|
+|-|-|-|
+`defaultTracking.pageViews.trackOn` | Optional. `"attribution"` or `() => boolean` | Provides advanced control on when page view events are tracked.<br /><br />You can omit or set the value to `undefined`,  and configure page view events to be tracked on initialization.<br /><br />You can set the value to `"attribution"` and configure page view events to be tracked only when web attribution are tracked.<br /><br />You can set the value to a function that returns a boolean (`true` or `false`) and configure page view events to be tracked based on your criteria.|
+`defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Track the page view only on the path changes, track all URL changes by defaultProvides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
+
+For example, you can configure Amplitude to track page views only when the URL path contains a certain substring, let’s say “home”. Refer to the code sample for how to achieve this.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: {
+          trackOn: () => {
+            return window.location.pathname.includes('home');
+          },
+        },
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        pageViews: {
+          trackOn: () => {
+            return window.location.pathname.includes('home');
+          },
+        },
+      },
+    });
+    ```
+
+#### Tracking sessions
+
+You can enable Amplitude to start tracking session events by setting `config.defaultEvents.sessions` to `true`. Refer to the code sample below.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        sessions: true,
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        sessions: true,
+      },
+    });
+    ```
+
+By setting `config.defaultEvents.sessions` to `true`, you enable Amplitude to track session start and session end events. When a new session starts, Amplitude tracks a session start event is and is the first event of the session. The event type for session start is "[Amplitude] Start Session". When an existing session ends, a session start end is tracked and is the last event of the session. The event type for session end is "[Amplitude] End Session".
+
+#### Tracking form interactions
+
+You can enable Amplitude to start tracking form interaction events by setting config.defaultEvents.formInteractions to true. Refer to the code sample below.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        formInteractions: true,
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        formInteractions: true,
+      },
+    });
+    ```
+
+By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit".
+
+Amplitude can track forms that are constructed with `<form>` tags and `<input>` tags nested. For example:
+
+```html
+<form id="subscriber-form" name="subscriber-form" action="/subscribe">
+  <input type="text" />
+  <input type="submit" />
+</form>
 ```
+
+#### Tracking file downloads
+
+You can enable Amplitude to start tracking file download events by setting `config.defaultEvents.fileDownloads` to `true`. Refer to the code sample below.
+
+===  "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        fileDownloads: true,
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      defaultEvents: {
+        fileDownloads: true,
+      },
+    });
+    ```
+
+By setting `config.defaultEvents.fileDownloads` to `true`, you enable Amplitude to track file download events. A file download event is tracked when an anchor or `<a>` tag linked to a file is clicked. The event type for file download is "[Amplitude] File Download". Amplitude determines that the anchor or `<a>` tag linked to a file if the file extension matches the following regex:
+
+`pdf|xlsx?|docx?|txt|rtf|csv|exe|key|pp(s|t|tx)|7z|pkg|rar|gz|zip|avi|mov|mp4|mpe?g|wmv|midi?|mp3|wav|wma`
 
 ### User properties
 
@@ -84,51 +346,93 @@ Identify is for setting the user properties of a particular user without sending
 
 The Identify object provides controls over setting user properties. It works like this: first, instantiate an Identify object, then call Identify methods on it, and finally, the client can make a call with the Identify object.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identify(identifyObj);
-```
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.set
 
 This method sets the value of a user property. For example, you can set a role property of a user.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.set('location', 'LAX');
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.set('location', 'LAX');
 
-identify(identifyObj);
-```
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.set('location', 'LAX');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.setOnce
 
 This method sets the value of a user property only one time. Subsequent calls using `setOnce()` are ignored. For example, you can set an initial login method for a user and because only the initial value is tracked, `setOnce()` ignores later calls.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.setOnce('initial-location', 'SFO');
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.setOnce('initial-location', 'SFO');
 
-identify(identifyObj);
-```
+    identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.setOnce('initial-location', 'SFO');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.add
 
 This method increments a user property by some numerical value. If the user property doesn't have a value set yet, it's initialized to 0 before it's incremented. For example, you can track a user's travel count.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.add('travel-count', 1);
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.add('travel-count', 1);
 
-identify(identifyObj);
-```
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.add('travel-count', 1);
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Arrays in user properties
 
@@ -138,66 +442,119 @@ You can use arrays as user properties. Directly set arrays or use `prepend`, `ap
 
 This method prepends a value or values to a user property array. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are prepended.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.prepend('visited-locations', 'LAX');
+    ```ts
+    const identifyEvent = new Identify();
+    identifyEvent.prepend('visited-locations', 'LAX');
 
-identify(identifyObj);
-```
+    identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.prepend('visited-locations', 'LAX');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.append
 
 This method appends a value or values to a user property array. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are prepended.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.append('visited-locations', 'SFO');
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.append('visited-locations', 'SFO');
 
-identify(identifyObj);
-```
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.append('visited-locations', 'SFO');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.preInsert
 
 This method pre-inserts a value or values to a user property, if it doesn't exist in the user property yet. Pre-insert means inserting the values at the beginning of a given list. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are pre-inserted. If the user property has an existing value, this method is a no-op.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.preInsert('unique-locations', 'LAX');
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.preInsert('unique-locations', 'LAX');
 
-identify(identifyObj);
-```
+    identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.preInsert('unique-locations', 'LAX');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.postInsert
 
 This method post-inserts a value or values to a user property, if it doesn't exist in the user property yet. Post-insert means inserting the values at the end of a given list. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are post-inserted. If the user property has an existing value, this method is a no-op..
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.postInsert('unique-locations', 'SFO');
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.postInsert('unique-locations', 'SFO');
 
-identify(identifyObj);
-```
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.postInsert('unique-locations', 'SFO');
+
+    amplitude.identify(identifyEvent);
+    ```
 
 #### Identify.remove
 
 This method removes a value or values to a user property, if it exists in the user property. Remove means remove the existing values from the given list. If the user property has an existing value, this method is a no-op.
 
-```ts
-import { identify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const identifyObj = new Identify();
-identifyObj.remove('unique-locations', 'JFK')
+    ```ts
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.remove('unique-locations', 'JFK')
 
-identify(identifyObj);
-```
+    amplitude.identify(identifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as Amplitude from '@amplitude/analytics-browser';
+
+    const identifyEvent = new amplitude.Identify();
+    identifyEvent.remove('unique-locations', 'JFK')
+
+    amplitude.identify(identifyEvent);
+    ```
 
 ### User groups
 
@@ -205,15 +562,27 @@ identify(identifyObj);
 
 --8<-- "includes/groups-intro-paragraph.md"
 
-```ts
-import { setGroup } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-// set group with single group name
-setGroup('orgId', '15');
+    ```ts
+    // set group with single group name
+    amplitude.setGroup('orgId', '15');
 
-// set group with multiple group names
-setGroup('sport', ['soccer', 'tennis']);
-```
+    // set group with multiple group names
+    amplitude.setGroup('sport', ['soccer', 'tennis']);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    // set group with single group name
+    amplitude.setGroup('orgId', '15');
+
+    // set group with multiple group names
+    amplitude.setGroup('sport', ['soccer', 'tennis']);
+    ```
 
 ### Group properties
 
@@ -223,16 +592,29 @@ Use the Group Identify API to set or update properties of particular groups. The
 
 The `groupIdentify()` method accepts a group type and group name string parameter, as well as an Identify object that's applied to the group.
 
-```ts
-import { groupIdentify, Identify } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const groupType = 'plan';
-const groupName = 'enterprise';
-const groupIdentifyObj = new Identify()
-groupIdentifyObj.set('key1', 'value1');
+    ```ts
+    const groupType = 'plan';
+    const groupName = 'enterprise';
+    const groupIdentifyEvent = new amplitude.Identify()
+    groupIdentifyEvent.set('key1', 'value1');
 
-groupIdentify(groupType, groupName, groupIdentifyObj);
-```
+    amplitude.groupIdentify(groupType, groupName, groupIdentifyEvent);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const groupType = 'plan';
+    const groupName = 'enterprise';
+    const groupIdentifyEvent = new amplitude.Identify()
+    groupIdentifyEvent.set('key1', 'value1');
+
+    amplitude.groupIdentify(groupType, groupName, groupIdentifyEvent);
+    ```
 
 ### Revenue tracking
 <!-- vale off-->
@@ -243,16 +625,29 @@ The preferred method of tracking revenue for a user is to use `revenue()` in con
 
 To track revenue from a user, call revenue each time a user generates revenue. In this example, 3 units of a product was purchased at $3.99.
 
-```ts
-import { revenue, Revenue } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-const event = new Revenue()
-  .setProductId('com.company.productId')
-  .setPrice(3.99)
-  .setQuantity(3);
+    ```ts
+    const event = new amplitude.Revenue()
+      .setProductId('com.company.productId')
+      .setPrice(3.99)
+      .setQuantity(3);
 
-revenue(event);
-```
+    amplitude.revenue(event);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    const event = new amplitude.Revenue()
+      .setProductId('com.company.productId')
+      .setPrice(3.99)
+      .setQuantity(3);
+
+    amplitude.revenue(event);
+    ```
 
 #### Revenue interface
 
@@ -270,53 +665,92 @@ revenue(event);
 
 The `flush` method triggers the client to send buffered events immediately.
 
-```typescript
-import { flush } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-flush();
-```
+    ```ts
+    amplitude.flush();
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.flush();
+    ```
 
 By default, `flush` is called automatically in an interval, if you want to flush the events all together, you can control the async flow with the optional Promise interface, example:
 
-```typescript
-import { flush, init, track } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-await init(AMPLITUDE_API_KEY).promise;
-track('Button Clicked');
-await flush().promise;
-```
+    ```ts
+    amplitude.init(API_KEY).promise.then(function() {
+      amplitude.track('Button Clicked');
+      amplitude.flush();
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    await amplitude.init(API_KEY).promise;
+    amplitude.track('Button Clicked');
+    await amplitude.flush().promise;
+    ```
 
 ### Custom user ID
 
 If your app has its own login system that you want to track users with, you can call `setUserId` at any time.
 
-TypeScript
+===  "Classic script"
 
-```ts
-import { setUserId } from '@amplitude/analytics-browser';
+    ```ts
+    amplitude.setUserId('user@amplitude.com');
+    ```
 
-setUserId('user@amplitude.com');
-```
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.setUserId('user@amplitude.com');
+    ```
 
 You can also assign the User ID as an argument to the init call.
 
-```ts
-import { init } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-init(API_KEY, 'user@amplitude.com');
-```
+    ```ts
+    amplitude.init(API_KEY, 'user@amplitude.com');
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, 'user@amplitude.com');
+    ```
 
 ### Custom session ID
 
 You can assign a new Session ID using `setSessionId`. When setting a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
 
-TypeScript
+===  "Classic script"
 
-```ts
-import { setSessionId } from '@amplitude/analytics-browser';
+    ```ts
+    amplitude.setSessionId(Date.now());
+    ```
 
-setSessionId(Date.now());
-```
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.setSessionId(Date.now());
+    ```
 
 ### Custom device ID
 
@@ -324,12 +758,20 @@ If your app has its own login system that you want to track users with, you can 
 
 You can assign a new device ID using `deviceId`. When setting a custom device ID, make sure the value is sufficiently unique. Amplitude recommends using a UUID.
 
-```ts
-import { setDeviceId } from '@amplitude/analytics-browser';
-const { uuid } = require('uuidv4');
+===  "Classic script"
 
-setDeviceId(uuid());
-```
+    ```ts
+    amplitude.setDeviceId(uuid());
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { v4 as uuid } from 'uuid';
+    
+    amplitude.setDeviceId(uuid());
+    ```
 
 ### Reset when user logs out
 
@@ -340,31 +782,55 @@ setDeviceId(uuid());
 
 With an undefined `userId` and a completely new `deviceId`, the current user would appear as a brand new user in dashboard.
 
-```ts
-import { reset } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-reset();
-```
+    ```ts
+    amplitude.reset();
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.reset();
+    ```
 
 ### Opt users out of tracking
 
 You can turn off logging for a given user by setting `setOptOut` to `true`.
 
-```ts
-import { setOptOut } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-setOptOut(true);
-```
+    ```ts
+    amplitude.setOptOut(true);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.setOptOut(true);
+    ```
 
 Events aren't saved or sent to the server while `setOptOut` is enabled, and the setting persists across page loads. 
 
 Re-enable logging by setting `setOptOut` to `false`.
 
-```ts
-import { setOptOut } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-setOptOut(false);
-```
+    ```ts
+    amplitude.setOptOut(false);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.setOptOut(false);
+    ```
 
 ### Optional tracking
 
@@ -380,42 +846,65 @@ By default, the SDK tracks these properties automatically. You can override this
 | `osVersion` | `true` |
 | `platform` | `true` |
 
-```ts
-import { init } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-init(API_KEY, OPTIONAL_USER_ID, {
-  trackingOptions: {
-    deviceManufacturer: false,
-    deviceModel: false,
-    ipAddress: false,
-    language: false,
-    osName: false,
-    osVersion: false,
-    platform: false,
-  },
-});
-```
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      trackingOptions: {
+        deviceManufacturer: false,
+        deviceModel: false,
+        ipAddress: false,
+        language: false,
+        osName: false,
+        osVersion: false,
+        platform: false,
+      },
+    });
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      trackingOptions: {
+        deviceManufacturer: false,
+        deviceModel: false,
+        ipAddress: false,
+        language: false,
+        osName: false,
+        osVersion: false,
+        platform: false,
+      },
+    });
+    ```
 
 ### Callback
 
 All asynchronous API are optionally awaitable through a Promise interface. This also serves as callback interface.
 
-```ts
-import { track } from '@amplitude/analytics-browser';
+===  "Classic script (Promise)"
 
-// Using async/await
-const results = await track('Button Clicked').promise;
-result.event; // {...} (The final event object sent to Amplitude)
-result.code; // 200 (The HTTP response status code of the request.
-result.message; // "Event tracked successfully" (The response message)
+    ```ts
+    amplitude.track('Button Clicked').promise.then(function(result) {
+      result.event; // {...} (The final event object sent to Amplitude)
+      result.code; // 200 (The HTTP response status code of the request.
+      result.message; // "Event tracked successfully" (The response message)
+    });
+    ```
 
-// Using promises
-track('Button Clicked').promise.then((result) => {
-  result.event; // {...} (The final event object sent to Amplitude)
-  result.code; // 200 (The HTTP response status code of the request.
-  result.message; // "Event tracked successfully" (The response message)
-});
-```
+===  "Module script (async/await)"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    // Using async/await
+    const results = await amplitude.track('Button Clicked').promise;
+    result.event; // {...} (The final event object sent to Amplitude)
+    result.code; // 200 (The HTTP response status code of the request.
+    result.message; // "Event tracked successfully" (The response message)
+    ```
 
 ### Plugins
 
@@ -425,27 +914,43 @@ Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying 
 
 The `add` method adds a plugin to Amplitude. Plugins can help processing and sending events.
 
-```typescript
-import { add } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-add(new Plugin());
-```
+    ```ts
+    amplitude.add(new Plugin());
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.add(new Plugin());
+    ```
 
 #### `remove`
 
 The `remove` method removes the given plugin name from the client instance if it exists.
 
-```typescript
-import { remove } from '@amplitude/analytics-browser';
+===  "Classic script"
 
-remove(plugin.name);
-```
+    ```ts
+    amplitude.remove(plugin.name);
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.remove(plugin.name);
+    ```
 
 #### Create your custom plugin
 
 ##### Plugin.setup
 
-This method contains logic for preparing the plugin for use and has config as a parameter. The expected return value is undefined. A typical use for this method, is to copy configuration from config or instantiate plugin dependencies. This method is called when the plugin is registered to the client via `client.add()`.
+This method contains logic for preparing the plugin for use and has config as a parameter. The expected return value is undefined. A typical use for this method, is to copy configuration from config or instantiate plugin dependencies. This method is called when the plugin is registered to the client via `amplitude.add()`.
 
 ##### Plugin.execute
 
@@ -457,89 +962,197 @@ This method contains the logic for processing events and has event as parameter.
 
 Here's an example of a plugin that sends each event that's instrumented to a target server URL using your preferred HTTP client.
 
-```ts
-import { add, BrowserConfig, DestinationPlugin, Event, init, PluginType, Result } from '@amplitude/analytics-types';
+===  "Classic script"
 
-export class MyDestinationPlugin implements DestinationPlugin {
-  name = 'my-destination-plugin';
-  type = PluginType.DESTINATION as const;
-  serverUrl: string;
-  config?: BrowserConfig;
+    ```ts
+    function myDestinationPlugin (serverUrl) {
+      const name = 'my-destination-plugin';
+      const type = amplitude.Types.PluginType.DESTINATION;
+      let amplitudeConfig;
+      
+      /**
+       * setup() is called on plugin installation
+       * example: amplitude.add(new myDestinationPlugin());
+       */
+      const setup = function (config) {
+        amplitudeConfig = config;
+      }
 
-  constructor(serverUrl: string) {
-    this.serverUrl = serverUrl;
-  }
+      /**
+       * execute() is called on each event instrumented
+       * example: amplitude.track('New Event');
+       */
+      const execute = function (event) {
+        const payload = {
+          key: 'secret',
+          data: event,
+        };
+        return fetch(this.serverUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: '*/*',
+          },
+          body: JSON.stringify(payload),
+        }).then(function(response) {
+          return {
+            code: response.status,
+            event: event,
+            message: response.statusText,
+          };
+        });
+      }
 
-  /**
-   * setup() is called on plugin installation
-   * example: client.add(new MyDestinationPlugin());
-   */
-  async setup(config: BrowserConfig): Promise<undefined> {
-    this.config = config;
-    return;
-  }
-
-  /**
-   * execute() is called on each event instrumented
-   * example: client.track('New Event');
-   */
-  async execute(event: Event): Promise<Result> {
-    const payload = { key: 'secret', data: event };
-    const response = await fetch(this.serverUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: '*/*',
+      return {
+        name,
+        type,
+        setup,
+        execute,
       },
-      body: JSON.stringify(payload),
-    });
-    return {
-      code: response.status,
-      event: event,
-      message: response.statusText,
-    };
-  }
-}
+    }
 
-init('API_KEY');
-add(new MyDestinationPlugin('https://custom.domain.com'));
-```
+    amplitude.init(API_KEY);
+    amplitude.add(myDestinationPlugin('https://custom.domain.com'));
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { BrowserConfig, DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
+
+    const myDestinationPlugin = (serverUrl: string): DestinationPlugin => {
+      const name = 'my-destination-plugin';
+      const type = PluginType.DESTINATION as const;
+      let amplitudeConfig: BrowserConfig | undefined;
+
+      /**
+       * setup() is called on plugin installation
+       * example: amplitude.add(new MyDestinationPlugin());
+       */
+      const setup = async (config: BrowserConfig): Promise<undefined> => {
+        amplitudeConfig = config;
+        return;
+      };
+
+      /**
+       * execute() is called on each event instrumented
+       * example: amplitude.track('New Event');
+       */
+      const execute = async (event: Event): Promise<Result> => {
+        const payload = {
+          key: 'secret',
+          data: event,
+        };
+        const response = await fetch(serverUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: '*/*',
+          },
+          body: JSON.stringify(payload),
+        });
+        return {
+          code: response.status,
+          event: event,
+          message: response.statusText,
+        };
+      };
+
+      return {
+        name,
+        type,
+        setup,
+        execute,
+      };
+    };
+
+    amplitude.init(API_KEY);
+    amplitude.add(myDestinationPlugin('https://custom.domain.com'));
+    ```
 
 ##### Enrichment type plugin
 
 Here's an example of a plugin that modifies each event that's instrumented by adding an increment integer to `event_id` property of an event starting from 100.
 
-```ts
-import { add, BrowserConfig, EnrichmentPlugin, Event, init, PluginType } from '@amplitude/analytics-types';
+===  "Classic script"
 
-export class AddEventIdPlugin implements EnrichmentPlugin {
-  name = 'add-event-id';
-  type = PluginType.ENRICHMENT as const;
-  currentId = 100;
-  config?: BrowserConfig;
+    ```ts
+    const addEventIdPlugin = () => {
+      const name = 'add-event-id';
+      const type = amplitude.Types.PluginType.ENRICHMENT;
+      let currentId = 100;
+      let amplitudeConfig;
 
-  /**
-   * setup() is called on plugin installation
-   * example: client.add(new AddEventIdPlugin());
-   */
-  async setup(config: BrowserConfig): Promise<undefined> {
-     this.config = config;
-     return;
-  }
+      /**
+       * setup() is called on plugin installation
+       * example: amplitude.add(new AddEventIdPlugin());
+       */
+      const setup = function (config) {
+        amplitudeConfig = config;
+      }
 
-  /**
-   * execute() is called on each event instrumented
-   * example: client.track('New Event');
-   */
-  async execute(event: Event): Promise<Event> {
-    event.event_id = this.currentId++;
-    return event;
-  }
-}
+      /**
+       * execute() is called on each event instrumented
+       * example: client.track('New Event');
+       */
+      const execute = function (event: Event) {
+        event.event_id = currentId++;
+        return event;
+      }
 
-init('API_KEY');
-add(new AddEventIdPlugin());
-```
+      return {
+        name,
+        type,
+        setup,
+        execute,
+      }
+    }
+
+    amplitude.init('API_KEY');
+    amplitude.add(addEventIdPlugin());
+    ```
+
+===  "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { BrowserConfig, EnrichmentPlugin, Event, PluginType } from '@amplitude/analytics-types';
+
+    const addEventIdPlugin = (): EnrichmentPlugin => {
+      const name = 'add-event-id';
+      const type = PluginType.ENRICHMENT as const;
+      let currentId = 100;
+      let amplitudeConfig: BrowserConfig | undefined;
+
+      /**
+       * setup() is called on plugin installation
+       * example: amplitude.add(new AddEventIdPlugin());
+       */
+      const setup = async (config: BrowserConfig): Promise<void> => {
+        amplitudeConfig = config;
+      }
+
+      /**
+       * execute() is called on each event instrumented
+       * example: client.track('New Event');
+       */
+      const execute = async (event: Event): Promise<Event> => {
+        event.event_id = currentId++;
+        return event;
+      }
+
+      return {
+        name,
+        type,
+        setup,
+        execute,
+      }
+    }
+
+    amplitude.init('API_KEY');
+    amplitude.add(addEventIdPlugin());
+    ```
 
 ##### Web attribution enrichment plugin
 
@@ -557,15 +1170,24 @@ You need to download `plugin-web-attribution-browser` package and add the `webAt
     yarn add @amplitude/plugin-web-attribution-browser
     ```
 
-```ts
-import * as client from '@amplitude/analytics-browser';
-import { add, init } from '@amplitude/analytics-browser';
-import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
+Add plugin to Ampltude instance.
 
-add(webAttributionPlugin(client, attributionOptions));
+=== "Classic script"
 
-init('API_KEY', configurationObj);
-```
+    ```ts
+    amplitude.add(webAttributionPlugin());
+    amplitude.init(API_KEY);
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
+
+    amplitude.add(webAttributionPlugin());
+    amplitude.init(API_KEY);
+    ```
 
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Web Attribution Plugin](../marketing-analytics-browser/#web-attribution) supports.
@@ -597,16 +1219,24 @@ You need to download `plugin-page-view-tracking-browser` and add the `pageViewTr
     yarn add @amplitude/plugin-page-view-tracking-browser
     ```
 
-```ts
-import * as client from '@amplitude/analytics-browser';
-import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
+Add plugin to Ampltude instance.
 
-const { add, init } = client;
+=== "Classic script"
 
-add(pageViewTrackingPlugin(client, pageViewTrackingOptions));
+    ```ts
+    amplitude.add(pageViewTrackingPlugin());
+    amplitude.init(API_KEY);
+    ```
 
-init('API_KEY', configurationObj);
-```
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
+
+    amplitude.add(pageViewTrackingPlugin(client));
+    amplitude.init(API_KEY);
+    ```
 
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Page View Plugin](../marketing-analytics-browser/#page-view) supports.
@@ -639,20 +1269,36 @@ If the `deviceId` isn't provided with the `init` like `init('API_KEY', null, { d
 
 You can provide an implementation of `Transport` interface to the `transportProvider` configuration option for customization purpose, for example, sending requests to your proxy server with customized HTTP request headers.
 
-```ts
-import { init } from '@amplitude/analytics-browser';
-import { Transport } from '@amplitude/analytics-types';
+=== "Classic script"
 
-class MyTransport implements Transport {
-  async send(serverUrl: string, payload: Payload): Promise<Response | null> {
-    // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
-  }
-}
+    ```ts
+    class MyTransport {
+      send(serverUrl, payload) {
+        // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
+      }
+    }
 
-init(API_KEY, OPTIONAL_USER_ID, {
-  transportProvider: new MyTransport(),
-});
-```
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      transportProvider: new MyTransport(),
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { Transport } from '@amplitude/analytics-types';
+
+    class MyTransport implements Transport {
+      async send(serverUrl: string, payload: Payload): Promise<Response | null> {
+        // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
+      }
+    }
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      transportProvider: new MyTransport(),
+    });
+    ```
 
 ### Content Security Policy (CSP)
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -46,23 +46,11 @@ You can configure the server zone when initializing the client for sending data 
 !!!note
     For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      serverZone: amplitude.Types.ServerZone.EU,
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      serverZone: amplitude.Types.ServerZone.EU,
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  serverZone: amplitude.Types.ServerZone.EU,
+});
+```
 
 ### Tracking an event
 
@@ -70,33 +58,16 @@ You can configure the server zone when initializing the client for sending data 
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 
-=== "Classic script"
+```ts
+// Track a basic event
+amplitude.track('Button Clicked');
 
-    ```ts
-    // Track a basic event
-    amplitude.track('Button Clicked');
-
-    // Track events with optional properties
-    const eventProperties = {
-      buttonColor: 'primary',
-    };
-    amplitude.track('Button Clicked', eventProperties);
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    // Track a basic event
-    amplitude.track('Button Clicked');
-
-    // Track events with optional properties
-    const eventProperties = {
-      buttonColor: 'primary',
-    };
-    amplitude.track('Button Clicked', eventProperties);
-    ```
+// Track events with optional properties
+const eventProperties = {
+  buttonColor: 'primary',
+};
+amplitude.track('Button Clicked', eventProperties);
+```
 
 ### Tracking default events
 
@@ -110,90 +81,46 @@ Starting on version 1.9.0, Browser SDK now tracks default events. Browser SDK ca
 ???config "Tracking default events options"
     |<div class="big-column">Name</div>|Value|Description|
     |-|-|-|
-    `config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: page_domain, page_location, page_path, page_title, page_url<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
+    `config.defaultTracking.pageViews` | Optional. `boolean` | Enables default page view tracking. If value is `true`, Amplitude tracks page view events on initialization. Default value is `false`.<br /><br />Event properties tracked includes: `page_domain`, `page_location`, `page_path`, `page_title`, `page_url`<br /><br />See [Tracking page views](#tracking-page-views) for more information.|
     `config.defaultTracking.sessions` | Optional. `boolean` | Enables session tracking. If value is `true`, Amplitude tracks session start and session end events. Default value is `false`.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
-    `config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: form_id, form_name, form_destination<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
-    `config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: file_extension, file_name, link_id, link_text, link_url<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
+    `config.defaultTracking.formInteractions` | Optional. `boolean` | Enables form interaction tracking. If value is `true`, Amplitude tracks form start and form submit events. Default value is `false`.<br /><br />Event properties tracked includes: `form_id`, `form_name`, `form_destination`<br /><br />See [Tracking form interactions](#tracking-form-interactions) for more information.|
+    `config.defaultTracking.fileDownloads` | Optional. `boolean` | Enables file download tracking. If value is `true`, Amplitude tracks file download events. Default value is `false`.<br /><br />Event properties tracked includes: `file_extension`, `file_name`, `link_id`, `link_text`, `link_url`<br /><br />See [Tracking file downloads](#tracking-file-downloads) for more information.|
 
 You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep them disabled.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: true,
-        sessions: true,
-        formInteractions: true,
-        fileDownloads: true,
-      },
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: true,
-        sessions: true,
-        formInteractions: true,
-        fileDownloads: true,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    pageViews: true,
+    sessions: true,
+    formInteractions: true,
+    fileDownloads: true,
+  },
+});
+```
 
 Alternatively, you can enable Amplitude to track all events mentioned above by setting `config.defaultEvents` to `true`.
 
 !!!note
     Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: true,
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: true,
-    });
-    ```
-
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: true,
+});
+```
 
 #### Tracking page views
 
 You can enable Amplitude to start tracking page view events by setting `config.defaultEvents.pageViews` to `true`. Refer to the code sample below.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: true,
-      },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: true,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    pageViews: true,
+  },
+});
+```
 
 By setting `config.defaultEvents.pageViews` to `true`, you enable Amplitude to use default page view tracking behavior. The default behavior sends a page view event on initialization. The event type for this event is "[Amplitude] Page View".
 
@@ -205,65 +132,33 @@ You can also use advanced configuration for better control of when page views ev
     |<div class="big-column">Name</div>|Value|Description|
     |-|-|-|
     `defaultTracking.pageViews.trackOn` | Optional. `"attribution"` or `() => boolean` | Provides advanced control on when page view events are tracked.<br /><br />You can omit or set the value to `undefined`,  and configure page view events to be tracked on initialization.<br /><br />You can set the value to `"attribution"` and configure page view events to be tracked only when web attribution are tracked.<br /><br />You can set the value to a function that returns a boolean (`true` or `false`) and configure page view events to be tracked based on your criteria.|
-    `defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Track the page view only on the path changes, track all URL changes by defaultProvides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
+    `defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Provides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
 
 For example, you can configure Amplitude to track page views only when the URL path contains a certain substring, let’s say “home”. Refer to the code sample for how to achieve this.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: {
-          trackOn: () => {
-            return window.location.pathname.includes('home');
-          },
-        },
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    pageViews: {
+      trackOn: () => {
+        return window.location.pathname.includes('home');
       },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        pageViews: {
-          trackOn: () => {
-            return window.location.pathname.includes('home');
-          },
-        },
-      },
-    });
-    ```
+    },
+  },
+});
+```
 
 #### Tracking sessions
 
 You can enable Amplitude to start tracking session events by setting `config.defaultEvents.sessions` to `true`. Refer to the code sample below.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        sessions: true,
-      },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        sessions: true,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    sessions: true,
+  },
+});
+```
 
 By setting `config.defaultEvents.sessions` to `true`, you enable Amplitude to track session start and session end events. A session is the period of time a user has your website open. See [How Amplitude defines sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions-in-Amplitude#how-amplitude-defines-sessions) for more information. When a new session starts, Amplitude tracks a session start event is and is the first event of the session. The event type for session start is "[Amplitude] Start Session". When an existing session ends, a session start end is tracked and is the last event of the session. The event type for session end is "[Amplitude] End Session".
 
@@ -271,27 +166,13 @@ By setting `config.defaultEvents.sessions` to `true`, you enable Amplitude to tr
 
 You can enable Amplitude to start tracking form interaction events by setting config.defaultEvents.formInteractions to true. Refer to the code sample below.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        formInteractions: true,
-      },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        formInteractions: true,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    formInteractions: true,
+  },
+});
+```
 
 By setting `config.defaultEvents.formInteractions` to `true`, you enable Amplitude to track form start and form submit events. A form start event is tracked when the user initially interacts with the form. An initial interaction can be the first change to an text input, or radio button, or dropdown. The event type for session start is "[Amplitude] Form Start". A form submit event is tracked when the user submits the form. The event type for session start is "[Amplitude] Form Submit". If a form is submitted with no initial change to any form fields, both "[Amplitude] Form Start" and "[Amplitude] Form Submit" are tracked.
 
@@ -308,27 +189,13 @@ Amplitude can track forms that are constructed with `<form>` tags and `<input>` 
 
 You can enable Amplitude to start tracking file download events by setting `config.defaultEvents.fileDownloads` to `true`. Refer to the code sample below.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        fileDownloads: true,
-      },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      defaultEvents: {
-        fileDownloads: true,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  defaultEvents: {
+    fileDownloads: true,
+  },
+});
+```
 
 By setting `config.defaultEvents.fileDownloads` to `true`, you enable Amplitude to track file download events. A file download event is tracked when an anchor or `<a>` tag linked to a file is clicked. The event type for file download is "[Amplitude] File Download". Amplitude determines that the anchor or `<a>` tag linked to a file if the file extension matches the following regex:
 
@@ -347,93 +214,43 @@ Identify is for setting the user properties of a particular user without sending
 
 The Identify object provides controls over setting user properties. It works like this: first, instantiate an Identify object, then call Identify methods on it, and finally, the client can make a call with the Identify object.
 
-===  "Classic script"
-
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    amplitude.identify(identifyEvent);
-    ```
+```ts
+const identifyEvent = new amplitude.Identify();
+amplitude.identify(identifyEvent);
+```
 
 #### Identify.set
 
 This method sets the value of a user property. For example, you can set a role property of a user.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.set('location', 'LAX');
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.set('location', 'LAX');
-
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.set('location', 'LAX');
-
-    amplitude.identify(identifyEvent);
-    ```
+amplitude.identify(identifyEvent);
+```
 
 #### Identify.setOnce
 
 This method sets the value of a user property only one time. Subsequent calls using `setOnce()` are ignored. For example, you can set an initial login method for a user and because only the initial value is tracked, `setOnce()` ignores later calls.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.setOnce('initial-location', 'SFO');
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.setOnce('initial-location', 'SFO');
-
-    identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.setOnce('initial-location', 'SFO');
-
-    amplitude.identify(identifyEvent);
-    ```
+identify(identifyEvent);
+```
 
 #### Identify.add
 
 This method increments a user property by some numerical value. If the user property doesn't have a value set yet, it's initialized to 0 before it's incremented. For example, you can track a user's travel count.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.add('travel-count', 1);
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.add('travel-count', 1);
-
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.add('travel-count', 1);
-
-    amplitude.identify(identifyEvent);
-    ```
+amplitude.identify(identifyEvent);
+```
 
 #### Arrays in user properties
 
@@ -443,119 +260,56 @@ You can use arrays as user properties. Directly set arrays or use `prepend`, `ap
 
 This method prepends a value or values to a user property array. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are prepended.
 
-===  "Classic script"
+```ts
+const identifyEvent = new Identify();
+identifyEvent.prepend('visited-locations', 'LAX');
 
-    ```ts
-    const identifyEvent = new Identify();
-    identifyEvent.prepend('visited-locations', 'LAX');
-
-    identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.prepend('visited-locations', 'LAX');
-
-    amplitude.identify(identifyEvent);
-    ```
+identify(identifyEvent);
+```
 
 #### Identify.append
 
 This method appends a value or values to a user property array. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are prepended.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.append('visited-locations', 'SFO');
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.append('visited-locations', 'SFO');
-
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.append('visited-locations', 'SFO');
-
-    amplitude.identify(identifyEvent);
-    ```
+amplitude.identify(identifyEvent);
+```
 
 #### Identify.preInsert
 
 This method pre-inserts a value or values to a user property, if it doesn't exist in the user property yet. Pre-insert means inserting the values at the beginning of a given list. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are pre-inserted. If the user property has an existing value, this method is a no-op.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.preInsert('unique-locations', 'LAX');
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.preInsert('unique-locations', 'LAX');
-
-    identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.preInsert('unique-locations', 'LAX');
-
-    amplitude.identify(identifyEvent);
-    ```
+identify(identifyEvent);
+```
 
 #### Identify.postInsert
 
 This method post-inserts a value or values to a user property, if it doesn't exist in the user property yet. Post-insert means inserting the values at the end of a given list. If the user property doesn't have a value set yet, it's initialized to an empty list before the new values are post-inserted. If the user property has an existing value, this method is a no-op..
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.postInsert('unique-locations', 'SFO');
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.postInsert('unique-locations', 'SFO');
-
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.postInsert('unique-locations', 'SFO');
-
-    amplitude.identify(identifyEvent);
-    ```
+amplitude.identify(identifyEvent);
+```
 
 #### Identify.remove
 
 This method removes a value or values to a user property, if it exists in the user property. Remove means remove the existing values from the given list. If the user property has an existing value, this method is a no-op.
 
-===  "Classic script"
+```ts
+const identifyEvent = new amplitude.Identify();
+identifyEvent.remove('unique-locations', 'JFK')
 
-    ```ts
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.remove('unique-locations', 'JFK')
-
-    amplitude.identify(identifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as Amplitude from '@amplitude/analytics-browser';
-
-    const identifyEvent = new amplitude.Identify();
-    identifyEvent.remove('unique-locations', 'JFK')
-
-    amplitude.identify(identifyEvent);
-    ```
+amplitude.identify(identifyEvent);
+```
 
 ### User groups
 
@@ -563,27 +317,13 @@ This method removes a value or values to a user property, if it exists in the us
 
 --8<-- "includes/groups-intro-paragraph.md"
 
-===  "Classic script"
+```ts
+// set group with single group name
+amplitude.setGroup('orgId', '15');
 
-    ```ts
-    // set group with single group name
-    amplitude.setGroup('orgId', '15');
-
-    // set group with multiple group names
-    amplitude.setGroup('sport', ['soccer', 'tennis']);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    // set group with single group name
-    amplitude.setGroup('orgId', '15');
-
-    // set group with multiple group names
-    amplitude.setGroup('sport', ['soccer', 'tennis']);
-    ```
+// set group with multiple group names
+amplitude.setGroup('sport', ['soccer', 'tennis']);
+```
 
 ### Group properties
 
@@ -593,29 +333,14 @@ Use the Group Identify API to set or update properties of particular groups. The
 
 The `groupIdentify()` method accepts a group type and group name string parameter, as well as an Identify object that's applied to the group.
 
-===  "Classic script"
+```ts
+const groupType = 'plan';
+const groupName = 'enterprise';
+const groupIdentifyEvent = new amplitude.Identify()
+groupIdentifyEvent.set('key1', 'value1');
 
-    ```ts
-    const groupType = 'plan';
-    const groupName = 'enterprise';
-    const groupIdentifyEvent = new amplitude.Identify()
-    groupIdentifyEvent.set('key1', 'value1');
-
-    amplitude.groupIdentify(groupType, groupName, groupIdentifyEvent);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const groupType = 'plan';
-    const groupName = 'enterprise';
-    const groupIdentifyEvent = new amplitude.Identify()
-    groupIdentifyEvent.set('key1', 'value1');
-
-    amplitude.groupIdentify(groupType, groupName, groupIdentifyEvent);
-    ```
+amplitude.groupIdentify(groupType, groupName, groupIdentifyEvent);
+```
 
 ### Revenue tracking
 <!-- vale off-->
@@ -626,29 +351,14 @@ The preferred method of tracking revenue for a user is to use `revenue()` in con
 
 To track revenue from a user, call revenue each time a user generates revenue. In this example, 3 units of a product was purchased at $3.99.
 
-===  "Classic script"
+```ts
+const event = new amplitude.Revenue()
+  .setProductId('com.company.productId')
+  .setPrice(3.99)
+  .setQuantity(3);
 
-    ```ts
-    const event = new amplitude.Revenue()
-      .setProductId('com.company.productId')
-      .setPrice(3.99)
-      .setQuantity(3);
-
-    amplitude.revenue(event);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    const event = new amplitude.Revenue()
-      .setProductId('com.company.productId')
-      .setPrice(3.99)
-      .setQuantity(3);
-
-    amplitude.revenue(event);
-    ```
+amplitude.revenue(event);
+```
 
 #### Revenue interface
 
@@ -666,92 +376,40 @@ To track revenue from a user, call revenue each time a user generates revenue. I
 
 The `flush` method triggers the client to send buffered events immediately.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.flush();
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.flush();
-    ```
+```ts
+amplitude.flush();
+```
 
 By default, `flush` is called automatically in an interval, if you want to flush the events all together, you can control the async flow with the optional Promise interface, example:
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY).promise.then(function() {
-      amplitude.track('Button Clicked');
-      amplitude.flush();
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    await amplitude.init(API_KEY).promise;
-    amplitude.track('Button Clicked');
-    await amplitude.flush().promise;
-    ```
+```ts
+amplitude.init(API_KEY).promise.then(function() {
+  amplitude.track('Button Clicked');
+  amplitude.flush();
+});
+```
 
 ### Custom user ID
 
 If your app has its own login system that you want to track users with, you can call `setUserId` at any time.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.setUserId('user@amplitude.com');
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.setUserId('user@amplitude.com');
-    ```
+```ts
+amplitude.setUserId('user@amplitude.com');
+```
 
 You can also assign the User ID as an argument to the init call.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, 'user@amplitude.com');
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, 'user@amplitude.com');
-    ```
+```ts
+amplitude.init(API_KEY, 'user@amplitude.com');
+```
 
 ### Custom session ID
 
 You can assign a new Session ID using `setSessionId`. When setting a custom session ID, make sure the value is in milliseconds since epoch (Unix Timestamp).
 
-===  "Classic script"
-
-    ```ts
-    amplitude.setSessionId(Date.now());
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.setSessionId(Date.now());
-    ```
+```ts
+amplitude.setSessionId(Date.now());
+```
 
 ### Custom device ID
 
@@ -759,20 +417,9 @@ If your app has its own login system that you want to track users with, you can 
 
 You can assign a new device ID using `deviceId`. When setting a custom device ID, make sure the value is sufficiently unique. Amplitude recommends using a UUID.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.setDeviceId(uuid());
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { v4 as uuid } from 'uuid';
-    
-    amplitude.setDeviceId(uuid());
-    ```
+```ts
+amplitude.setDeviceId(uuid());
+```
 
 ### Reset when user logs out
 
@@ -783,55 +430,25 @@ You can assign a new device ID using `deviceId`. When setting a custom device ID
 
 With an undefined `userId` and a completely new `deviceId`, the current user would appear as a brand new user in dashboard.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.reset();
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.reset();
-    ```
+```ts
+amplitude.reset();
+```
 
 ### Opt users out of tracking
 
 You can turn off logging for a given user by setting `setOptOut` to `true`.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.setOptOut(true);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.setOptOut(true);
-    ```
+```ts
+amplitude.setOptOut(true);
+```
 
 Events aren't saved or sent to the server while `setOptOut` is enabled, and the setting persists across page loads. 
 
 Re-enable logging by setting `setOptOut` to `false`.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.setOptOut(false);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.setOptOut(false);
-    ```
+```ts
+amplitude.setOptOut(false);
+```
 
 ### Optional tracking
 
@@ -847,45 +464,25 @@ By default, the SDK tracks these properties automatically. You can override this
 | `osVersion` | `true` |
 | `platform` | `true` |
 
-===  "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      trackingOptions: {
-        deviceManufacturer: false,
-        deviceModel: false,
-        ipAddress: false,
-        language: false,
-        osName: false,
-        osVersion: false,
-        platform: false,
-      },
-    });
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      trackingOptions: {
-        deviceManufacturer: false,
-        deviceModel: false,
-        ipAddress: false,
-        language: false,
-        osName: false,
-        osVersion: false,
-        platform: false,
-      },
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  trackingOptions: {
+    deviceManufacturer: false,
+    deviceModel: false,
+    ipAddress: false,
+    language: false,
+    osName: false,
+    osVersion: false,
+    platform: false,
+  },
+});
+```
 
 ### Callback
 
 All asynchronous API are optionally awaitable through a Promise interface. This also serves as callback interface.
 
-===  "Classic script (Promise)"
+=== "Promise"
 
     ```ts
     amplitude.track('Button Clicked').promise.then(function(result) {
@@ -895,7 +492,7 @@ All asynchronous API are optionally awaitable through a Promise interface. This 
     });
     ```
 
-===  "Module script (async/await)"
+=== "async/await"
 
     ```ts
     import * as amplitude from '@amplitude/analytics-browser';
@@ -915,37 +512,17 @@ Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying 
 
 The `add` method adds a plugin to Amplitude. Plugins can help processing and sending events.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.add(new Plugin());
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.add(new Plugin());
-    ```
+```ts
+amplitude.add(new Plugin());
+```
 
 #### `remove`
 
 The `remove` method removes the given plugin name from the client instance if it exists.
 
-===  "Classic script"
-
-    ```ts
-    amplitude.remove(plugin.name);
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.remove(plugin.name);
-    ```
+```ts
+amplitude.remove(plugin.name);
+```
 
 #### Create your custom plugin
 
@@ -963,197 +540,96 @@ This method contains the logic for processing events and has event as parameter.
 
 Here's an example of a plugin that sends each event that's instrumented to a target server URL using your preferred HTTP client.
 
-===  "Classic script"
+```ts
+function myDestinationPlugin (serverUrl) {
+  const name = 'my-destination-plugin';
+  const type = amplitude.Types.PluginType.DESTINATION;
+  let amplitudeConfig;
+  
+  /**
+   * setup() is called on plugin installation
+   * example: amplitude.add(new myDestinationPlugin());
+   */
+  const setup = function (config) {
+    amplitudeConfig = config;
+  }
 
-    ```ts
-    function myDestinationPlugin (serverUrl) {
-      const name = 'my-destination-plugin';
-      const type = amplitude.Types.PluginType.DESTINATION;
-      let amplitudeConfig;
-      
-      /**
-       * setup() is called on plugin installation
-       * example: amplitude.add(new myDestinationPlugin());
-       */
-      const setup = function (config) {
-        amplitudeConfig = config;
-      }
-
-      /**
-       * execute() is called on each event instrumented
-       * example: amplitude.track('New Event');
-       */
-      const execute = function (event) {
-        const payload = {
-          key: 'secret',
-          data: event,
-        };
-        return fetch(this.serverUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: '*/*',
-          },
-          body: JSON.stringify(payload),
-        }).then(function(response) {
-          return {
-            code: response.status,
-            event: event,
-            message: response.statusText,
-          };
-        });
-      }
-
-      return {
-        name,
-        type,
-        setup,
-        execute,
-      },
-    }
-
-    amplitude.init(API_KEY);
-    amplitude.add(myDestinationPlugin('https://custom.domain.com'));
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { BrowserConfig, DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
-
-    const myDestinationPlugin = (serverUrl: string): DestinationPlugin => {
-      const name = 'my-destination-plugin';
-      const type = PluginType.DESTINATION as const;
-      let amplitudeConfig: BrowserConfig | undefined;
-
-      /**
-       * setup() is called on plugin installation
-       * example: amplitude.add(new MyDestinationPlugin());
-       */
-      const setup = async (config: BrowserConfig): Promise<undefined> => {
-        amplitudeConfig = config;
-        return;
-      };
-
-      /**
-       * execute() is called on each event instrumented
-       * example: amplitude.track('New Event');
-       */
-      const execute = async (event: Event): Promise<Result> => {
-        const payload = {
-          key: 'secret',
-          data: event,
-        };
-        const response = await fetch(serverUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: '*/*',
-          },
-          body: JSON.stringify(payload),
-        });
-        return {
-          code: response.status,
-          event: event,
-          message: response.statusText,
-        };
-      };
-
-      return {
-        name,
-        type,
-        setup,
-        execute,
-      };
+  /**
+   * execute() is called on each event instrumented
+   * example: amplitude.track('New Event');
+   */
+  const execute = function (event) {
+    const payload = {
+      key: 'secret',
+      data: event,
     };
+    return fetch(this.serverUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      body: JSON.stringify(payload),
+    }).then(function(response) {
+      return {
+        code: response.status,
+        event: event,
+        message: response.statusText,
+      };
+    });
+  }
 
-    amplitude.init(API_KEY);
-    amplitude.add(myDestinationPlugin('https://custom.domain.com'));
-    ```
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  },
+}
+
+amplitude.init(API_KEY);
+amplitude.add(myDestinationPlugin('https://custom.domain.com'));
+```
 
 ##### Enrichment type plugin
 
 Here's an example of a plugin that modifies each event that's instrumented by adding an increment integer to `event_id` property of an event starting from 100.
 
-===  "Classic script"
+```ts
+const addEventIdPlugin = () => {
+  const name = 'add-event-id';
+  const type = amplitude.Types.PluginType.ENRICHMENT;
+  let currentId = 100;
+  let amplitudeConfig;
 
-    ```ts
-    const addEventIdPlugin = () => {
-      const name = 'add-event-id';
-      const type = amplitude.Types.PluginType.ENRICHMENT;
-      let currentId = 100;
-      let amplitudeConfig;
+  /**
+   * setup() is called on plugin installation
+   * example: amplitude.add(new AddEventIdPlugin());
+   */
+  const setup = function (config) {
+    amplitudeConfig = config;
+  }
 
-      /**
-       * setup() is called on plugin installation
-       * example: amplitude.add(new AddEventIdPlugin());
-       */
-      const setup = function (config) {
-        amplitudeConfig = config;
-      }
+  /**
+   * execute() is called on each event instrumented
+   * example: client.track('New Event');
+   */
+  const execute = function (event: Event) {
+    event.event_id = currentId++;
+    return event;
+  }
 
-      /**
-       * execute() is called on each event instrumented
-       * example: client.track('New Event');
-       */
-      const execute = function (event: Event) {
-        event.event_id = currentId++;
-        return event;
-      }
+  return {
+    name,
+    type,
+    setup,
+    execute,
+  }
+}
 
-      return {
-        name,
-        type,
-        setup,
-        execute,
-      }
-    }
-
-    amplitude.init('API_KEY');
-    amplitude.add(addEventIdPlugin());
-    ```
-
-===  "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { BrowserConfig, EnrichmentPlugin, Event, PluginType } from '@amplitude/analytics-types';
-
-    const addEventIdPlugin = (): EnrichmentPlugin => {
-      const name = 'add-event-id';
-      const type = PluginType.ENRICHMENT as const;
-      let currentId = 100;
-      let amplitudeConfig: BrowserConfig | undefined;
-
-      /**
-       * setup() is called on plugin installation
-       * example: amplitude.add(new AddEventIdPlugin());
-       */
-      const setup = async (config: BrowserConfig): Promise<void> => {
-        amplitudeConfig = config;
-      }
-
-      /**
-       * execute() is called on each event instrumented
-       * example: client.track('New Event');
-       */
-      const execute = async (event: Event): Promise<Event> => {
-        event.event_id = currentId++;
-        return event;
-      }
-
-      return {
-        name,
-        type,
-        setup,
-        execute,
-      }
-    }
-
-    amplitude.init('API_KEY');
-    amplitude.add(addEventIdPlugin());
-    ```
+amplitude.init(API_KEY);
+amplitude.add(addEventIdPlugin());
+```
 
 ##### Web attribution enrichment plugin
 
@@ -1171,24 +647,12 @@ You need to download `plugin-web-attribution-browser` package and add the `webAt
     yarn add @amplitude/plugin-web-attribution-browser
     ```
 
-Add plugin to Ampltude instance.
+Add plugin to Amplitude instance.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.add(webAttributionPlugin());
-    amplitude.init(API_KEY);
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { webAttributionPlugin } from '@amplitude/plugin-web-attribution-browser';
-
-    amplitude.add(webAttributionPlugin());
-    amplitude.init(API_KEY);
-    ```
+```ts
+amplitude.add(webAttributionPlugin());
+amplitude.init(API_KEY);
+```
 
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Web Attribution Plugin](../marketing-analytics-browser/#web-attribution) supports.
@@ -1220,24 +684,12 @@ You need to download `plugin-page-view-tracking-browser` and add the `pageViewTr
     yarn add @amplitude/plugin-page-view-tracking-browser
     ```
 
-Add plugin to Ampltude instance.
+Add plugin to Amplitude instance.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.add(pageViewTrackingPlugin());
-    amplitude.init(API_KEY);
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { pageViewTrackingPlugin } from '@amplitude/plugin-page-view-tracking-browser';
-
-    amplitude.add(pageViewTrackingPlugin(client));
-    amplitude.init(API_KEY);
-    ```
+```ts
+amplitude.add(pageViewTrackingPlugin());
+amplitude.init(API_KEY);
+```
 
 See the [configuration options](../marketing-analytics-browser/#configuration).
 Learn more about what the [Page View Plugin](../marketing-analytics-browser/#page-view) supports.
@@ -1270,36 +722,17 @@ If the `deviceId` isn't provided with the `init` like `init('API_KEY', null, { d
 
 You can provide an implementation of `Transport` interface to the `transportProvider` configuration option for customization purpose, for example, sending requests to your proxy server with customized HTTP request headers.
 
-=== "Classic script"
+```ts
+class MyTransport {
+  send(serverUrl, payload) {
+    // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
+  }
+}
 
-    ```ts
-    class MyTransport {
-      send(serverUrl, payload) {
-        // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
-      }
-    }
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      transportProvider: new MyTransport(),
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-    import { Transport } from '@amplitude/analytics-types';
-
-    class MyTransport implements Transport {
-      async send(serverUrl: string, payload: Payload): Promise<Response | null> {
-        // check example: https://github.com/amplitude/Amplitude-TypeScript/blob/main/packages/analytics-client-common/src/transports/fetch.ts
-      }
-    }
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      transportProvider: new MyTransport(),
-    });
-    ```
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  transportProvider: new MyTransport(),
+});
+```
 
 ### Content Security Policy (CSP)
 

--- a/includes/sdk-ts-browser/init.md
+++ b/includes/sdk-ts-browser/init.md
@@ -1,29 +1,12 @@
 You must initialize the SDK before you can instrument any events. Your Amplitude project's API key is required. You can pass an optional user ID and config object in this call. You can use the SDK anywhere after it's initialized anywhere in an application.
 
-=== "Classic script"
+```ts
+// Option 1, initialize with API_KEY only
+amplitude.init(API_KEY);
 
-    ```ts
-    // Option 1, initialize with API_KEY only
-    amplitude.init(API_KEY);
+// Option 2, initialize including user ID if it's already known
+amplitude.init(API_KEY, 'user@amplitude.com');
 
-    // Option 2, initialize including user ID if it's already known
-    amplitude.init(API_KEY, 'user@amplitude.com');
-
-    // Option 3, initialize including configuration
-    amplitude.init(API_KEY, 'user@amplitude.com', configurationObj);
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    // Option 1, initialize with API_KEY only
-    amplitude.init(API_KEY);
-
-    // Option 2, initialize including user ID if it's already known
-    amplitude.init(API_KEY, 'user@amplitude.com');
-
-    // Option 3, initialize including configuration
-    amplitude.init(API_KEY, 'user@amplitude.com', configurationObj);
-    ```
+// Option 3, initialize including configuration
+amplitude.init(API_KEY, 'user@amplitude.com', configurationObj);
+```

--- a/includes/sdk-ts-browser/init.md
+++ b/includes/sdk-ts-browser/init.md
@@ -1,15 +1,29 @@
 You must initialize the SDK before you can instrument any events. Your Amplitude project's API key is required. You can pass an optional user ID and config object in this call. You can use the SDK anywhere after it's initialized anywhere in an application.
 
-```ts
-import { init }  from '@amplitude/analytics-browser';
+=== "Classic script"
 
-// Option 1, initialize with API_KEY only
-init(API_KEY);
+    ```ts
+    // Option 1, initialize with API_KEY only
+    amplitude.init(API_KEY);
 
-// Option 2, initialize including user ID if it's already known
-init(API_KEY, 'user@amplitude.com');
+    // Option 2, initialize including user ID if it's already known
+    amplitude.init(API_KEY, 'user@amplitude.com');
 
-// Option 3, initialize including configuration
-init(API_KEY, 'user@amplitude.com', configurationObj);
+    // Option 3, initialize including configuration
+    amplitude.init(API_KEY, 'user@amplitude.com', configurationObj);
+    ```
 
-```
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    // Option 1, initialize with API_KEY only
+    amplitude.init(API_KEY);
+
+    // Option 2, initialize including user ID if it's already known
+    amplitude.init(API_KEY, 'user@amplitude.com');
+
+    // Option 3, initialize including configuration
+    amplitude.init(API_KEY, 'user@amplitude.com', configurationObj);
+    ```

--- a/includes/sdk-ts-browser/marketing-analytics.md
+++ b/includes/sdk-ts-browser/marketing-analytics.md
@@ -101,127 +101,59 @@ Amplitude tracks the following as user properties:
 
 For users who initially visits a page directly or organically, by default, the initial value is set to `"EMPTY"`. If you prefer a different initial value, set `attriubtion.initialEmptyValue` to any string value.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        initialEmptyValue: 'none',
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        initialEmptyValue: 'none',
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  attribution: {
+    initialEmptyValue: 'none',
+  }
+});
+```
 
 #### Exclude the referrers from specific domain
 
 You can configure Amplitude to opt out of collection of attribution data for a given list of referrers.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        excludeReferrers: ['www.test.com'],
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        excludeReferrers: ['www.test.com'],
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  attribution: {
+    excludeReferrers: ['www.test.com'],
+  }
+});
+```
 
 #### Reset the session on a new campaign
 
 You can configure Amplitude to reset the session on a new campaign. Do this by setting `attribution.resetSessionOnNewCampaign` to `true`. By default `attribution.resetSessionOnNewCampaign` is set to `false`.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        resetSessionOnNewCampaign: true,
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        resetSessionOnNewCampaign: true,
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  attribution: {
+    resetSessionOnNewCampaign: true,
+  }
+});
+```
 
 #### Disable attribution tracking
 
 You can configure Amplitude to opt out of automatic collection of attribution data. Do this by setting `attribution.disabled` to `true`. By default `attribution.disabled` is set to `false`.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        disabled: true,
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      attribution: {
-        disabled: true,
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  attribution: {
+    disabled: true,
+  }
+});
+```
 
 ### Page view
 
 Enable page view tracking by setting `pageViewTracking` to `true`. The page view event is fired when the page loads.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: true
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: true
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  pageViewTracking: true
+});
+```
 
 You can set `pageViewTracking` to an object to pass more options.
 
@@ -229,57 +161,27 @@ You can set `pageViewTracking` to an object to pass more options.
 
 Set the `trackOn` option to `'attribution'` to send Page View events _only_ when attribution information changes.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackOn: 'attribution',
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackOn: 'attribution',
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  pageViewTracking: {
+    trackOn: 'attribution',
+  }
+});
+```
 
 #### Track the page view event based on specific criteria
 
 `trackOn` can also be set to a function callback to fully customize when a Page View event is sent.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackOn: () => {
-          return window.location.pathname === '/landing_page'
-        },
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackOn: () => {
-          return window.location.pathname === '/landing_page'
-        },
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  pageViewTracking: {
+    trackOn: () => {
+      return window.location.pathname === '/landing_page'
+    },
+  }
+});
+```
 
 #### Single page app page view tracking
 
@@ -293,24 +195,10 @@ Possible values for `trackHistoryChanges`:
 
 You can set the `trackHistoryChanges` to `pathOnly` to only track the on path changes. By default, full page URL is considered into the page view changes.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackHistoryChanges: 'pathOnly' // or 'all'
-      }
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/marketing-analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      pageViewTracking: {
-        trackHistoryChanges: 'pathOnly' // or 'all'
-      }
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  pageViewTracking: {
+    trackHistoryChanges: 'pathOnly' // or 'all'
+  }
+});
+```

--- a/includes/sdk-ts-browser/marketing-analytics.md
+++ b/includes/sdk-ts-browser/marketing-analytics.md
@@ -101,58 +101,127 @@ Amplitude tracks the following as user properties:
 
 For users who initially visits a page directly or organically, by default, the initial value is set to `"EMPTY"`. If you prefer a different initial value, set `attriubtion.initialEmptyValue` to any string value.
 
-```ts
-init(API_KEY, OPTIONAL_USER_ID, {
-  attribution: {
-    initialEmptyValue: "none",
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        initialEmptyValue: 'none',
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        initialEmptyValue: 'none',
+      }
+    });
+    ```
 
 #### Exclude the referrers from specific domain
 
 You can configure Amplitude to opt out of collection of attribution data for a given list of referrers.
 
-```ts
-init(API_KEY, OPTIONAL_USER_ID, {
-  attribution: {
-    excludeReferrers: ['www.test.com'],
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        excludeReferrers: ['www.test.com'],
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        excludeReferrers: ['www.test.com'],
+      }
+    });
+    ```
 
 #### Reset the session on a new campaign
 
 You can configure Amplitude to reset the session on a new campaign. Do this by setting `attribution.resetSessionOnNewCampaign` to `true`. By default `attribution.resetSessionOnNewCampaign` is set to `false`.
 
-```ts
-init(API_KEY, OPTIONAL_USER_ID, {
-  attribution: {
-    resetSessionOnNewCampaign: true,
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        resetSessionOnNewCampaign: true,
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        resetSessionOnNewCampaign: true,
+      }
+    });
+    ```
 
 #### Disable attribution tracking
 
 You can configure Amplitude to opt out of automatic collection of attribution data. Do this by setting `attribution.disabled` to `true`. By default `attribution.disabled` is set to `false`.
 
-```ts
-init(API_KEY, OPTIONAL_USER_ID, {
-  attribution: {
-    disabled: true,
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        disabled: true,
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      attribution: {
+        disabled: true,
+      }
+    });
+    ```
 
 ### Page view
 
 Enable page view tracking by setting `pageViewTracking` to `true`. The page view event is fired when the page loads.
-```ts
-init(API_KEY, 'user@amplitude.com', {
-  pageViewTracking: true
-});
-```
+
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: true
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: true
+    });
+    ```
 
 You can set `pageViewTracking` to an object to pass more options.
 
@@ -160,27 +229,57 @@ You can set `pageViewTracking` to an object to pass more options.
 
 Set the `trackOn` option to `'attribution'` to send Page View events _only_ when attribution information changes.
 
-```ts
-init(API_KEY, 'user@amplitude.com', {
-  pageViewTracking: {
-    trackOn: 'attribution',
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackOn: 'attribution',
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackOn: 'attribution',
+      }
+    });
+    ```
 
 #### Track the page view event based on specific criteria
 
 `trackOn` can also be set to a function callback to fully customize when a Page View event is sent.
 
-```ts
-init(API_KEY, 'user@amplitude.com', {
-  pageViewTracking: {
-    trackOn: () => {
-      return window.location.pathname === '/landing_page'
-    },
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackOn: () => {
+          return window.location.pathname === '/landing_page'
+        },
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackOn: () => {
+          return window.location.pathname === '/landing_page'
+        },
+      }
+    });
+    ```
 
 #### Single page app page view tracking
 
@@ -194,10 +293,24 @@ Possible values for `trackHistoryChanges`:
 
 You can set the `trackHistoryChanges` to `pathOnly` to only track the on path changes. By default, full page URL is considered into the page view changes.
 
-```ts
-init(API_KEY, 'user@amplitude.com', {
-  pageViewTracking: {
-    trackHistoryChanges: 'pathOnly' // or 'all'
-  }
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackHistoryChanges: 'pathOnly' // or 'all'
+      }
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/marketing-analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      pageViewTracking: {
+        trackHistoryChanges: 'pathOnly' // or 'all'
+      }
+    });
+    ```

--- a/includes/sdk-ts/client-debugging.md
+++ b/includes/sdk-ts/client-debugging.md
@@ -8,66 +8,30 @@ You can control the level of logs printed to the developer console.
 
 Set the log level by configuring the `logLevel` with the level you want.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      logLevel: amplitude.Types.LogLevel.Warn,
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      logLevel: amplitude.Types.LogLevel.Warn,
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  logLevel: amplitude.Types.LogLevel.Warn,
+});
+```
 
 The default logger outputs logs to the developer console. You can provide your own logger implementation based on the `Logger` interface for any customization purpose. For example, collecting any error messages from the SDK in a production environment.
 
 Set the logger by configuring the `loggerProvider` with your own implementation.
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      loggerProvider: new MyLogger(),
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      loggerProvider: new MyLogger(),
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  loggerProvider: new MyLogger(),
+});
+```
 
 #### Debug Mode
 Enable the debug mode by setting the `logLevel` to "Debug", example:
 
-=== "Classic script"
-
-    ```ts
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      logLevel: amplitude.Types.LogLevel.Debug,
-    });
-    ```
-
-=== "Module script"
-
-    ```ts
-    import * as amplitude from '@amplitude/analytics-browser';
-
-    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-      logLevel: amplitude.Types.LogLevel.Debug,
-    });
-    ```
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  logLevel: amplitude.Types.LogLevel.Debug,
+});
+```
 
 With the default logger, extra function context information will be output to the developer console when invoking any SDK public method, including:
 

--- a/includes/sdk-ts/client-debugging.md
+++ b/includes/sdk-ts/client-debugging.md
@@ -8,30 +8,66 @@ You can control the level of logs printed to the developer console.
 
 Set the log level by configuring the `logLevel` with the level you want.
 
-```ts
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  logLevel: amplitude.Types.LogLevel.Warn,
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      logLevel: amplitude.Types.LogLevel.Warn,
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      logLevel: amplitude.Types.LogLevel.Warn,
+    });
+    ```
 
 The default logger outputs logs to the developer console. You can provide your own logger implementation based on the `Logger` interface for any customization purpose. For example, collecting any error messages from the SDK in a production environment.
 
 Set the logger by configuring the `loggerProvider` with your own implementation.
 
-```ts
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  loggerProvider: new MyLogger(),
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      loggerProvider: new MyLogger(),
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      loggerProvider: new MyLogger(),
+    });
+    ```
 
 #### Debug Mode
 Enable the debug mode by setting the `logLevel` to "Debug", example:
 
-```ts
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  logLevel: amplitude.Types.LogLevel.Debug,
-});
-```
+=== "Classic script"
+
+    ```ts
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      logLevel: amplitude.Types.LogLevel.Debug,
+    });
+    ```
+
+=== "Module script"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+
+    amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+      logLevel: amplitude.Types.LogLevel.Debug,
+    });
+    ```
 
 With the default logger, extra function context information will be output to the developer console when invoking any SDK public method, including:
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

* Adds docs for default event tracking
* Updates code samples for browser SDK and marketing analytics SDK to include classic and module script

Affected pages/sections:
* https://pr-628.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-browser/#tracking-default-events
* https://pr-628.d19s7xzcva2mw3.amplifyapp.com/data/sdks/sdk-quickstart/
* https://pr-628.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-browser/
* https://pr-628.d19s7xzcva2mw3.amplifyapp.com/data/sdks/marketing-analytics-browser/

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [x] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
