### PR TITLE
Incorrect information on groups

### DIFF
--- a/docs/guides/accounts-instrumentation-guide.md
+++ b/docs/guides/accounts-instrumentation-guide.md
@@ -67,17 +67,7 @@ Amplitude recommends taking the following approach for event level groups.
 
 <div class="grid cards" markdown>
 
-- :material-numeric-1-circle:{ .lg .middle } **Group Identify**
-
-    ---
-
-    **Set and update group properties** via group identify calls. 
-
-    Send group identify calls server-side to the [Group Identify API](../../analytics/apis/group-identify-api) or using an SDK. 
-
-    Group properties persist for the group until they're explicitly updated or unset. Updates to group properties aren't retroactive. 
-
-- :material-numeric-2-circle:{ .lg .middle } **Events**
+- :material-numeric-1-circle:{ .lg .middle } **Events**
 
     ---
 


### PR DESCRIPTION
This card about using the Group Identify API is mistakenly shown in both sections when it only applies to setting user-level groups

# Amplitude Developer Docs PR


## Description

Removed a card about setting event level groups with the Group Identify API - this is incorrect since this will persist when users are sending events without groups. Misleading to customers 

## Deadline

As soon as possible


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
