### PR TITLE
add more words to explain trackingSessionEvent in Flutter web. 

### DIFF
--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -79,7 +79,7 @@ For other default configurations:
     | `setServerUrl()` | `String`. The API endpoint URL that events are sent to. Automatically selected by `ServerZone`. For example, `Amplitude.getInstance().setServerUrl(https://www.your-server-url.com)`. | `https://api2.amplitude.com/` |
     | `setUseDynamicConfig()` | `bool`. Find the best server url automatically based on users' geo location. For example, `setUseDynamicConfig(true)`. | `false` |
     | `setOptOut()` | `bool`. Opt the user out of tracking. For example, `Amplitude.getInstance().setOptOut(true)`.| `false` |
-    | `trackingSessionEvents()` | `bool`. Flushing of unsent events on app close. For example, `Amplitude.getInstance().trackingSessionEvents(true)`. | `false` |
+    | `trackingSessionEvents()` | `bool`. Whether to automatically log start and end session events corresponding to the start and end of a user's session. For example, `Amplitude.getInstance().trackingSessionEvents(true)`. | `false` |
     | `useAppSetIdForDeviceId()` | Only for Android. Whether to use app ser id as device id on Android side. Please check [here](../android/#app-set-id) for the required module and permission. For example, `Amplitude.getInstance().useAppSetIdForDeviceId(true)` | By default, the deviceId will be UUID+"R" |
     
 #### Configure batching behavior
@@ -419,7 +419,7 @@ These features aren't supported in Flutter web:
 
 - `enableCoppaControl`
 - `disableCoppaControl`
-- `trackingSessionEvents`
+- `trackingSessionEvents`. We are still tracking the sessionId in Flutter Web, but whether to automatically log start and end session events corresponding to the start and end of a user's session is not supported in Flutter Web.
 - `useAppSetIdForDeviceId`
 
 #### Usage

--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -79,7 +79,7 @@ For other default configurations:
     | `setServerUrl()` | `String`. The API endpoint URL that events are sent to. Automatically selected by `ServerZone`. For example, `Amplitude.getInstance().setServerUrl(https://www.your-server-url.com)`. | `https://api2.amplitude.com/` |
     | `setUseDynamicConfig()` | `bool`. Find the best server url automatically based on users' geo location. For example, `setUseDynamicConfig(true)`. | `false` |
     | `setOptOut()` | `bool`. Opt the user out of tracking. For example, `Amplitude.getInstance().setOptOut(true)`.| `false` |
-    | `trackingSessionEvents()` | `bool`. Whether to automatically log start and end session events corresponding to the start and end of a user's session. For example, `Amplitude.getInstance().trackingSessionEvents(true)`. | `false` |
+    | `trackingSessionEvents()` | `bool`. Whether to automatically log "[Amplitude] Session Start" and "[Amplitude] Session End" session events corresponding to the start and end of a user's session. | `false` |
     | `useAppSetIdForDeviceId()` | Only for Android. Whether to use app ser id as device id on Android side. Please check [here](../android/#app-set-id) for the required module and permission. For example, `Amplitude.getInstance().useAppSetIdForDeviceId(true)` | By default, the deviceId will be UUID+"R" |
     
 #### Configure batching behavior
@@ -419,7 +419,7 @@ These features aren't supported in Flutter web:
 
 - `enableCoppaControl`
 - `disableCoppaControl`
-- `trackingSessionEvents`. We are still tracking the sessionId in Flutter Web, but whether to automatically log start and end session events corresponding to the start and end of a user's session is not supported in Flutter Web.
+- `trackingSessionEvents`. Flutter Web will still track the sessionId, but it is not possible to automatically log start and end session events corresponding to the start and end of a user's session.
 - `useAppSetIdForDeviceId`
 
 #### Usage


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
The customer has confused about trackingSessionEvent not being supported on flutter Web. They thought that means there is no session tracking logic, but that's is only for not supporting tracking session events. 

 https://discourse.amplitude.com/t/needing-web-session-tracking-that-supports-the-flutter-sdk-and-wants-to-know-timeline-to-accommodate-this-request/10066

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
