### PR TITLE
fix configuration nits and others

### DIFF
--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -66,7 +66,7 @@ In addition to the basic configuration options, the Marketing Analytics Browser 
 |---|----|---|
 |`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
 |`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. | 
-|`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
+|`attribution.initialEmptyValue`| `string`. Customize the initial empty value for attribution related user properties to any string value. | `EMPTY` |
 |`attribution.resetSessionOnNewCampaign`| `boolean`. Whether reset the `sessionId` on a new campaign. | SDK won't create a new session for new campaign by default. | 
 |`pageViewTracking.trackOn`| `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions| `undefined` |
 |`pageViewTracking.trackHistoryChanges`  | `pathOnly` or `all` or `undefined`. Use this option to subscribe to page view changes in a single page application like React.js. `pathOnly` - Compare the path only changes for page view tracking. `all`- Compare the full url changes for page view tracking. `undefined` - Default behavior. Page view changes in single page applications does not trigger a page view event. | `undefined` |

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -66,7 +66,7 @@ In addition to the basic configuration options, the Marketing Analytics Browser 
 |---|----|---|
 |`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
 |`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. | 
-|`attribution.initialEmptyValue`| `string`. Whether reset the `sessionId` on a new campaign. | `EMPTY` |
+|`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
 |`attribution.resetSessionOnNewCampaign`| `boolean`. Whether reset the `sessionId` on a new campaign. | SDK won't create a new session for new campaign by default. | 
 |`pageViewTracking.trackOn`| `attribution` or `() => boolean`. `attribution` - Fire a page view event attribution information changes. `undefined` - Fire a page view event on page load or on history changes for single page application, default behavior. `() => boolean` - Fire a page view events based on a `trackOn` functions| `undefined` |
 |`pageViewTracking.trackHistoryChanges`  | `pathOnly` or `all` or `undefined`. Use this option to subscribe to page view changes in a single page application like React.js. `pathOnly` - Compare the path only changes for page view tracking. `all`- Compare the full url changes for page view tracking. `undefined` - Default behavior. Page view changes in single page applications does not trigger a page view event. | `undefined` |

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -35,15 +35,19 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
-In addition to the basic configuration options, there also has options to configure web attribution and page view tracking. However, we are migrating the web attribution and page view tracking logic to `webAttributionPlugin` and `pageViewTrackingPlugin`, which was adopted by `Marketing Analytics Browser SDK`. We highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/) for better attribution and page view tracking. 
+In addition to the basic configuration options, there also has options to configure web attribution and page view tracking. 
 
-|<div class="big-column">Name</div>| Description| Default Value|
-|---|----|---|
-|`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
-|`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. |
-|`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
-|`attribution.trackNewCampaigns`| `boolean`. Whether tracking new campaigns on the current session. | `false` | 
-|`attribution.trackPageViews`| `boolean`. Whether track page views. | `false` |
+!!!warning "Using Marketing Analytics Browser SDK for better campaign tracking"
+    We are migrating the web attribution and page view tracking logic to `webAttributionPlugin` and `pageViewTrackingPlugin`, which was adopted by `Marketing Analytics Browser SDK`. We highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/) for better attribution and page view tracking. 
+
+???config "Other Options"
+    |<div class="big-column">Name</div>| Description| Default Value|
+    |---|----|---|
+    |`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
+    |`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. |
+    |`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
+    |`attribution.trackNewCampaigns`| `boolean`. Whether tracking new campaigns on the current session. | `false` | 
+    |`attribution.trackPageViews`| `boolean`. Whether track page views. | `false` |
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -35,6 +35,16 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
+In addition to the basic configuration options, there also has options to configure web attribution and page view tracking. However, we are migrating the web attribution and page view tracking logic to `webAttributionPlugin` and `pageViewTrackingPlugin`, which was adopted by `Marketing Analytics Browser SDK`. We highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/) for better attribution and page view tracking. 
+
+|<div class="big-column">Name</div>| Description| Default Value|
+|---|----|---|
+|`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
+|`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. |
+|`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
+|`attribution.trackNewCampaigns`| `boolean`. Whether tracking new campaigns on the current session. | `false` | 
+|`attribution.trackPageViews`| `boolean`. Whether track page views. | `false` |
+
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
 ```ts

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -43,9 +43,9 @@ In addition to the basic configuration options, there also has options to config
 ???config "Other Options"
     |<div class="big-column">Name</div>| Description| Default Value|
     |---|----|---|
-    |`attribution.disabled`| `boolean`. Whether disable the attribution tracking.| `false` |
+    |`attribution.disabled`| `boolean`. Whether disable the attribution tracking. | `false` |
     |`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. |
-    |`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value | `EMPTY` |
+    |`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value. | `EMPTY` |
     |`attribution.trackNewCampaigns`| `boolean`. Whether tracking new campaigns on the current session. | `false` | 
     |`attribution.trackPageViews`| `boolean`. Whether track page views. | `false` |
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -35,19 +35,16 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 
 --8<-- "includes/sdk-ts-browser/shared-configurations.md"
 
-In addition to the basic configuration options, there also has options to configure web attribution and page view tracking. 
-
-!!!warning "Using Marketing Analytics Browser SDK for better campaign tracking"
-    We are in the process of migrating web attribution and page view tracking logic to webAttributionPlugin and pageViewTrackingPlugin as adopted by Marketing Analytics Browser SDK. For improved attribution and page view monitoring, we highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/).
+In addition to the basic configuration options, there also has options to configure attribution.
     
-???config "Other Options"
+???config "Attribution Options"
     |<div class="big-column">Name</div>| Description| Default Value|
     |---|----|---|
     |`attribution.disabled`| `boolean`. Whether disable the attribution tracking. | `false` |
     |`attribution.excludeReferrers`| `string[]`. Exclude the attribution tracking for the provided referrers string | Including all referrers by default. |
-    |`attribution.initialEmptyValue`| `string`. Custom the init empty value for attribution related user properties to any string value. | `EMPTY` |
+    |`attribution.initialEmptyValue`| `string`. Customize the initial empty value for attribution related user properties to any string value. | `EMPTY` |
     |`attribution.trackNewCampaigns`| `boolean`. Whether tracking new campaigns on the current session. | `false` | 
-    |`attribution.trackPageViews`| `boolean`. Whether track page views. | `false` |
+    |`attribution.trackPageViews`| `boolean`. Whether track page view on attribution. | `false` |
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -38,8 +38,8 @@ Use [this quickstart guide](../sdk-quickstart#browser) to get started with Ampli
 In addition to the basic configuration options, there also has options to configure web attribution and page view tracking. 
 
 !!!warning "Using Marketing Analytics Browser SDK for better campaign tracking"
-    We are migrating the web attribution and page view tracking logic to `webAttributionPlugin` and `pageViewTrackingPlugin`, which was adopted by `Marketing Analytics Browser SDK`. We highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/) for better attribution and page view tracking. 
-
+    We are in the process of migrating web attribution and page view tracking logic to webAttributionPlugin and pageViewTrackingPlugin as adopted by Marketing Analytics Browser SDK. For improved attribution and page view monitoring, we highly recommend using [Marketing Analytics Browser SDK](../marketing-analytics-browser/).
+    
 ???config "Other Options"
     |<div class="big-column">Name</div>| Description| Default Value|
     |---|----|---|

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -93,15 +93,10 @@ The new Browser SDK configuration comes in a different shape. The configurations
 |`config.optOut`|`config.optOut`|
 |`config.onError`|NOT SUPPORTED|
 |`config.onExitPage`|NOT SUPPORTED. See [Flush](#flush-or-onexitpage).|
-|`config.plan`|`config.plan`|
-|`config.plan.branch`|`config.plan.branch`|
-|`config.plan.source`|`config.plan.source`|
-|`config.plan.version`|`config.plan.version`|
-|`config.plan.versionId`|`config.plan.versionId`|
 |`config.platform`|NOT SUPPORTED. See [Plugins](#plugins).|
 |`config.savedMaxCount`|NOT SUPPORTED|
 |`config.saveEvents`|NOT SUPPORTED|
-|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`|
+|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`. Opposite with `saveParamsReferrerOncePerSession`. See [configuration](../typescript-browser/#configuration). |
 |`config.secureCookie`|`config.cookieSecure`|
 |`config.sessionTimeout`|`config.sessionTimeout`|
 |`config.storage`|`config.storageProvider`|

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -96,7 +96,7 @@ The new Browser SDK configuration comes in a different shape. The configurations
 |`config.platform`|NOT SUPPORTED. See [Plugins](#plugins).|
 |`config.savedMaxCount`|NOT SUPPORTED|
 |`config.saveEvents`|NOT SUPPORTED|
-|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`. Opposite with `saveParamsReferrerOncePerSession`. See [configuration](../typescript-browser/#configuration). |
+|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`. Opposite with `saveParamsReferrerOncePerSession`. See [configuration](../#configuration). |
 |`config.secureCookie`|`config.cookieSecure`|
 |`config.sessionTimeout`|`config.sessionTimeout`|
 |`config.storage`|`config.storageProvider`|

--- a/docs/data/sdks/typescript-browser/migration.md
+++ b/docs/data/sdks/typescript-browser/migration.md
@@ -96,7 +96,7 @@ The new Browser SDK configuration comes in a different shape. The configurations
 |`config.platform`|NOT SUPPORTED. See [Plugins](#plugins).|
 |`config.savedMaxCount`|NOT SUPPORTED|
 |`config.saveEvents`|NOT SUPPORTED|
-|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`. Opposite with `saveParamsReferrerOncePerSession`. See [configuration](../#configuration). |
+|`config.saveParamsReferrerOncePerSession`|`config.attribution.trackNewCampaigns`. Opposite of `saveParamsReferrerOncePerSession`. See [configuration](../#configuration). |
 |`config.secureCookie`|`config.cookieSecure`|
 |`config.sessionTimeout`|`config.sessionTimeout`|
 |`config.storage`|`config.storageProvider`|

--- a/includes/sdk-ts-browser/shared-configurations.md
+++ b/includes/sdk-ts-browser/shared-configurations.md
@@ -1,6 +1,6 @@
 --8<-- "includes/sdk-ts/shared-ts-configuration.md"
     |`appVersion`| `string`. The current version of your application. For example: "1.0.0" | `null` |
-    |`deviceId`| `string` | A device-specific identifier. | `UUID()` |
+    |`deviceId`| `string`. A device-specific identifier. | `UUID()` |
     |`cookieExpiration`| `number`. The days when the cookie expires. | 365 days. |
     |`cookieSameSite`| `string`. The SameSite attribute of the Set-Cookie HTTP response header. | `LAX` |
     |`cookieSecure`| `boolean`. If restrict access to cookies or not. A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol. | `false` |

--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -7,7 +7,7 @@
     |`flushMaxRetries`| `number`. The max retry limits. | 5 times.|
     |`logLevel`| `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. The log level. | `LogLevel.Warn` |
     |`loggerProvider`| `Logger`. Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.| `Amplitude Logger` |
-    |`minIdLength`| `number` | Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
+    |`minIdLength`| `number`. Overrides the minimum length of `user_id` & `device_id` fields. | `5` |
     |`optOut`| `boolean`. If `optOut` is `true`, the event isn't sent to Amplitude's servers. | `false` |
     |`serverUrl`| `string`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` | 
     |`serverZone`| `EU` or  `US`. Set Amplitude Server Zone, switch to zone related configuration. To send data to Amplitude's EU servers should configure to `EU` | `US` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
1. fixed some configuration nits.
2. add web attribution and page view tracking on the browser SDK.  There has an update on Browser SDK. Right now for web attribution and pageview tracking, it's using the plugins internally. Also, we mentioned the browser SDK web attribution parameter in the Browser SDK Migration Guide, but there is no place to explain how it works. (Check this [Github issue](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/issues/643)). We should list the attribution configurations in the browser SDK.


Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
