### PR TITLE
add more default configuration

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -22,31 +22,92 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
 
 ## Usage
 
-### `Configuration`
+### Configuration
 
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    | `flushIntervalMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
-    | `flushQueueSize` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
-    | `flushMaxRetries` | Maximum retry times.  | `5` |
-    | `minIdLength` | The minimum length for user id or device id. | `5` |
-    | `partnerId` | The partner id for partner integration. | `null` |
-    | `identifyBatchIntervalMillis` | The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
-    | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
-    | `callback` | Callback function after event sent. | `null` |
-    | `optOut` | Opt the user out of tracking. | `false` |
-    | `trackingSessionEvents` | Flushing of unsent events on app close. | `false` |
-    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
-    | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
-    | `serverZone` |  The server zone to send to, will adjust server url based on this config. | `US` |
-    | `useBatch` |  Whether to use batch api. | `false` |
-    | `useAdvertisingIdForDeviceId` |  Whether to use advertising id as device id. Need to include the module and permission. | `false` |
-    | `useAppSetIdForDeviceId` |  Whether to use app ser id as device id. Need to include the module and permission. | `false` |
-    | `trackingOptions` |  Options to control the values tracked in SDK. | `enable` |
-    | `enableCoppaControl` |  Whether to enable coppa control for tracking options. | `false` |'
+    | `flushIntervalMillis` | `Int`. The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
+    | `flushQueueSize` | `Int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
+    | `flushMaxRetries` | `Int`. Maximum retry times.  | `5` |
+    | `minIdLength` | `Int`. The minimum length for user id or device id. | `5` |
+    | `partnerId` | `Int`. The partner id for partner integration. | `null` |
+    | `identifyBatchIntervalMillis` | `Long`. The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
+    | `flushEventsOnClose` | `Boolean`. Flushing of unsent events on app close. | `true` |
+    | `callback` | `EventCallBack`. Callback function after event sent. | `null` |
+    | `optOut` | `Boolean`. Opt the user out of tracking. | `false` |
+    | `trackingSessionEvents` | `Boolean`. Flushing of unsent events on app close. | `false` |
+    | `minTimeBetweenSessionsMillis` | `Long`. The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
+    | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
+    | `useBatch` | `Boolean` Whether to use batch api. | `false` |
+    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Need to include the module and permission. | `false` |
+    | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app ser id as device id. Need to include the module and permission. | `false` |
+    | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
+    | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'
 
-### `track`
+#### Configure batching behavior
+
+--8<-- "includes/sdk-ts/shared-batch-configuration.md"
+
+=== "Java"
+
+    ```java 
+    import com.amplitude.android.Amplitude;
+
+    Amplitude amplitude =  new Amplitude(new Configuration(
+        apiKey = AMPLITUDE_API_KEY,
+        context = applicationContext,
+        flushIntervalMillis = 50000,
+        flushQueueSize = 20,
+    ));
+    ```
+=== "Kotlin"
+
+    ```kotlin
+    import com.amplitude.android.Amplitude
+
+    val amplitude = Amplitude(
+        Configuration(
+            apiKey = AMPLITUDE_API_KEY,
+            context = applicationContext,
+            flushIntervalMillis = 50000,
+            flushQueueSize = 20,
+
+        )
+    )
+    ```
+
+#### EU data residency
+
+--8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
+
+=== "Java"
+
+    ```java
+    import com.amplitude.android.Amplitude;
+
+    Amplitude amplitude =  new Amplitude(new Configuration(
+        apiKey = AMPLITUDE_API_KEY,
+        context = applicationContext,
+        serverZone = ServerZone.EU
+    ));
+    ```
+=== "Kotlin"
+
+    ```kotlin
+    import com.amplitude.android.Amplitude
+
+    val amplitude = Amplitude(
+        Configuration(
+            apiKey = AMPLITUDE_API_KEY,
+            context = applicationContext,
+            serverZone = ServerZone.EU
+        )
+    )
+    ```
+
+### track
 
 Events represent how users interact with your application. For example, "Button Clicked" may be an action you want to note.
 
@@ -57,7 +118,7 @@ amplitude.track(
 )
 ```
 
-### `identify`
+### identify
 
 Identify is for setting the user properties of a particular user without sending any event. The SDK supports the operations `set`, `setOnce`, `unset`, `add`, `append`, `prepend`, `preInsert`, `postInsert`, and `remove` on individual user properties. Declare the operations via a provided Identify interface. You can chain together multiple operations in a single Identify object. The Identify object is then passed to the Amplitude client to send to the server.
 Starting from release v1.7.0, identify events with only set operations will be batched and sent with fewer events. This change won't affect running the set operations. There is a config `identifyBatchIntervalMillis` managing the interval to flush the batched identify intercepts.

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -41,8 +41,8 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
     | `useBatch` | `Boolean` Whether to use batch api. | `false` |
-    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Need to include the module and permission. | `false` |
-    | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app ser id as device id. Need to include the module and permission. | `false` |
+    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](data/sdks/android-kotlin/#advertiser-id) for required module and permission. | `false` |
+    | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](data/sdks/android-kotlin/#app-set-id) for required module and permission. | `false` |
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -41,8 +41,8 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
     | `useBatch` | `Boolean` Whether to use batch api. | `false` |
-    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](data/sdks/android-kotlin/#advertiser-id) for required module and permission. | `false` |
-    | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](data/sdks/android-kotlin/#app-set-id) for required module and permission. | `false` |
+    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](../android-kotlin/data/#advertiser-id) for required module and permission. | `false` |
+    | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](../android-kotlin/#app-set-id) for required module and permission. | `false` |
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -41,7 +41,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
     | `useBatch` | `Boolean` Whether to use batch api. | `false` |
-    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](../android-kotlin/data/#advertiser-id) for required module and permission. | `false` |
+    | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](../android-kotlin/#advertiser-id) for required module and permission. | `false` |
     | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](../android-kotlin/#app-set-id) for required module and permission. | `false` |
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -71,7 +71,6 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
             context = applicationContext,
             flushIntervalMillis = 50000,
             flushQueueSize = 20,
-
         )
     )
     ```

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -46,8 +46,6 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'
 
-#### Configure batching behavior
-
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
 === "Java"
@@ -77,8 +75,6 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
         )
     )
     ```
-
-#### EU data residency
 
 --8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -27,17 +27,17 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    | `flushIntervalMillis` | `Int`. The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
+    | `flushIntervalMillis` | `Int`. The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. The value is in milliseconds. | `30000` |
     | `flushQueueSize` | `Int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
     | `flushMaxRetries` | `Int`. Maximum retry times.  | `5` |
     | `minIdLength` | `Int`. The minimum length for user id or device id. | `5` |
     | `partnerId` | `Int`. The partner id for partner integration. | `null` |
-    | `identifyBatchIntervalMillis` | `Long`. The amount of time SDK will attempt to batch intercepted identify events. | `30000` |
+    | `identifyBatchIntervalMillis` | `Long`. The amount of time SDK will attempt to batch intercepted identify events. The value is in milliseconds| `30000` |
     | `flushEventsOnClose` | `Boolean`. Flushing of unsent events on app close. | `true` |
     | `callback` | `EventCallBack`. Callback function after event sent. | `null` |
     | `optOut` | `Boolean`. Opt the user out of tracking. | `false` |
     | `trackingSessionEvents` | `Boolean`. Flushing of unsent events on app close. | `false` |
-    | `minTimeBetweenSessionsMillis` | `Long`. The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `minTimeBetweenSessionsMillis` | `Long`. The amount of time for session timeout if disable foreground tracking. The value is in milliseconds. | `300000` |
     | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
     | `useBatch` | `Boolean` Whether to use batch api. | `false` |

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -74,17 +74,18 @@ client.init("YOUR_API_KEY");
 
 To support high performance environments, the SDK sends events in batches. Every event logged by `logEvent` method is queued in memory. Events are flushed in batch in background. You can customize batch behavior with `setEventUploadThreshold` and `setEventUploadPeriodMillis`. By default, the SDK is in regular mode with `serverUrl` to `https://api2.amplitude.com/2/httpapi`. For customers who want to send large batches of data at a time, switch to batch mode by setting `useBatchMode` to `true` to set setServerUrl to batch event upload API `https://api2.amplitude.com/batch`. Both the regular mode and the batch mode use the same flush queue size and flush intervals.
 
-For customers who want to send large batches of data at a time, 
-
 ```java
 Amplitude client = Amplitude.getInstance();
-// events queued in memory will flush when number of events exceed upload threshold
-// default value is 10
+// Events queued in memory will flush when number of events exceed upload threshold
+// Default value is 10
 client.setEventUploadThreshold(20);
 
-// events queue will flush every certain milliseconds based on setting
-// default value is 10,000 milliseconds
+// Events queue will flush every certain milliseconds based on setting
+// Default value is 10,000 milliseconds
 client.setEventUploadPeriodMillis(5000);
+
+// Using batch mode with batch API endpoint, `https://api2.amplitude.com/batch`
+client.useBatchMode(true);
 ```
 
 You can also flush events on demand.

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -51,7 +51,7 @@ client.init("YOUR_API_KEY");
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    | `setServerUrl()` | `String`. The server url events are uploaded to. For example, `Amplitude.getInstance().setServerUrl(https://www.your-server-url.com)`. | `https://api2.amplitude.com/2/httpapi` |
+    | `setServerUrl()` | `String`. The server url events are uploaded to. For example, `Amplitude.getInstance().setServerUrl("https://www.your-server-url.com")`. | `https://api2.amplitude.com/2/httpapi` |
     | `useBatchMode()` | `Boolean`. Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. For example, `Amplitude.getInstance().useBatchMode(true)`. | `false` |
     | `setLogMode()` | `AmplitudeLog.LogMode`. The level at which to filter out debug messages. For example, `Amplitude.getInstance().setLogMode(AmplitudeLog.LogMode.DEBUG);`. | `AmplitudeLog.LogMode.ERROR` |
     | `setEventUploadThreshold()` | `int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. For example, `Amplitude.getInstance().setEventUploadThreshold(50);`. | `10` |

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -51,24 +51,24 @@ client.init("YOUR_API_KEY");
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    | `setServerUrl` | `String`. The server url events are uploaded to. | `https://api2.amplitude.com/2/httpapi` |
-    | `useBatchMode` | `Boolean`. Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. | `false` |
-    | `setLogMode` | `AmplitudeLog.LogMode`. The level at which to filter out debug messages. | `LogMode.ERROR` |
-    | `setEventUploadThreshold` | `int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. | `10` |
-    | `setEventUploadPeriodMillis` | `int`. The amount of time SDK will attempt to upload the unsent events to the server or reach eventUploadThreshold threshold. | `10 seconds` |
-    | `setCallbacks` | `Function`. Event callback which are triggered after event sent. | `null`|
-    | `setProxy` | `Proxy`. Custom proxy for https requests. | `Proxy.NO_PROXY`|
-    | `setFlushTimeout` | `long`. Events flushing thread timeout in milliseconds. | `0` |
-    | `setOptions` | `Options`. A dictionary of key-value pairs that represent additional instructions for server save operation.| Please check [available options](/#options). |
+    | `setServerUrl()` | `String`. The server url events are uploaded to. For example, `Amplitude.getInstance().setServerUrl(https://www.your-server-url.com)`. | `https://api2.amplitude.com/2/httpapi` |
+    | `useBatchMode()` | `Boolean`. Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. For example, `Amplitude.getInstance().useBatchMode(true)`. | `false` |
+    | `setLogMode()` | `AmplitudeLog.LogMode`. The level at which to filter out debug messages. For example, `Amplitude.getInstance().setLogMode(AmplitudeLog.LogMode.DEBUG)`. | `AmplitudeLog.LogMode.ERROR` |
+    | `setEventUploadThreshold()` | `int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. For example, `Amplitude.getInstance().setEventUploadThreshold(50)`. | `10` |
+    | `setEventUploadPeriodMillis()` | `int`. The amount of time SDK will attempt to upload the unsent events to the server or reach eventUploadThreshold threshold. The input parameter is in millionseconds. For example, `Amplitude.getInstance().setEventUploadPeriodMillis(200000)`. | `10 seconds` |
+    | `setCallbacks()` | `AmplitudeCallbacks`. Event callback which are triggered after event sent. | `null`|
+    | `setProxy()` | `Proxy`. Custom proxy for https requests. For example, `Amplitude.getInstance().setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy.domain.com", port)));`. | `Proxy.NO_PROXY` |
+    | `setFlushTimeout()` | `long`. Events flushing thread timeout in milliseconds.  For example, `Amplitude.getInstance().setFlushTimeout(2000L)`. | `0` |
+    | `setOptions()` | `Options`. A dictionary of key-value pairs that represent additional instructions for server save operation. For example, `Amplitude.getInstance().setOptions(new Options().setMinIdLength(8));`. | Please check [available options](/#options). |
 
 ### Options
 
 ???config "Availabe Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    | `Options.setMinIdLength` | `Integer`. Set the minimum length for user id or device id. | `5` |
-    | `Options.setHeaders` | `Map<String, String>`. Set the custom headers. | `{"Content-Type", "application/json", "Accept", "application/json"}` |
-    | `Options.addHeaders` | `String, String`. Add more custom headers. | `{"Content-Type", "application/json", "Accept", "application/json"}` |
+    | `Options.setMinIdLength()` | `Integer`. Set the minimum length for user id or device id. For example, `Amplitude.getInstance().setOptions(new Options().setMinIdLength(8));`. | `5` |
+    | `Options.setHeaders()` | `Map<String, String>`. Set the custom headers. For example, `Amplitude.getInstance().setOptions(new Options().setHeaders(new HashMap<>(Map.of("Custom Header", "value"))));`. | `{"Content-Type", "application/json", "Accept", "application/json"}` |
+    | `Options.addHeader()` | `String, String`. Add more custom headers. For example, `Amplitude.getInstance().setOptions(new Options().addHeader("Custom Header", "value"));`. | `{"Content-Type", "application/json", "Accept", "application/json"}` |
 
 #### Configure batching behavior
 

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -53,12 +53,12 @@ client.init("YOUR_API_KEY");
     | --- | --- | --- |
     | `setServerUrl()` | `String`. The server url events are uploaded to. For example, `Amplitude.getInstance().setServerUrl(https://www.your-server-url.com)`. | `https://api2.amplitude.com/2/httpapi` |
     | `useBatchMode()` | `Boolean`. Whether to use [batch API](../../../analytics/apis/batch-event-upload-api/#batch-event-upload). By default, the SDK will use the default `serverUrl`. For example, `Amplitude.getInstance().useBatchMode(true)`. | `false` |
-    | `setLogMode()` | `AmplitudeLog.LogMode`. The level at which to filter out debug messages. For example, `Amplitude.getInstance().setLogMode(AmplitudeLog.LogMode.DEBUG)`. | `AmplitudeLog.LogMode.ERROR` |
-    | `setEventUploadThreshold()` | `int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. For example, `Amplitude.getInstance().setEventUploadThreshold(50)`. | `10` |
-    | `setEventUploadPeriodMillis()` | `int`. The amount of time SDK will attempt to upload the unsent events to the server or reach eventUploadThreshold threshold. The input parameter is in millionseconds. For example, `Amplitude.getInstance().setEventUploadPeriodMillis(200000)`. | `10 seconds` |
+    | `setLogMode()` | `AmplitudeLog.LogMode`. The level at which to filter out debug messages. For example, `Amplitude.getInstance().setLogMode(AmplitudeLog.LogMode.DEBUG);`. | `AmplitudeLog.LogMode.ERROR` |
+    | `setEventUploadThreshold()` | `int`. SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach eventUploadPeriodSeconds interval. For example, `Amplitude.getInstance().setEventUploadThreshold(50);`. | `10` |
+    | `setEventUploadPeriodMillis()` | `int`. The amount of time SDK will attempt to upload the unsent events to the server or reach eventUploadThreshold threshold. The input parameter is in millionseconds. For example, `Amplitude.getInstance().setEventUploadPeriodMillis(200000);`. | `10 seconds` |
     | `setCallbacks()` | `AmplitudeCallbacks`. Event callback which are triggered after event sent. | `null`|
     | `setProxy()` | `Proxy`. Custom proxy for https requests. For example, `Amplitude.getInstance().setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("proxy.domain.com", port)));`. | `Proxy.NO_PROXY` |
-    | `setFlushTimeout()` | `long`. Events flushing thread timeout in milliseconds.  For example, `Amplitude.getInstance().setFlushTimeout(2000L)`. | `0` |
+    | `setFlushTimeout()` | `long`. Events flushing thread timeout in milliseconds.  For example, `Amplitude.getInstance().setFlushTimeout(2000L);`. | `0` |
     | `setOptions()` | `Options`. A dictionary of key-value pairs that represent additional instructions for server save operation. For example, `Amplitude.getInstance().setOptions(new Options().setMinIdLength(8));`. | Please check [available options](/#options). |
 
 ### Options

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -11,7 +11,7 @@ The Marketing Analytics Browser SDK extends the Browser SDK to identify users an
 !!!info "Marketing Analytics Browser SDK Resources"
 
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/marketing-analytics-browser) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases?q=marketing-analytics-browser&expanded=true) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/modules/_amplitude_marketing_analytics_browser.html)
-
+ 
 !!!note "Marketing Analytics Browser SDK versus the Browser SDK"
 
     The Marketing Analytics Browser SDK extends the Browser SDK with automatic web attribution and page view tracking. This doc only includes the configuration related with web attribution and page view tracking. For other functionality check the [Browser SDK](../typescript-browser).
@@ -56,18 +56,36 @@ The Marketing Analytics Browser SDK has the same functionalities as the Browser 
 
 ### Configuration
 
-In addition to the [basic configuration options](../typescript-browser/#configuration), the Marketing Analytics Browser SDK has options to configure web attribution and page view tracking.
+???config "Basic Configuration Options"
+    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
-|<div class="big-column">Name</div>| Description|
-|---|----|
-|`attribution.disabled`| Optional. `boolean`. Disable the attribution tracking, attribution is enabled by default |
-|`attribution.excludeReferrers`|  Optional. `string[]`. Exclude the attribution tracking for the provided referrers string |
-|`attribution.initialEmptyValue`| Optional. `string`. Reset the `sessionId` on a new campaign, Default value is `EMPTY` |
-|`attribution.resetSessionOnNewCampaign`| Optional. `boolean`. Reset the `sessionId` on a new campaign, won't create a new session for new campaign by default. |
-|`pageViewTracking.trackOn`| Optional. `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions|
-|`pageViewTracking.trackHistoryChanges`  | Optional. `pathOnly` or `all`. Track the page view only on the path changes, track `all` URL changes by default|
+In addition to the basic configuration options, the Marketing Analytics Browser SDK has options to configure web attribution and page view tracking.
 
---8<-- "includes/sdk-ts-browser/marketing-analytics.md"
+|<div class="big-column">Name</div>| Description| Default Value|
+|---|----|---|
+|`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
+|`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. | 
+|`attribution.initialEmptyValue`| `string`. Whether reset the `sessionId` on a new campaign. | `EMPTY` |
+|`attribution.resetSessionOnNewCampaign`| `boolean`. Whether reset the `sessionId` on a new campaign. | SDK won't create a new session for new campaign by default. | 
+|`pageViewTracking.trackOn`| `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions| `undefined` |
+|`pageViewTracking.trackHistoryChanges`  | `pathOnly` or `all` or `undefined`. Use this option to subscribe to page view changes in a single page application like React.js. `pathOnly` - Compare the path only changes for page view tracking. `all`- Compare the full url changes for page view tracking. `undefined` - Default behavior. Page view changes in single page applications does not trigger a page view event. | `undefined` |
+
+ --8<-- "includes/sdk-ts/shared-batch-configuration.md"
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  // Events queued in memory will flush when number of events exceed upload threshold
+  // Default value is 30
+  flushQueueSize: 30, 
+  // Events queue will flush every certain milliseconds based on setting
+  // Default value is 10000 milliseconds
+  flushIntervalMillis: 20000,
+  // Using batch mode with batch API endpoint, `https://api2.amplitude.com/batch`
+  useBatch: true
+});
+```
+
+---8<-- "includes/sdk-ts-browser/marketing-analytics.md"
 
 ### Use the Marketing Analytics SDK with Ampli
 

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -4,14 +4,14 @@ description: The Amplitude Marketing Analytics Browser SDK Installation & Quick 
 icon: simple/javascript
 ---
 
-[![npm version](https://badge.fury.io/js/@amplitude%2Fmarketing-analytics-browser.svg)](https://badge.fury.io/js/@amplitude%2Fmarketing-analytics-browser)
+![npm version](https://img.shields.io/npm/v/@amplitude/marketing-analytics-browser)
 
 The Marketing Analytics Browser SDK extends the Browser SDK to identify users and events based on marketing channels. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/marketing-analytics-browser).
 
 !!!info "Marketing Analytics Browser SDK Resources"
 
     [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/marketing-analytics-browser) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases?q=marketing-analytics-browser&expanded=true) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/modules/_amplitude_marketing_analytics_browser.html)
- 
+
 !!!note "Marketing Analytics Browser SDK versus the Browser SDK"
 
     The Marketing Analytics Browser SDK extends the Browser SDK with automatic web attribution and page view tracking. This doc only includes the configuration related with web attribution and page view tracking. For other functionality check the [Browser SDK](../typescript-browser).
@@ -56,8 +56,7 @@ The Marketing Analytics Browser SDK has the same functionalities as the Browser 
 
 ### Configuration
 
-???config "Basic Configuration Options"
-    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
+--8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
 In addition to the basic configuration options, the Marketing Analytics Browser SDK has options to configure web attribution and page view tracking.
 
@@ -70,7 +69,7 @@ In addition to the basic configuration options, the Marketing Analytics Browser 
 |`pageViewTracking.trackOn`| `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions| `undefined` |
 |`pageViewTracking.trackHistoryChanges`  | `pathOnly` or `all` or `undefined`. Use this option to subscribe to page view changes in a single page application like React.js. `pathOnly` - Compare the path only changes for page view tracking. `all`- Compare the full url changes for page view tracking. `undefined` - Default behavior. Page view changes in single page applications does not trigger a page view event. | `undefined` |
 
- --8<-- "includes/sdk-ts/shared-batch-configuration.md"
+--8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
 ```ts
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
@@ -85,7 +84,11 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
----8<-- "includes/sdk-ts-browser/marketing-analytics.md"
+#### EU data residency
+
+--8<-- "includes/sdk-ts/client-eu-residency.md"
+
+--8<-- "includes/sdk-ts-browser/marketing-analytics.md"
 
 ### Use the Marketing Analytics SDK with Ampli
 

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -56,6 +56,8 @@ The Marketing Analytics Browser SDK has the same functionalities as the Browser 
 
 ### Configuration
 
+Basic configuration options are the same as the standard Browser SDK.
+
 --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
 In addition to the basic configuration options, the Marketing Analytics Browser SDK has options to configure web attribution and page view tracking.

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -75,7 +75,7 @@ In addition to the basic configuration options, the Marketing Analytics Browser 
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   // Events queued in memory will flush when number of events exceed upload threshold
   // Default value is 30
-  flushQueueSize: 30, 
+  flushQueueSize: 50, 
   // Events queue will flush every certain milliseconds based on setting
   // Default value is 10000 milliseconds
   flushIntervalMillis: 20000,
@@ -83,8 +83,6 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   useBatch: true
 });
 ```
-
-#### EU data residency
 
 --8<-- "includes/sdk-ts/client-eu-residency.md"
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -52,7 +52,6 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 --8<-- "includes/sdk-ts/client-eu-residency.md"
 
-
 #### Debugging
 
 --8<-- "includes/sdk-ts/client-debugging.md"
@@ -711,8 +710,8 @@ The page view plugin sends a Page View event on each page a user visits by defau
 
 You can track anonymous behavior across two different domains. Amplitude identifies anonymous users by their device IDs which must be passed between the domains. For example:
 
-- Site 1: `www.example.com`
-- Site 2: `www.example.org`
+* Site 1: `www.example.com`
+* Site 2: `www.example.org`
 
 Users who start on Site 1 and then navigate to Site 2 must have the device ID generated from Site 1 passed as a parameter to Site 2. Site 2 then needs to initialize the SDK with the device ID.
  The SDK can parse the URL parameter automatically if `deviceId` is in the URL query parameters.
@@ -743,7 +742,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 If your web app configures the strict Content Security Policy (CSP) for security concerns, adjust the policy to whitelist the Amplitude domains:
 
-- When using ["Script Loader"](../sdk-quickstart/#install-the-dependency), add `https://*.amplitude.com` to `script-src`.
-- Add `https://*.amplitude.com` to `connect-src`.
+* When using ["Script Loader"](../sdk-quickstart/#install-the-dependency), add `https://*.amplitude.com` to `script-src`.
+* Add `https://*.amplitude.com` to `connect-src`.
 
 --8<-- "includes/abbreviations.md"

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -41,7 +41,7 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   // Events queued in memory will flush when number of events exceed upload threshold
   // Default value is 30
-  flushQueueSize: 30, 
+  flushQueueSize: 50, 
   // Events queue will flush every certain milliseconds based on setting
   // Default value is 10000 milliseconds
   flushIntervalMillis: 20000,
@@ -49,8 +49,6 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   useBatch: true
 });
 ```
-
-#### EU data residency
 
 --8<-- "includes/sdk-ts/client-eu-residency.md"
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -31,15 +31,27 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 --8<-- "includes/sdk-ts-browser/init.md"
 
-### Debugging
-
---8<-- "includes/sdk-ts/client-debugging.md"
-
 ### Configuration
 
---8<-- "includes/sdk-ts-browser/shared-configurations.md"
+???config "Configuration Options"
+    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
-### EU data residency
+ --8<-- "includes/sdk-ts/shared-batch-configuration.md"
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  // Events queued in memory will flush when number of events exceed upload threshold
+  // Default value is 30
+  flushQueueSize: 30, 
+  // Events queue will flush every certain milliseconds based on setting
+  // Default value is 10000 milliseconds
+  flushIntervalMillis: 20000,
+  // Using batch mode with batch API endpoint, `https://api2.amplitude.com/batch`
+  useBatch: true
+});
+```
+
+#### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
@@ -48,9 +60,13 @@ You can configure the server zone when initializing the client for sending data 
 
 ```ts
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  serverZone: amplitude.Types.ServerZone.EU,
+  serverZone: `EU`,
 });
 ```
+
+#### Debugging
+
+--8<-- "includes/sdk-ts/client-debugging.md"
 
 ### Tracking an event
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -5,7 +5,7 @@ icon: simple/javascript
 ---
 
 
-[![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-browser.svg)](https://badge.fury.io/js/@amplitude%2Fanalytics-browser)
+![npm version](https://img.shields.io/npm/v/@amplitude/analytics-browser.svg)
 
 The Browser SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 
@@ -33,10 +33,9 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 ### Configuration
 
-???config "Configuration Options"
-    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
+--8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
- --8<-- "includes/sdk-ts/shared-batch-configuration.md"
+--8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
 ```ts
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
@@ -53,16 +52,8 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 #### EU data residency
 
-You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
+--8<-- "includes/sdk-ts/client-eu-residency.md"
 
-!!!note
-    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
-
-```ts
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  serverZone: `EU`,
-});
-```
 
 #### Debugging
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -39,9 +39,25 @@ init(API_KEY, {
 });
 ```
 
-### Debugging
+### Configuration
 
---8<-- "includes/sdk-ts/server-debugging.md"
+???config "Configuration Options"
+    --8<-- "includes/sdk-ts/shared-ts-configurations.md"  
+
+--8<-- "includes/sdk-ts/shared-batch-configuration.md"
+
+```ts
+import * as amplitude from '@amplitude/analytics-node';
+
+amplitude.init(API_KEY, {
+  // Events queued in memory will flush when number of events exceed upload threshold
+  // Default value is 30
+  flushQueueSize: 20, 
+  // Events queue will flush every certain milliseconds based on setting
+  // Default value is 10000 milliseconds
+  flushIntervalMillis: 20000,
+});
+```
 
 #### EU data residency
 
@@ -57,6 +73,10 @@ amplitude.init(API_KEY, {
   serverZone: amplitude.Types.ServerZone.EU,
 });
 ```
+
+#### Debugging
+
+--8<-- "includes/sdk-ts/server-debugging.md"
 
 ### Tracking an event
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -6,8 +6,7 @@ search:
   boost: 2
 ---
 
-
-[![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-node.svg)](https://badge.fury.io/js/@amplitude%2Fanalytics-node)
+![npm version](https://img.shields.io/npm/v/@amplitude/analytics-node)
 
 The Node.js SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 
@@ -41,8 +40,7 @@ init(API_KEY, {
 
 ### Configuration
 
-???config "Configuration Options"
-    --8<-- "includes/sdk-ts/shared-ts-configurations.md"  
+--8<-- "includes/sdk-ts/shared-ts-configuration.md"
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
@@ -61,10 +59,7 @@ amplitude.init(API_KEY, {
 
 #### EU data residency
 
-You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
-
-!!!note
-    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
+--8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
 
 ```ts
 import * as amplitude from '@amplitude/analytics-node';

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -50,14 +50,12 @@ import * as amplitude from '@amplitude/analytics-node';
 amplitude.init(API_KEY, {
   // Events queued in memory will flush when number of events exceed upload threshold
   // Default value is 30
-  flushQueueSize: 20, 
+  flushQueueSize: 50, 
   // Events queue will flush every certain milliseconds based on setting
   // Default value is 10000 milliseconds
   flushIntervalMillis: 20000,
 });
 ```
-
-#### EU data residency
 
 --8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -75,11 +75,27 @@ init(API_KEY, 'user@amplitude.com', {
 });
 ```
 
-### Debugging
+### Configuration
 
---8<-- "includes/sdk-ts/client-debugging.md"
+???config "Configuration Options"
+    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
-### EU data residency
+--8<-- "includes/sdk-ts/shared-batch-configuration.md"
+
+```ts
+import * as amplitude from '@amplitude/analytics-react-native';
+
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  // Events queued in memory will flush when number of events exceed upload threshold
+  // Default value is 30
+  flushQueueSize: 20, 
+  // Events queue will flush every certain milliseconds based on setting
+  // Default value is 10000 milliseconds
+  flushIntervalMillis: 20000,
+});
+```
+
+#### EU data residency
 
 You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
 
@@ -93,6 +109,10 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   serverZone: amplitude.Types.ServerZone.EU,
 });
 ```
+
+#### Debugging
+
+--8<-- "includes/sdk-ts/client-debugging.md"
 
 ### Tracking an event
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -87,14 +87,12 @@ import * as amplitude from '@amplitude/analytics-react-native';
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   // Events queued in memory will flush when number of events exceed upload threshold
   // Default value is 30
-  flushQueueSize: 20, 
+  flushQueueSize: 50, 
   // Events queue will flush every certain milliseconds based on setting
   // Default value is 10000 milliseconds
   flushIntervalMillis: 20000,
 });
 ```
-
-#### EU data residency
 
 --8<-- "includes/sdk-ts/client-eu-residency.md"
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -4,7 +4,7 @@ description: The Amplitude React Native SDK Installation & Quick Start guide.
 icon: simple/react
 ---
 
-[![npm version](https://badge.fury.io/js/@amplitude%2Fanalytics-react-native.svg)](https://badge.fury.io/js/@amplitude%2Fanalytics-react-native)
+![npm version](https://img.shields.io/npm/v/@amplitude/analytics-react-native)
 
 The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native).
 
@@ -77,8 +77,7 @@ init(API_KEY, 'user@amplitude.com', {
 
 ### Configuration
 
-???config "Configuration Options"
-    --8<-- "includes/sdk-ts-browser/shared-configurations.md"
+--8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
@@ -97,18 +96,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 #### EU data residency
 
-You can configure the server zone when initializing the client for sending data to Amplitude's EU servers. The SDK sends data based on the server zone if it's set.
-
-!!!note
-    For EU data residency, the project must be set up inside Amplitude EU. You must initialize the SDK with the API key from Amplitude EU.
-
-```ts
-import * as amplitude from '@amplitude/analytics-react-native';
-
-amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  serverZone: amplitude.Types.ServerZone.EU,
-});
-```
+--8<-- "includes/sdk-ts/client-eu-residency.md"
 
 #### Debugging
 

--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -1,31 +1,14 @@
-|<div class="big-column">Name</div>|Value|Description|
-|-|-|-|
-|`flushIntervalMillis`| Optional. `number` | The amount of time waiting to upload the event to the server. The default is 1 second.|
-|`flushMaxRetries`| Optional. `number` | The max retry limits. The default is 5 times.|
-|`flushQueueSize`| Optional. `number` |  The maximum number of events that can be stored locally before forcing an upload. The default is 30 events. |
-|`logLevel`| Optional. `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug` | The log level.|
-|`loggerProvider`| Optional. `Logger` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.|
-|`minIdLength`| Optional. `number` | Overrides the minimum length of `user_id` & `device_id` fields. The default is 5. |
-|`plan`| Optional. `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. |
-|`plan.branch`| Optional. `string` | The tracking plan branch name. For example: "main". |
-|`plan.source`| Optional. `string` | The tracking plan source. For example: "web". |
-|`plan.version`| Optional. `string` | The tracking plan version. For example: "1", "15". |
-|`serverUrl`| Optional. `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
-|`serverZone`| Optional. `ServerZone.EU` or  `ServerZone.US` | Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `ServerZone.EU` |
-|`storageProvider`| Optional.  `Storage<Event[]>` | Implements a custom `storageProvider` class from Storage. The default is `MemoryStorage`. |
-|`useBatch`| Optional. `boolean` | When `true`, uses the Batch API instead of the HTTP V2 API.|
-|`appVersion`| Optional. `string` | The current version of your application. For example: "1.0.0" |
-|`deviceId`| Optional. `string` | A device-specific identifier. |
-|`cookieExpiration`| Optional. `number` | The days when the cookie expires. The default is 365 days. |
-|`cookieSameSite`| Optional. `string` | The SameSite attribute of the Set-Cookie HTTP response header. The default is `LAX`. |
-|`cookieSecure`| Optional. `boolean` | If restrict access to cookies or not. A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. |
-|`cookieStorage`| Optional. `Storage<UserSession>` | Implements a custom `cookieStorage` class from `Storage`. The default is `MemoryStorage<UserSession>`|
-|`disableCookies`| Optional. `boolean` | If disable cookies or not. If cookies is disable, using LocalStorage or MemoryStorage. The cookies is enable by default. |
-|`domain`| Optional. `string` | Set the top level domain. |
-|`partnerId`| Optional. `string` | The partner Id value. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. |
-|`sessionManager`| Optional. `SessionManager` | Implements a custom `sessionManager` class from `SessionManager`. The default is `SessionManager(new MemoryStorage<UserSession>(), '')`. |
-|`sessionTimeout`| Optional. `number` | How long one session expire. The default is `30` minutes. |
-|`userId`| Optional. `number` | ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_user_length` option. |
-|`optOut`| Optional. `boolean` | If `optOut` is `true`, the event isn't sent to Amplitude's servers. The default is `false`. |
-|`transport`| Optional. `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`| Set the transport type. |
-|`config.trackingOptions`| Optional. `TrackingOptions` | [Learn more about tracking options](/data/sdks/typescript-browser/#optional-tracking). |
+--8<-- "includes/sdk-ts/shared-ts-configurations.md"
+|`appVersion`| `string`. The current version of your application. For example: "1.0.0" | `null` |
+|`deviceId`| `string` | A device-specific identifier. | `UUID()` |
+|`cookieExpiration`| `number`. The days when the cookie expires. | 365 days. |
+|`cookieSameSite`| `string`. The SameSite attribute of the Set-Cookie HTTP response header. | `LAX` |
+|`cookieSecure`| `boolean`. If restrict access to cookies or not. A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. | `false` |
+|`cookieStorage`| `Storage<UserSession>`. Implements a custom `cookieStorage` class from `Storage`. | `MemoryStorage<UserSession>` |
+|`disableCookies`| `boolean`. If disable cookies or not. If cookies is disable, using LocalStorage or MemoryStorage. | The cookies is enable by default. |
+|`domain`| `string`. Set the top level domain. | `null` |
+|`partnerId`| `string`. The partner Id value. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. | `null` |
+|`sessionManager`| `SessionManager`. Implements a custom `sessionManager` class from `SessionManager`. | `SessionManager(new MemoryStorage<UserSession>(), '')` |
+|`sessionTimeout`| `number`. How long one session expire. | `30` minutes. |
+|`userId`| `number`. ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_user_length` option. | `undefined` |
+|`config.trackingOptions`| `TrackingOptions`. [Learn more about tracking options](/#optional-tracking). | Enable all tracking options by default. |

--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -1,14 +1,15 @@
---8<-- "includes/sdk-ts/shared-ts-configurations.md"
-|`appVersion`| `string`. The current version of your application. For example: "1.0.0" | `null` |
-|`deviceId`| `string` | A device-specific identifier. | `UUID()` |
-|`cookieExpiration`| `number`. The days when the cookie expires. | 365 days. |
-|`cookieSameSite`| `string`. The SameSite attribute of the Set-Cookie HTTP response header. | `LAX` |
-|`cookieSecure`| `boolean`. If restrict access to cookies or not. A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. | `false` |
-|`cookieStorage`| `Storage<UserSession>`. Implements a custom `cookieStorage` class from `Storage`. | `MemoryStorage<UserSession>` |
-|`disableCookies`| `boolean`. If disable cookies or not. If cookies is disable, using LocalStorage or MemoryStorage. | The cookies is enable by default. |
-|`domain`| `string`. Set the top level domain. | `null` |
-|`partnerId`| `string`. The partner Id value. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. | `null` |
-|`sessionManager`| `SessionManager`. Implements a custom `sessionManager` class from `SessionManager`. | `SessionManager(new MemoryStorage<UserSession>(), '')` |
-|`sessionTimeout`| `number`. How long one session expire. | `30` minutes. |
-|`userId`| `number`. ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_user_length` option. | `undefined` |
-|`config.trackingOptions`| `TrackingOptions`. [Learn more about tracking options](/#optional-tracking). | Enable all tracking options by default. |
+--8<-- "includes/sdk-ts/shared-ts-configuration.md"
+    |`appVersion`| `string`. The current version of your application. For example: "1.0.0" | `null` |
+    |`deviceId`| `string` | A device-specific identifier. | `UUID()` |
+    |`cookieExpiration`| `number`. The days when the cookie expires. | 365 days. |
+    |`cookieSameSite`| `string`. The SameSite attribute of the Set-Cookie HTTP response header. | `LAX` |
+    |`cookieSecure`| `boolean`. If restrict access to cookies or not. A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. | `false` |
+    |`cookieStorage`| `Storage<UserSession>`. Implements a custom `cookieStorage` class from `Storage`. | `MemoryStorage<UserSession>` |
+    |`disableCookies`| `boolean`. If disable cookies or not. If cookies is disable, using LocalStorage or MemoryStorage. | The cookies is enable by default. |
+    |`domain`| `string`. Set the top level domain. | `null` |
+    |`partnerId`| `string`. The partner Id value. Amplitude requires the customer who built an event ingestion integration to add the partner identifier to `partner_id`. | `null` |
+    |`sessionManager`| `SessionManager`. Implements a custom `sessionManager` class from `SessionManager`. | `SessionManager(new MemoryStorage<UserSession>(), '')` |
+    |`sessionTimeout`| `number`. How long one session expire. | `30` minutes. |
+    |`userId`| `number`. ID for the user. Must have a minimum length of 5 characters unless overridden with the `min_user_length` option. | `undefined` |
+    |`config.trackingOptions`| `TrackingOptions`. Please check the `Optional tracking` section for more tracking options configuration. | Enable all tracking options by default. |
+    

--- a/includes/sdk-ts/client-debugging.md
+++ b/includes/sdk-ts/client-debugging.md
@@ -24,7 +24,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-#### Debug Mode
+##### Debug Mode
 Enable the debug mode by setting the `logLevel` to "Debug", example:
 
 ```ts

--- a/includes/sdk-ts/client-eu-residency.md
+++ b/includes/sdk-ts/client-eu-residency.md
@@ -1,0 +1,7 @@
+--8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
+
+```ts
+amplitude.init(API_KEY, OPTIONAL_USER_ID, {
+  serverZone: `EU`,
+});
+```

--- a/includes/sdk-ts/client-eu-residency.md
+++ b/includes/sdk-ts/client-eu-residency.md
@@ -2,6 +2,6 @@
 
 ```ts
 amplitude.init(API_KEY, OPTIONAL_USER_ID, {
-  serverZone: `EU`,
+  serverZone: 'EU',
 });
 ```

--- a/includes/sdk-ts/shared-batch-configuration.md
+++ b/includes/sdk-ts/shared-batch-configuration.md
@@ -1,0 +1,3 @@
+#### Configure batching behavior
+
+To support high performance environments, the SDK sends events in batches. Every event logged by `track` method is queued in memory. Events are flushed in batch in background. You can customize batch behavior with `flushQueueSize` and `flushIntervalMillis`. By default, the serverUrl will be `https://api2.amplitude.com/2/httpapi`. For customers who want to send large batches of data at a time, set `useBatch` to true to set setServerUrl to batch event upload api `https://api2.amplitude.com/batch`. Both the regular mode and the batch mode use the same events upload threshold and flush time intervals.

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -9,10 +9,6 @@
     |`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
     |`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
     |`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
-    |`plan`| `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. | `{}` |
-    |`plan.branch`| `string`. The tracking plan branch name. For example: "main". | `undefined` |
-    |`plan.source`| `string`. The tracking plan source. For example: "web". | `undefined` |
-    |`plan.version`| `string`. The tracking plan version. For example: "1", "15". | `undefined` |
     |`serverUrl`| `string`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |
     |`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -5,7 +5,7 @@
     |`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server. | 1 second.| 
     |`flushQueueSize`| `number`. The maximum number of events that can be stored locally before forcing an upload.  | 30 events. |
     |`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
-    |`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | LogLevel.Warn |
+    |`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | `LogLevel.Warn` |
     |`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
     |`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
     |`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
@@ -13,7 +13,7 @@
     |`plan.branch`| `string`. The tracking plan branch name. For example: "main". | `undefined` |
     |`plan.source`| `string`. The tracking plan source. For example: "web". | `undefined` |
     |`plan.version`| `string`. The tracking plan version. For example: "1", "15". | `undefined` |
-    |`serverUrl`| `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
+    |`serverUrl`| `string`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |
     |`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |
     |`useBatch`| `boolean`. When `true`, uses the Batch API instead of the HTTP V2 API.| `false` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -1,20 +1,21 @@
-| <div class="big-column">Name</div>  | Description | Default Value |
-| --- | --- | --- |
-|`apiKey`| Required. `string`. The apiKey of your project. | `null` | 
-|`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server. | 1 second.| 
-|`flushQueueSize`| `number` |  The maximum number of events that can be stored locally before forcing an upload.  | 30 events. |
-|`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
-|`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | LogLevel.Warn |
-|`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
-|`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
-|`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
-|`plan`| `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. | `{}` |
-|`plan.branch`| `string`. The tracking plan branch name. For example: "main". | `undefined` |
-|`plan.source`| `string`. The tracking plan source. For example: "web". | `undefined` |
-|`plan.version`| `string`. The tracking plan version. For example: "1", "15". | `undefined` |
-|`serverUrl`| `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
-|`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |
-|`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |
-|`useBatch`| `boolean`. When `true`, uses the Batch API instead of the HTTP V2 API.| `false` |
-|`transportProvider`| `Transport`. Custom HTTP client. For example, sending requests to your proxy server with customized HTTP request headers.| `Transport` |
-|`transport`| `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`. Set the transport type. | `TransportType.Fetch` |
+???config "Configuration Options"
+    | <div class="big-column">Name</div>  | Description | Default Value |
+    | --- | --- | --- |
+    |`apiKey`| Required. `string`. The apiKey of your project. | `null` | 
+    |`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server. | 1 second.| 
+    |`flushQueueSize`| `number`. The maximum number of events that can be stored locally before forcing an upload.  | 30 events. |
+    |`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
+    |`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | LogLevel.Warn |
+    |`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
+    |`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
+    |`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
+    |`plan`| `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. | `{}` |
+    |`plan.branch`| `string`. The tracking plan branch name. For example: "main". | `undefined` |
+    |`plan.source`| `string`. The tracking plan source. For example: "web". | `undefined` |
+    |`plan.version`| `string`. The tracking plan version. For example: "1", "15". | `undefined` |
+    |`serverUrl`| `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
+    |`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |
+    |`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |
+    |`useBatch`| `boolean`. When `true`, uses the Batch API instead of the HTTP V2 API.| `false` |
+    |`transportProvider`| `Transport`. Custom HTTP client. For example, sending requests to your proxy server with customized HTTP request headers.| `Transport` |
+    |`transport`| `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`. Set the transport type. | `TransportType.Fetch` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -2,7 +2,7 @@
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
     |`apiKey`| Required. `string`. The apiKey of your project. | `null` | 
-    |`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server. | 1 second.| 
+    |`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server in millionseconds. | 1 second.|
     |`flushQueueSize`| `number`. The maximum number of events that can be stored locally before forcing an upload.  | 30 events. |
     |`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
     |`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | `LogLevel.Warn` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -1,0 +1,20 @@
+| <div class="big-column">Name</div>  | Description | Default Value |
+| --- | --- | --- |
+|`apiKey`| Required. `string`. The apiKey of your project. | `null` | 
+|`flushIntervalMillis`| `number`. The amount of time waiting to upload the event to the server. | 1 second.| 
+|`flushQueueSize`| `number` |  The maximum number of events that can be stored locally before forcing an upload.  | 30 events. |
+|`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
+|`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | LogLevel.Warn |
+|`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
+|`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
+|`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
+|`plan`| `Plan` | Tracking plan properties. Amplitude supports only branch, source, version properties. | `{}` |
+|`plan.branch`| `string`. The tracking plan branch name. For example: "main". | `undefined` |
+|`plan.source`| `string`. The tracking plan source. For example: "web". | `undefined` |
+|`plan.version`| `string`. The tracking plan version. For example: "1", "15". | `undefined` |
+|`serverUrl`| `string` | Sends events to a different URL other than AMPLITUDE_SERVER_URL. Used for proxy servers |
+|`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |
+|`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |
+|`useBatch`| `boolean`. When `true`, uses the Batch API instead of the HTTP V2 API.| `false` |
+|`transportProvider`| `Transport`. Custom HTTP client. For example, sending requests to your proxy server with customized HTTP request headers.| `Transport` |
+|`transport`| `TransportType.XHR` or `TransportType.SendBeacon` or `TransportType.Fetch`. Set the transport type. | `TransportType.Fetch` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- Added the default configuration for 
  - [next gen node SDK](https://pr-660.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-node/#configuration)
  - [marketing analytics SDK](https://pr-660.d19s7xzcva2mw3.amplifyapp.com/data/sdks/marketing-analytics-browser/)
  - [next gen browser SDK](https://pr-660.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-browser/#initialize-the-sdk)
  - [next gen react-native SDK](https://pr-660.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-react-native/)
- Other minor fixes.
  - fix the npm version badge broken issue
  - alignment issue
  - others

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
