### PR TITLE
feat: add multiple instance information to Kotlin SDK

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -44,7 +44,8 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](../android-kotlin/#advertiser-id) for required module and permission. | `false` |
     | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](../android-kotlin/#app-set-id) for required module and permission. | `false` |
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
-    | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |'
+    | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |
+    | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
@@ -793,3 +794,21 @@ Implements a customized `loggerProvider` class from the LoggerProvider, and pass
         )
     )
     ```
+
+
+### Multiple Instances
+
+It is possible to create multiple instances of Amplitude. Instances with the same `instanceName` will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. For more details see [Configuration](#configuration).
+
+```kotlin
+val amplitude1 = Amplitude(Configuration(
+    instanceName = "one",
+    apiKey = "api-key-1",
+    context = applicationContext,
+))
+val amplitude2 = Amplitude(Configuration(
+    instanceName = "two",
+    apiKey = "api-key-2",
+    context = applicationContext,
+))
+```

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -795,7 +795,6 @@ Implements a customized `loggerProvider` class from the LoggerProvider, and pass
     )
     ```
 
-
 ### Multiple Instances
 
 It is possible to create multiple instances of Amplitude. Instances with the same `instanceName` will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. For more details see [Configuration](#configuration).

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -44,7 +44,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `useAdvertisingIdForDeviceId` | `Boolean`. Whether to use advertising id as device id. Please check [here](../android-kotlin/#advertiser-id) for required module and permission. | `false` |
     | `useAppSetIdForDeviceId` | `Boolean`.  Whether to use app set id as device id. Please check [here](../android-kotlin/#app-set-id) for required module and permission. | `false` |
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
-    | `enableCoppaControl` | `Boolean`. Whether to enable coppa control for tracking options. | `false` |
+    | `enableCoppaControl` | `Boolean`. Whether to enable COPPA control for tracking options. | `false` |
     | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"

--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -374,9 +374,9 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
  Remember that apps asking for information from children under 13 years of age must comply with COPPA.
 
 ```dart
-//Enable COPPA Control
+// Enable COPPA Control
 Amplitude.getInstance().enableCoppaControl();
-//Disable COPPA Control
+// Disable COPPA Control
 Amplitude.getInstance().disableCoppaControl();
 ```
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -51,7 +51,7 @@ let amplitude = Amplitude(configuration: Configuration(
     | `serverZone` |  The server zone to send to, will adjust server url based on this config. | `US` |
     | `useBatch` |  Whether to use batch api. | `false` |
     | `trackingOptions` |  Options to control the values tracked in SDK. | `enable` |
-    | `enableCoppaControl` |  Whether to enable coppa control for tracking options. | `false` |'
+    | `enableCoppaControl` |  Whether to enable COPPA control for tracking options. | `false` |'
 
 ### `track`
 

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -415,9 +415,9 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 === "TypeScript"
 
     ```ts
-    //Enable COPPA Control
+    // Enable COPPA Control
     Amplitude.instance().enableCoppaControl();
-    //Disable COPPA Control
+    // Disable COPPA Control
     Amplitude.instance().disableCoppaControl();
     ```
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

* Added `Mulitple Instances` and `instanceName` information to Android Kotlin docs
* https://amplitude.atlassian.net/browse/DXOC-741

<img width="792" alt="image" src="https://user-images.githubusercontent.com/5790872/233713655-afa4db9c-fb3f-4ceb-8beb-da6d21825317.png">
<img width="783" alt="image" src="https://user-images.githubusercontent.com/5790872/233713581-4090270e-58bf-4125-a9ac-66c9ce935a75.png">


## Change type

- [x] New documentation.


@amplitude-dev-docs
