### PR TITLE
Add plugin docs for GTM

### DIFF
--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -428,13 +428,10 @@ Use a Destination Plugin to send events to a third-party APIs
                     event: "gtm.js"
                   })
                   const head = document.getElementsByTagName("head")[0],
-                    script = document.createElement("script"),
-                    dataLayer = "datalayer" != "dataLayer" ? "&l=" + "datalayer" : ""
+                    script = document.createElement("script");
                   script.async = true
                   script.src =
-                    "https://www.googletagmanager.com/gtm.js?id=" +
-                    this.containerId +
-                    dataLayer
+                    `https://www.googletagmanager.com/gtm.js?id=${this.containerId}&l=datalayer`
                   head.insertBefore(script, head.firstChild)
                 }
               }

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -405,6 +405,91 @@ Use a Destination Plugin to send events to a third-party APIs
             }
             ```
 
+    ???code-example "Send to Google Tag Manager by pushing events onto the [data layer](https://developers.google.com/tag-platform/tag-manager/web/datalayer) (click to expand)"
+
+        === "JavaScript"
+  
+            ```js
+            import { PluginType } from "@amplitude/analytics-types"
+
+            export class GTMPlugin {
+              name = "google-tag-manager"
+              type = PluginType.DESTINATION
+
+              constructor(containerId) {
+                this.containerId = containerId
+              }
+
+              async setup() {
+                if (!window.dataLayer) {
+                  window.dataLayer = window.dataLayer || []
+                  window.dataLayer.push({
+                    "gtm.start": new Date().getTime(),
+                    event: "gtm.js"
+                  })
+                  const head = document.getElementsByTagName("head")[0],
+                    script = document.createElement("script"),
+                    dataLayer = "datalayer" != "dataLayer" ? "&l=" + "datalayer" : ""
+                  script.async = true
+                  script.src =
+                    "https://www.googletagmanager.com/gtm.js?id=" +
+                    this.containerId +
+                    dataLayer
+                  head.insertBefore(script, head.firstChild)
+                }
+              }
+
+              async execute(event) {
+                window.dataLayer.push(event)
+
+                return {
+                  code: 0,
+                  event: event,
+                  message: "Event pushed onto GTM Data Layer"
+                }
+              }
+            }
+
+            ```
+        
+        === "TypeScript"
+        
+            ```ts
+            import { DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
+
+            export class GTMPlugin implements DestinationPlugin {
+              name = 'google-tag-manager';
+              type = PluginType.DESTINATION as const;
+              containerId: string;
+
+              constructor(containerId: string) {
+                this.containerId = containerId;
+              }
+
+              async setup(): Promise<void> {
+                if (!window.dataLayer) {
+                  window.dataLayer = window.dataLayer || [];
+                  window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+                  const head = document.getElementsByTagName('head')[0],
+                    script = document.createElement('script'),
+                    dataLayer = 'datalayer' != 'dataLayer' ? '&l=' + 'datalayer' : '';
+                  script.async = true;
+                  script.src = 'https://www.googletagmanager.com/gtm.js?id=' + this.containerId + dataLayer;
+                  head.insertBefore(script, head.firstChild);
+                }
+              }
+
+              async execute(event: Event): Promise<Result> {
+                window.dataLayer.push(event);
+
+                return {
+                  code: 0,
+                  event: event,
+                  message: 'Event pushed onto GTM Data Layer',
+                };
+              }
+            }
+            ```
 ## Supported SDKs
 
 |Platform|SDK|Github|

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -443,7 +443,7 @@ Use a Destination Plugin to send events to a third-party APIs
                 window.dataLayer.push(event)
 
                 return {
-                  code: 0,
+                  code: 200,
                   event: event,
                   message: "Event pushed onto GTM Data Layer"
                 }
@@ -483,7 +483,7 @@ Use a Destination Plugin to send events to a third-party APIs
                 window.dataLayer.push(event);
 
                 return {
-                  code: 0,
+                  code: 200,
                   event: event,
                   message: 'Event pushed onto GTM Data Layer',
                 };


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Adds destination plugin example for sending events to google tag manager client-side

![image](https://user-images.githubusercontent.com/15751908/234940950-0cd9d4b0-ee73-48c2-a0ec-c9833549e77f.png)


## Deadline

Important, not urgent


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
