### PR TITLE
AMP-0: Add codeowners to amplitude dev center repo.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# code owners for amplitude-dev-center repo
+*	brian.giori@amplitude.com hao.liu@amplitude.com justin.fiedler@amplitude.com simon.coffin@amplitude.com nirmal@amplitude.com


### PR DESCRIPTION
# Amplitude Developer Docs PR
Adding code owners for this repo