### PR TITLE
Android update

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -572,50 +572,7 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 
 ### Advertiser ID
 
-Advertiser ID (also referred to as IDFA) is a unique identifier provided by the iOS and Google Play stores. As it's unique to every person and not just their devices, it's useful for mobile attribution.
- [Mobile attribution](https://www.adjust.com/blog/mobile-ad-attribution-introduction-for-beginners/) is the attribution of an installation of a mobile app to its original source (such as ad campaign, app store search).
- Mobile apps need permission to ask for IDFA, and apps targeted to children can't track at all. Consider IDFV or device ID when IDFA isn't available.
-
-Follow these steps to use Android Ad ID.
-
-!!!warning "Google Ad ID and Tracking Warning"
-
-    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
-
-1. Add `play-services-ads` as a dependency.
-
-    ```bash
-    dependencies {
-      implementation 'com.google.android.gms:play-services-ads:18.3.0'
-    }
-    ```
-
-2. `AD_MANAGER_APP` Permission
-If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_MANAGER_APP` to `AndroidManifest.xml`.
-
-    ```xml
-    <manifest>
-        <application>
-            <meta-data
-                android:name="com.google.android.gms.ads.AD_MANAGER_APP"
-                android:value="true"/>
-        </application>
-    </manifest>
-    ```
-
-3. Add ProGuard exception
-
-    Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
-    `-keep class com.google.android.gms.ads.** { *; }`
-
-4. `AD_ID` Permission 
-    When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
-
-    ```xml
-        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
-    ```
-    
-    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
+--8<-- "includes/sdk-android/android-sdk-advertiser-id.md"
 
 #### Set advertising ID as device ID
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -580,7 +580,7 @@ Follow these steps to use Android Ad ID.
 
 !!!warning "Google Ad ID and Tracking Warning"
 
-    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
+    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
 
 1. Add `play-services-ads` as a dependency.
 
@@ -605,8 +605,17 @@ If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_M
 
 3. Add ProGuard exception
 
-Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
-`-keep class com.google.android.gms.ads.** { *; }`
+    Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
+    `-keep class com.google.android.gms.ads.** { *; }`
+
+4. `AD_ID` Permission 
+    When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
+
+    ```xml
+        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    ```
+    
+    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
 
 #### Set advertising ID as device ID
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -933,50 +933,7 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 
 ### Advertiser ID
 
-Advertiser ID (also referred to as IDFA) is a unique identifier provided by the iOS and Google Play stores. As it's unique to every person and not just their devices, it's useful for mobile attribution.
- [Mobile attribution](https://www.adjust.com/blog/mobile-ad-attribution-introduction-for-beginners/) is the attribution of an installation of a mobile app to its original source (such as ad campaign, app store search).
- Mobile apps need permission to ask for IDFA, and apps targeted to children can't track at all. Consider IDFV or device ID when IDFA isn't available.
-
-Follow these steps to use Android Ad ID.
-
-!!!warning "Google Ad ID and Tracking Warning"
-
-    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
-
-1. Add `play-services-ads` as a dependency.
-
-    ```bash
-    dependencies {
-      implementation 'com.google.android.gms:play-services-ads:18.3.0'
-    }
-    ```
-
-2. `AD_MANAGER_APP` Permission
-If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_MANAGER_APP` to `AndroidManifest.xml`.
-
-    ```xml
-    <manifest>
-        <application>
-            <meta-data
-                android:name="com.google.android.gms.ads.AD_MANAGER_APP"
-                android:value="true"/>
-        </application>
-    </manifest>
-    ```
-
-3. Add ProGuard exception
-
-    Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
-    `-keep class com.google.android.gms.ads.** { *; }`
-
-4. `AD_ID` Permission 
-    When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
-
-    ```xml
-        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
-    ```
-    
-    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
+--8<-- "includes/sdk-android/android-sdk-advertiser-id.md"
 
 #### Set advertising ID as device ID
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -941,7 +941,7 @@ Follow these steps to use Android Ad ID.
 
 !!!warning "Google Ad ID and Tracking Warning"
 
-    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
+    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
 
 1. Add `play-services-ads` as a dependency.
 
@@ -966,8 +966,17 @@ If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_M
 
 3. Add ProGuard exception
 
-Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
-`-keep class com.google.android.gms.ads.** { *; }`
+    Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
+    `-keep class com.google.android.gms.ads.** { *; }`
+
+4. `AD_ID` Permission 
+    When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
+
+    ```xml
+        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    ```
+    
+    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en)
 
 #### Set advertising ID as device ID
 

--- a/includes/sdk-android/android-sdk-advertiser-id.md
+++ b/includes/sdk-android/android-sdk-advertiser-id.md
@@ -35,10 +35,11 @@ If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_M
     `-keep class com.google.android.gms.ads.** { *; }`
 
 4. `AD_ID` Permission 
+
     When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
 
     ```xml
-        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     ```
     
-    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
+    Learn More at [here](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).

--- a/includes/sdk-android/android-sdk-advertiser-id.md
+++ b/includes/sdk-android/android-sdk-advertiser-id.md
@@ -1,0 +1,44 @@
+Advertiser ID (also referred to as IDFA) is a unique identifier provided by the iOS and Google Play stores. As it's unique to every person and not just their devices, it's useful for mobile attribution.
+ [Mobile attribution](https://www.adjust.com/blog/mobile-ad-attribution-introduction-for-beginners/) is the attribution of an installation of a mobile app to its original source (such as ad campaign, app store search).
+ Mobile apps need permission to ask for IDFA, and apps targeted to children can't track at all. Consider IDFV or device ID when IDFA isn't available.
+
+Follow these steps to use Android Ad ID.
+
+!!!warning "Google Ad ID and Tracking Warning"
+
+    As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
+
+1. Add `play-services-ads` as a dependency.
+
+    ```bash
+    dependencies {
+      implementation 'com.google.android.gms:play-services-ads:18.3.0'
+    }
+    ```
+
+2. `AD_MANAGER_APP` Permission
+If you use Google Mobile Ads SDK version 17.0.0 or higher, you need to add `AD_MANAGER_APP` to `AndroidManifest.xml`.
+
+    ```xml
+    <manifest>
+        <application>
+            <meta-data
+                android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+                android:value="true"/>
+        </application>
+    </manifest>
+    ```
+
+3. Add ProGuard exception
+
+    Amplitude Android SDK uses Java Reflection to use classes in Google Play Services. For Amplitude SDKs to work in your Android application, add these exceptions to `proguard.pro` for the classes from `play-services-ads`.
+    `-keep class com.google.android.gms.ads.** { *; }`
+
+4. `AD_ID` Permission 
+    When apps update their target to Android 13 or above will need to declare a Google Play services normal permission in the manifest file as follows if you are trying to use the ADID as a deviceId:
+
+    ```xml
+        <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+    ```
+    
+    [Learn More](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Based on the Android doc, https://support.google.com/googleplay/android-developer/answer/6048248?hl=en and also the customer question from [Discourse](https://discourse.amplitude.com/t/ad-id-declaration-in-the-manifest-for-android-sdk/10198/2), I added the ADID permission on both Android and Kotlin side. 

<img width="746" alt="Screen Shot 2023-04-14 at 6 11 32 PM" src="https://user-images.githubusercontent.com/13028329/232175875-f7dd7faa-ed28-4e22-85a7-af5d3636c77d.png">

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
