### PR TITLE
Update mkdocs material verison 8.5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for core
-mkdocs-material==8.1.8
+mkdocs-material==8.5.10
 jinja2>=3.0.2
 markdown>=3.2
 mkdocs>=1.4.0


### PR DESCRIPTION
## Description

Update the mkdocs-material version in requirements.txt.

I was getting an error when running locally due to: 
```
INFO     -  DeprecationWarning: invalid escape sequence '\s'
              File "/usr/local/lib/python3.9/site-packages/jinja2/lexer.py", line 389, in __next__
                self.current = next(self._iter)
              File "/usr/local/lib/python3.9/site-packages/jinja2/lexer.py", line 650, in wrap
                self._normalize_newlines(value_str[1:-1])
```

Quick google lead me to: https://github.com/squidfunk/mkdocs-material/issues/3695

I decided to use the latest version from 8.x.x.