### PR TITLE
Add lookup table CSV example

### DIFF
--- a/docs/assets/csv/lookup-table-example.csv
+++ b/docs/assets/csv/lookup-table-example.csv
@@ -1,0 +1,3 @@
+en_US,English
+fr_FR,French
+de_DE,German

--- a/docs/data/sources/lookup-table.md
+++ b/docs/data/sources/lookup-table.md
@@ -53,3 +53,15 @@ With Amplitude's Lookup Table feature, you can import your own data and map it t
 - **Enrich data using ingested property values**. You've captured an event called `Purchased` with an event property named `SKU`. The `SKU` value itself doesn't inherently hold a lot of meaning. But with your list of all the SKUs and their corresponding product names, you can use this feature to create a new property called `Product Name` and have it automatically populate based on that list.
 - **Bulk update property values.** You've captured a user property called `Language Code` and passed in language codes (`en_US`, `fr_FR`, `de_DE`, etc.). This is difficult to read, so you want a `Language` property that maps to friendlier values like `English`, `French`, and `German`. Use this feature to create a new property called `Language` that maps the language codes to the language names.
 - **Bulk filter long lists**. You want to see user behavior for a specific region and you have a list of all the customers and their regions. Use this to map each customer to a region, creating a new "Region" property. Now you can filter specifically to each region in a chart.
+
+## CSV example
+The following CSV will create a new property called `Language` that maps to the `SKU` property. This CSV is an example implementation of the **Bulk update property values** use case from the previous section.
+
+
+| SKU       | Language |
+|-----------|----------|
+| en_US    | English    |
+| fr_FR | French     |
+| de_DE | German     |
+
+[Click to download this example CSV](../../assets/csv/lookup-table-example.csv)


### PR DESCRIPTION
People are asking for the sample CSV they can use for lookup tables. This PR adds an example CSV to the lookup tables docs page
<img width="1367" alt="Screenshot 2023-04-28 at 10 45 43" src="https://user-images.githubusercontent.com/36277508/235115347-59561894-e74b-401d-9f62-0c825fe2e01b.png">


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
