### PR TITLE
fix Java doc structure and add default configurations

### DIFF
--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -46,7 +46,22 @@ Amplitude client = Amplitude.getInstance("YOUR_INSTANCE_NAME");
 client.init("YOUR_API_KEY");
 ```
 
-### Configure batching behavior
+### `Configuration`
+
+???config "Configuration Options"
+    | <div class="big-column">Name</div>  | Description | Default Value |
+    | --- | --- | --- |
+    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
+    | `minIdLength` | The minimum length for user id or device id. | `5` |
+    | `isBatchMode` |  Whether to use batch api. | `false` |
+    | `logMode` |  Whether to use batch api. | `LogMode.ERROR` |
+    | `eventUploadThreshold` |  SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. | `10` |
+    | `eventUploadPeriodMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach eventUploadThreshold threshold. | `10 seconds` |
+    | `callbacks` | Event callback which are triggered after event sent | `null`|
+    | `proxy` | custom proxy for https requests | `Proxy.NO_PROXY`|
+    | `flushTimeout` | events flushing thread timeout in milliseconds | `0` |
+
+#### Configure batching behavior
 
 To support high performance environments, the SDK sends events in batches. Every event logged by `logEvent` method is queued in memory. Events are flushed in batch in background. You can customize batch behavior with `setEventUpdloadThreshfold` and `setEventUploadPeriodMillis`.
 
@@ -79,7 +94,7 @@ client.useBatchMode(true);
 client.useBatchMode(false);
 ```
 
-## Config custom HTTP proxy
+#### Config custom HTTP proxy
 
 New in version 1.9.0. Set and unset custom proxy for HTTP requests.
 
@@ -91,7 +106,7 @@ client.setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy.domain.c
 client.setProxy(Proxy.NO_PROXY);
 ```
 
-## Config custom logger
+#### Config custom logger
 
 New in version 1.10.0. Set a customized logger for amplitude client.
 
@@ -107,7 +122,7 @@ client.setLogger(new AmplitudeLog() {
 });
 ```
 
-## Config events flushing thread timeout
+#### Config events flushing thread timeout
 
 New in version 1.10.0. Set events flushing thread timeout in milliseconds. If set to a positive long integer, events flushing tasks time out and trigger callbacks for those events.
 
@@ -115,7 +130,7 @@ New in version 1.10.0. Set events flushing thread timeout in milliseconds. If se
 client.setFlushTimeout(2000L); // 2 seconds
 ```
 
-## Shutdown client and release resource
+### Shutdown client and release resource
 
 New in version 1.10.0. Stops the Amplitude client from accepting new events and shuts down the threadspool. Events in the buffer trigger callbacks. A new instance is created and returned if you call `Amplitude.getInstance(INSTANCE_NAME)` with the same instance name.
 
@@ -123,7 +138,7 @@ New in version 1.10.0. Stops the Amplitude client from accepting new events and 
 client.shutdown();
 ```
 
-## Send events
+### Send events
 
 --8<-- "includes/sdk-httpv2-notice.md"
 
@@ -138,7 +153,7 @@ Amplitude client = Amplitude.getInstance();
 client.logEvent(new Event("Button Clicked", "test_user_id"));
 ```
 
-### Events with properties
+#### Events with properties
 
 Events can also contain properties. They provide context about the event taken. For example, "hover time" may be a relevant event property to "button click."
 
@@ -158,7 +173,7 @@ event.eventProperties = eventProps;
 client.logEvent(event);
 ```
 
-### Set user properties
+#### Set user properties
 
 !!!warning "Privacy and tracking"
 
@@ -182,7 +197,7 @@ event.userProperties = userProps;
 client.logEvent(event);
 ```
 
-### Set device information
+#### Set device information
 
 Unlike the Android SDK or iOS SDK, device information in Java SDK isn't collected via SDK. Device information like device id, device brand, device manufacturer, and device model can be set as properties in each event.
 
@@ -195,7 +210,7 @@ event.deviceModel = "device_model";
 client.logEvent(event);
 ```
 
-### Set session information
+#### Set session information
 
 You can set `sessionId` in an event. This pattern also applies to other properties like `city` and `price`. You can see a full list of events properties in [Event.java](https://github.com/amplitude/Amplitude-Java/blob/main/src/main/java/com/amplitude/Event.java).
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
Fix Java Doc structure and add the defaults configurations

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
