### PR TITLE
Replaces JS icon

### DIFF
--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -1,7 +1,7 @@
 ---
 title: Marketing Analytics Browser
 description: The Amplitude Marketing Analytics Browser SDK Installation & Quick Start guide.
-icon: simple/typescript
+icon: simple/javascript
 ---
 
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -1,7 +1,7 @@
 ---
 title: Browser SDK
 description: The Amplitude Browser SDK Installation & Quick Start guide.
-icon: simple/typescript
+icon: simple/javascript
 ---
 
 

--- a/includes/data-sources-sdks-client-side.md
+++ b/includes/data-sources-sdks-client-side.md
@@ -3,8 +3,8 @@
 <div class="grid cards" markdown>
 
 - :android: [Android](/data/sdks/android-kotlin/)
-- :typescript: [Browser](/data/sdks/typescript-browser/)
-- :typescript: [Marketing Analytics Browser](/data/sdks/marketing-analytics-browser/)
+- :javascript-color: [Browser](/data/sdks/typescript-browser/)
+- :javascript-color: [Marketing Analytics Browser](/data/sdks/marketing-analytics-browser/)
 - :material-apple-ios: [iOS Swift (Beta)](/data/sdks/ios-swift/)
 - :material-apple-ios: [iOS](/data/sdks/ios/)
 - :flutter: [Flutter](/data/sdks/flutter)


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Replaced TypeScript icon with JavaScript icon

![Screenshot 2023-03-08 at 3 41 55 PM](https://user-images.githubusercontent.com/20634289/223877913-f251f740-3900-4df1-ad29-3e36b92b6acc.png)

![Screenshot 2023-03-08 at 3 42 04 PM](https://user-images.githubusercontent.com/20634289/223877963-0dfd52a4-c283-486c-bc1a-3b3113489ca3.png)

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [x] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
