### PR TITLE
AMP-70231-improve-auth-documentation

### DIFF
--- a/docs/analytics/apis/behavioral-cohorts-api.md
+++ b/docs/analytics/apis/behavioral-cohorts-api.md
@@ -35,7 +35,7 @@ Get all discoverable cohorts for an app. Use the `id` for each cohort returned i
     ```bash
 
     curl --location --request GET 'https://amplitude.com/api/3/cohorts' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -90,7 +90,7 @@ This is step one in the download a cohort operation. Use the `request_id` return
     ```bash
 
     curl --location --request GET 'https://amplitude.com/api/5/cohorts/request/id'
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
 
     ```
 
@@ -198,7 +198,7 @@ Poll the request status using the `request_id` retrieved for the cohort. This is
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/5/cohorts/request-status/:request_id' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded'
+    -u '{api_key}:{secret_key}''
     ```
 
 === "HTTP"
@@ -265,7 +265,7 @@ This is a basic request.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/5/cohorts/request/:requestId/file' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -318,7 +318,7 @@ Generate a new cohort or update an existing cohort by uploading a set of User ID
     ```bash
     curl --location --request POST 'https://amplitude.com/api/3/cohorts/upload' \
     --header 'Content-Type: application/json' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded'
+    -u '{api_key}:{secret_key}''
     --data-raw '{
       "name": "Cohort Name",
       "app_id": amplitude_project,
@@ -365,7 +365,7 @@ Generate a new cohort or update an existing cohort by uploading a set of User ID
         curl --location --request POST 'https://amplitude.com/api/3/cohorts/upload' \
         --header 'Content-Type: application/json' \
         --header 'Authorization: Basic MTIzNDU2NzgwMDoxMjM0NTY3MDA=' \
-        --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded \
+        -u '{api_key}:{secret_key}' \
         --data-raw '{
           "name": "New Cohort",
           "app_id": 153957,
@@ -435,7 +435,7 @@ Add and remove IDs to incrementally update existing cohort membership.
     ```bash
     curl --location --request POST 'https://amplitude.com/api/3/cohorts/membership' \
     --header 'Content-Type: application/json' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --data-raw '{
     "cohort_id":"COHORT_ID",
     "memberships": [

--- a/docs/analytics/apis/ccpa-dsar-api.md
+++ b/docs/analytics/apis/ccpa-dsar-api.md
@@ -98,7 +98,7 @@ Create a request for user data.
     curl --location --request POST 'https://amplitude.com/api/2/dsar/requests' \
     --header 'Accept: application/json' \
     --header 'Content-Type: application/json' \
-    --header 'Authorization: Basic {{org-api-key}}:{{org-secret_key}}' # credentials must be base64 encoded \
+    -u '{org-api-key}:{org-secret_key}' \
     --data-raw '{
         "userId": 12345,
         "startDate": "2020-04-24",
@@ -281,7 +281,7 @@ The download link is valid for two days. Most clients used to send API requests 
 
     ```bash
     curl --location --request GET 'https://analytics.amplitude.com/api/2/dsar/requests/:request_id/outputs/:output_id' \
-    --header 'Authorization: Basic {{org-api-key}}:{{org-secret_key}}' # credentials must be base64 encoded
+    -u '{org-api-key}:{org-secret_key}'
     ```
 
 === "HTTP"

--- a/docs/analytics/apis/dashboard-rest-api.md
+++ b/docs/analytics/apis/dashboard-rest-api.md
@@ -173,7 +173,7 @@ Get JSON results from any saved chart via chart ID.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/3/chart/:chart_id/query' \
-    --header 'Authorization: Basic = {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "Python"
@@ -184,11 +184,9 @@ Get JSON results from any saved chart via chart ID.
     url = "https://amplitude.com/api/3/chart/:chart_id/query"
 
     payload={}
-    headers = {
-      'Authorization': 'Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
-    }
+    auth=requests.auth.HTTPBasicAuth('api-key', 'secret-key')
 
-    response = requests.request("GET", url, headers=headers, data=payload)
+    response = requests.request("GET", url, auth=auth, data=payload)
 
     print(response.text)
 
@@ -218,7 +216,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/users?start=STARTDATE&end=ENDDATE' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -403,7 +401,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/sessions/length?start=STARTDATE&end=ENDDATE'
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' # credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -524,7 +522,7 @@ This request retrieves the average session length in seconds for the period betw
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/sessions/average?start=20210601&end=20210630' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -581,7 +579,7 @@ This example retrieves the average number of sessions per user on each day betwe
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/sessions/peruser?start=&end=' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -638,7 +636,7 @@ This is a basic request.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/composition?start=STARTDATE&end=ENDDATE&p=PROPERTY' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' # credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -744,7 +742,7 @@ Get the list of events with the current week's totals, uniques, and % DAU (daily
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/events/list' \
-    --header 'Authorization: Basic ={{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api-key}:{secret-key}'
     ```
 
 === "HTTP"
@@ -807,7 +805,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/events/segmentation?e={"event_type":"YOUR%20EVENT"}&start=STARTDATE&end=DATE' \
-    --header 'Authorization: Basic ={{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api-key}:{secret-key}'
     ```
 
 === "HTTP"
@@ -1172,7 +1170,7 @@ This is a basic request with only the required fields.
 
     ```bash
     curl --location -g --request GET 'https://amplitude.com/api/2/funnels?e={"event_type":"EVENT_1"}&e={"event_type":"EVENT_2"}&start=STARTDATE&end=ENDDATE'
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -1419,7 +1417,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/retention?se={"event_type":"STARTEVENT"}&re={"event_type":"RETURNEVENT"}&start=STARTDATE&end=ENDDATE' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -1606,8 +1604,8 @@ This is a basic example with only the required parameters.
 === "cURL"
 
     ```bash
-        curl --location --request GET 'https://amplitude.com/api/2/useractivity?user=USERID'
-        --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+        curl --location --request GET 'https://amplitude.com/api/2/useractivity?user={amplitude_id}'
+        -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -1765,7 +1763,7 @@ Search for a user with a specified Amplitude ID, device ID, user ID, or user ID 
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/usersearch?user=USER_ID' \
-    --header 'Authorization: Basic ={{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api-key}:{secret-key}'
     ```
 
 === "HTTP"
@@ -1928,7 +1926,7 @@ Get active user numbers with 5-minute granularity for the last two days.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/realtime' \
-    --header 'Authorization: Basic ={{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api-key}:{secret-key}'
     ```
 
 === "HTTP"
@@ -1983,7 +1981,7 @@ Learn more about this chart in the [Help Center](https://help.amplitude.com/hc/e
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/revenue/ltv?start=&end=' \
-    --header 'Authorization: Basic ={{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api-key}:{secret-key}'
     ```
 
 === "HTTP"

--- a/docs/analytics/apis/event-streaming-metrics-summary-api.md
+++ b/docs/analytics/apis/event-streaming-metrics-summary-api.md
@@ -33,7 +33,7 @@ Here is a basic request with only the required parameters.
 
     ```bash
     curl --location --request GET 'https://analytics.amplitude.com/api/2/event-streaming/delivery-metrics-summary?sync_id=SYNC_ID&time_period=TIME_PERIOD' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64-encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"

--- a/docs/analytics/apis/export-api.md
+++ b/docs/analytics/apis/export-api.md
@@ -32,7 +32,7 @@ Send a GET request to `https://amplitude.com/api/2/export` with two required que
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/export?start=<starttime>&end=<endtime>' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"

--- a/docs/analytics/apis/taxonomy-api.md
+++ b/docs/analytics/apis/taxonomy-api.md
@@ -158,7 +158,7 @@ Get all event categories in your project.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/category' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -217,7 +217,7 @@ This is a basic request that shows the required fields.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/category/:category_name' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -297,7 +297,7 @@ This basic request shows the required fields.
 
     ```bash
     curl --location --request PUT 'https://amplitude.com/api/2/taxonomy/category/CATEGORY_ID' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'category_name=NEW_NAME'
     ```
@@ -394,7 +394,7 @@ This basic request shows the required fields.
 
     ```bash 
     curl --location --request DELETE 'https://amplitude.com/api/2/taxonomy/category/:category_id' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -480,7 +480,7 @@ This basic request shows the required fields.
 
     ```bash
     curl --location --request POST 'https://amplitude.com/api/2/taxonomy/event' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' # credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'event_type=EVENT_TYPE' \
     --data-urlencode 'category=CATEGORY_NAME' \
@@ -577,7 +577,7 @@ This basic request shows the required fields.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/event' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -630,7 +630,7 @@ This basic request shows the required fields.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/event:event_type' \
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -715,7 +715,7 @@ This is a basic request with the required path parameter and a few optional para
 
     ```bash
         curl --location --request PUT 'https://amplitude.com/api/2/taxonomy/event/EVENT_TYPE_NAME' \
-        --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+        -u '{api_key}:{secret_key}'
         --data-urlencode 'category=NEW_CATEGORY_NAME' \
         --data-urlencode 'display_name=NEW_EVENT_TYPE_DISPLAY_NAME'
     ```
@@ -816,7 +816,7 @@ Delete an event type.
 
     ```bash
     curl --location --request DELETE 'https://amplitude.com/api/2/taxonomy/event/EVENT_TYPE'
-    --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"
@@ -901,7 +901,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request POST 'https://amplitude.com/api/2/taxonomy/event-property' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'event_type=EVENT_TYPE' \
     --data-urlencode 'event_property=EVENT_PROPERTY' \
@@ -1005,7 +1005,7 @@ This is a basic request.
     ```bash
 
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/event-property' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'event_type=EVENT_NAME'
     ```
@@ -1103,7 +1103,7 @@ This is a basic request with the required path parameter and body parameter.
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/event-property?event_property=EVENT_PROPERTY' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'event_type=EVENT_NAME'
     ```
@@ -1208,7 +1208,7 @@ This is a basic request with only the required parameters.
 
     ```bash
     curl --location --request PUT 'https://amplitude.com/api/2/taxonomy/event-property/EVENT_PROPERTY' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded \
+    -u '{api_key}:{secret_key}' \
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'event_type=EVENT_NAME' \
     ```
@@ -1482,7 +1482,7 @@ Retrieves all user properties in your account. This call doesn't have any requir
 
     ```bash
     curl --location --request GET 'https://amplitude.com/api/2/taxonomy/user-property' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded'
+    -u '{api_key}:{secret_key}''
     ```
 
 === "HTTP"
@@ -1583,7 +1583,7 @@ This is a basic request.
 
 ```bash
 curl --location --request GET 'https://amplitude.com/api/2/taxonomy/user-property/USER_PROPERTY' \
---header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded
+-u '{api_key}:{secret_key}'
 ```
 
 === "HTTP"
@@ -1670,7 +1670,7 @@ This is a basic request with only the required path parameter and a few optional
 
     ```bash
     curl --location --request PUT 'https://amplitude.com/api/2/taxonomy/user-property/USER_PROPERTY' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     --header 'Content-Type: application/x-www-form-urlencoded' \
     --data-urlencode 'new_user_property_value=VALUE' \
     --data-urlencode 'description=DESCRIPTION'
@@ -1760,7 +1760,7 @@ Deletes a single user property, by name.
 
     ```bash
     curl --location --request DELETE 'https://amplitude.com/api/2/taxonomy/user-property/USER_PROPERTY' \
-    --header 'Authorization: Basic {{api-key}}:{{secret:key}}' #credentials must be base64 encoded
+    -u '{api_key}:{secret_key}'
     ```
 
 === "HTTP"


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

* The example says user=USERID when it should be user={amplitude_id} or something (the table below is correct)
* The curl request uses --header 'Authorization: Basic {{api-key}}:{{secret-key}}' #credentials must be base64 encoded when it should just say -u {api_key}:{secret_key} 
* Update the Python example to use Basic Auth properly.

This is a quick change to fix the obvious ones. We will be following up with a Dash Rest API documentation audit next quarter.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/72047120/222287152-fab4ab16-9cf3-45b1-b83b-3beae5d1dd77.png">
<img width="782" alt="image" src="https://user-images.githubusercontent.com/72047120/222290141-58429bbb-19b2-4fd6-9aad-5a15668d540a.png">




## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes AMP-70231. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
