### PR TITLE
Update Shopify app installation instructions

### DIFF
--- a/docs/data/sources/shopify.md
+++ b/docs/data/sources/shopify.md
@@ -96,8 +96,8 @@ Users who start on Site 1 and then navigate to Site 2 have their Device ID gener
 
 1. Go to the [Amplitude app](https://www.google.com/url?q=https://apps.shopify.com/amplitude?surface_detail%3Damplitude%26surface_inter_position%3D1%26surface_intra_position%3D2%26surface_type%3Dsearch&sa=D&source=docs&ust=1639610653341000&usg=AOvVaw2Z_lud4-S1WhAHoDKWdJKC) in the Shopify app store.
 2. Click **Add app** to begin the installation process.
-3. Go to your Amplitude project, then navigate to **Sources and Destinations > Destinations**.
-4. Under **Add More Destinations …**, click **Shopify**.
+3. Go to your Amplitude project, then navigate to **Settings => Projects**.
+4. Navigate to the project you want to import events into (portfolio views cannot be used as a destination).
 5. Copy the Amplitude project’s API key.
 6. In the Shopify admin portal, enter the API key in **Amplitude API Key** field. Then click **Connect**.
 7. Choose a `User_ID` for known customers. To support a broader range of use cases, the app lets you choose which of the following fields you want to send as the `User_ID` for known customers.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- Updated the Shopify App installation instructions to remove out of date steps and update with new method to retrieve Amplitude project API key.
- In response to this ticket: https://amplitude.atlassian.net/browse/AMP-72508; customer is trying to add Shopify as a source by following our dev doc instructions, however, it is out of date.

## Deadline

When do these changes need to be live on the site?
- Not urgent, but it's a small change and I have confirmed this method of retrieving the API key works so it should be able to go through pretty fast.


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
