### PR TITLE
Update identify api documentation for setOnce

### DIFF
--- a/docs/analytics/apis/identify-api.md
+++ b/docs/analytics/apis/identify-api.md
@@ -77,7 +77,7 @@ The `user_properties` field supports these operations:
 |<div class="big-column">Name</div>|Description|
 |----|------|
 |`$set` |Sets the value of a property.|
-|`$setOnce`| Sets the value of a property, prevent overriding the property value.|
+|`$setOnce`| Set the value only if the value hasn't already been set.|
 |`$add`| Adds a numeric value to a numeric property.|
 |`$append` and `$prepend` | Appends and prepends the value to a user property array.|
 |`$unset`| Removes a property|


### PR DESCRIPTION
# Amplitude Developer Docs PR
`setOnce`'s documentation was very misleading, I'm normalizing it from the setting up user properties page.

## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
