### PR TITLE
AMP-71818 Remove beta blurbs from streaming docs

### DIFF
--- a/docs/data/destinations/appsflyer.md
+++ b/docs/data/destinations/appsflyer.md
@@ -3,8 +3,6 @@ title: AppsFlyer Event Streaming
 description: Amplitude CDP's AppsFlyer streaming integration enables you to forward your Amplitude events straight to AppsFlyer with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's AppsFlyer streaming integration enables you to forward your Amplitude events straight to [AppsFlyer](https://www.appsflyer.com/) with just a few clicks.
 
 !!!note "Other Amplitude + AppsFlyer integrations"

--- a/docs/data/destinations/branch.md
+++ b/docs/data/destinations/branch.md
@@ -3,8 +3,6 @@ title: Branch Event Streaming
 description: Amplitude CDP's Branch streaming integration enables you to forward your Amplitude events straight to Branch with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Branch streaming integration enables you to forward your Amplitude events straight to [Branch](https://branch.io/) with just a few clicks.
 
 ## Setup

--- a/docs/data/destinations/braze.md
+++ b/docs/data/destinations/braze.md
@@ -3,8 +3,6 @@ title: Braze Event Streaming
 description: Amplitude CDP's Braze streaming integration enables you to forward your Amplitude events and users straight to Braze with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Braze streaming integration enables you to forward your Amplitude events and users straight to [Braze](https://www.braze.com/) with just a few clicks.
 
 !!!note "Other Amplitude CDP + Braze integrations"

--- a/docs/data/destinations/customerio.md
+++ b/docs/data/destinations/customerio.md
@@ -3,8 +3,6 @@ title: Customer.io Event Streaming
 description: Amplitude CDP's Customer.io streaming integration enables you to forward your Amplitude events and users straight to Customer.io with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Customer.io streaming integration enables you to forward your Amplitude events and users straight to [Customer.io](https://customer.io/) with just a few clicks.
 
 !!!note "Other Amplitude CDP + Customer.io integrations"

--- a/docs/data/destinations/intercom.md
+++ b/docs/data/destinations/intercom.md
@@ -3,8 +3,6 @@ title: Intercom Event Streaming
 description: Amplitude CDP's Intercom streaming integration enables you to forward your Amplitude events and users straight to Intercom with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Intercom streaming integration enables you to forward your Amplitude events and users straight to [Intercom](https://www.intercom.com/) with just a few clicks.
 
 !!!note "Other Amplitude CDP + Intercom integrations"

--- a/docs/data/destinations/iterable.md
+++ b/docs/data/destinations/iterable.md
@@ -3,8 +3,6 @@ title: Iterable Event Streaming
 description: Amplitude CDP's Iterable streaming integration enables you to forward your Amplitude events and users straight to Iterable with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Iterable streaming integration enables you to forward your Amplitude events and users straight to [Iterable](https://iterable.com/) with just a few clicks.
 
 !!!note "Other Amplitude CDP + Iterable integrations"

--- a/docs/data/destinations/meta-pixel.md
+++ b/docs/data/destinations/meta-pixel.md
@@ -3,8 +3,6 @@ title: Meta Pixel Event Streaming
 description: Amplitude CDP's Meta Pixel streaming integration enables you to forward your Amplitude events and users straight to Meta Pixel with just a few clicks.
 ---
 
---8<-- "includes/open-beta.md"
-
 Amplitude CDP's Meta Pixel streaming integration enables you to forward your Amplitude events and users straight to Meta Pixel with just a few clicks.
 
 ## Setup

--- a/docs/data/destinations/webhooks-streaming.md
+++ b/docs/data/destinations/webhooks-streaming.md
@@ -5,8 +5,6 @@ description: Use this integration to stream Amplitude event data to your custom 
 
 Amplitude Data's Webhook integration lets you stream your Amplitude event data to custom webhooks. This is a light-weight way to set a stream of event data out of Amplitude, which you can then pick up from the Webhook destination, and transform/configure to how you like.
 
---8<-- "includes/closed-beta.md"
-
 ## Setup
 
 ### Webhook setup


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Move AppsFlyer, Branch, Braze, Customer.io, GA4, Intercom, Iterable, Meta Pixel, Webhook to GA.

Note: GA4 docs never had the beta blurb added.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
