### PR TITLE
feat: add docs for ampli event level group support

### DIFF
--- a/docs/data/sdk-middleware.md
+++ b/docs/data/sdk-middleware.md
@@ -104,7 +104,7 @@ Use an Middleware to modify event properties, transformation, filtering, routing
 
     ???code-example "Send event level groups (click to expand)"
 
-        This is an example of how to send event level groups in Ampli V1
+        This is an example of how to send event level groups in Ampli V1.
         How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
         
         ```js

--- a/docs/data/sdk-middleware.md
+++ b/docs/data/sdk-middleware.md
@@ -102,7 +102,7 @@ Use an Middleware to modify event properties, transformation, filtering, routing
         });
         ```
 
-    ???code-example "Send event level groups (click to expand)"
+    ???code-example "Send event level groups using Ampli v1 (click to expand)"
 
         This is an example of how to send event level groups in Ampli V1.
         How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.

--- a/docs/data/sdk-middleware.md
+++ b/docs/data/sdk-middleware.md
@@ -93,13 +93,33 @@ Use an Middleware to modify event properties, transformation, filtering, routing
     ???code-example "Enrich Event Properties (click to expand)"
 
         ```js
-        ampli.client.addEventMiddleware((payload, next) => {
+        amplitude.addEventMiddleware((payload, next) => {
           const { event } = payload;
           if (needsDeviceId(event)) {
             payload.event.deviceId = getDeviceId();
           }
           next(payload)
         });
+        ```
+
+    ???code-example "Send event level groups (click to expand)"
+
+        This is an example of how to send event level groups in Ampli V1
+        How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
+        
+        ```js
+        ampli.addEventMiddleware((payload, next) => {
+          const {event, extra} =  payload;
+          if (event && extra && event.extra.groups) {
+            event.groups =  event.extra.groups;
+          }
+
+          next(payload);
+        });
+
+        // Pass the event level groups info though middleware extra when calling the tracking plan.
+        const extra = {groups: {"test_group_name": "test_group_value"}};
+        ampli.eventWithGroups({requiredNumber: 1.23, requiredBoolean: false}, extra);
         ```
 
 !!!example "Routing to third-party destinations example"

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -544,6 +544,7 @@ Use a Destination Plugin to send events to a third-party APIs
               }
             }
             ```
+
 ## Supported SDKs
 
 |Platform|SDK|Github|

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -182,11 +182,10 @@ Use an Enrichment Plugin to modify event properties:
             amplitude.init('API_KEY');
             ```
 
-
     ???code-example "Send event level groups using Ampli v2 (click to expand)"
-      This is an example of how to send event level groups in Ampli V2.
-      How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
 
+        This is an example of how to send event level groups in Ampli V2.
+        How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
         === "JavaScript"
             ```js
             import * as amplitude from '@amplitude/analytics-browser';
@@ -215,9 +214,7 @@ Use an Enrichment Plugin to modify event properties:
             const extra = {extra: { groups: ["test_group_name": "test_group_value"]}};
             ampli.eventWithGroups({requiredNumber: 1.23, requiredBoolean: false}, extra);
             ```
-
-      === "TypeScript"
-
+        === "TypeScript"
             ```ts    
             import { EnrichmentPlugin, BrowserConfig, PluginType, Event } from '@amplitude/analytics-types';
     

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -183,7 +183,7 @@ Use an Enrichment Plugin to modify event properties:
             ```
 
 
-    ???code-example "Send event level groups (click to expand)"
+    ???code-example "Send event level groups using Ampli v2 (click to expand)"
       This is an example of how to send event level groups in Ampli V2.
       How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
 

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -82,8 +82,8 @@ Use an Enrichment Plugin to modify event properties:
               }
             }
     
-            amplitude.init('API_KEY');
             amplitude.add(new FilterEventsPlugin());
+            amplitude.init('API_KEY');
             ```
 
         === "TypeScript"
@@ -112,8 +112,8 @@ Use an Enrichment Plugin to modify event properties:
               }
             }
 
-            amplitude.init('API_KEY');
             amplitude.add(new FilterEventsPlugin());
+            amplitude.init('API_KEY');
             ```
 
     ???code-example "Remove PII (Personally Identifiable Information) (click to expand)"
@@ -178,10 +178,70 @@ Use an Enrichment Plugin to modify event properties:
               }
             }
     
-            amplitude.init('API_KEY');
             amplitude.add(new FilterEventsPlugin());
+            amplitude.init('API_KEY');
             ```
-  
+
+
+    ???code-example "Send event level groups (click to expand)"
+       This is an example of how to send event level groups in Ampli V2
+       How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
+
+       === "JavaScript"
+            ```js
+            import * as amplitude from '@amplitude/analytics-browser';
+    
+            import {PluginType} from '@amplitude/analytics-types';
+    
+            class EventLevelGroupPlugin {
+              name = 'group-plugin';
+              type = PluginType.ENRICHMENT;
+    
+              async setup(config) {
+                return undefined;
+              }
+    
+              async execute(event) {
+                  event.groups = event.extra['groups'];
+                  return event;
+              }
+    
+              // Allow other events to be processed and sent to destination plugins
+              return event;
+            }
+    
+            ampli.client.add(new EventLevelGroupPlugin());
+
+            const extra = {extra: { groups: ["test_group_name": "test_group_value"]}};
+            ampli.eventWithGroups({requiredNumber: 1.23, requiredBoolean: false}, extra);
+            ```
+
+          === "TypeScript"
+
+            ```ts    
+            import { EnrichmentPlugin, BrowserConfig, PluginType, Event } from '@amplitude/analytics-types';
+    
+            class EventLevelGroupPlugin implements EnrichmentPlugin {
+              name = 'group-plugin';
+              type = PluginType.ENRICHMENT as any;
+    
+              async setup(config: BrowserConfig): Promise<void> {
+                return undefined;
+              }
+    
+              async execute(event: Event): Promise<Event> {
+                  event.groups = event.extra['groups'];
+                  return event;
+              }
+            }
+    
+            ampli.client.add(new EventLevelGroupPlugin());
+            
+            // Pass the event level groups info though middleware extra when calling the tracking plan.
+            const extra = {extra: { groups: ["test_group_name": "test_group_value"]}};
+            ampli.eventWithGroups({requiredNumber: 1.23, requiredBoolean: false}, extra);
+            ```
+
 ### Destination type plugin
 
 Use a Destination Plugin to send events to a third-party APIs

--- a/docs/data/sdk-plugins.md
+++ b/docs/data/sdk-plugins.md
@@ -184,10 +184,10 @@ Use an Enrichment Plugin to modify event properties:
 
 
     ???code-example "Send event level groups (click to expand)"
-       This is an example of how to send event level groups in Ampli V2
-       How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
+      This is an example of how to send event level groups in Ampli V2.
+      How to send event level groups in SDKs(not in Ampli) is different. Please check the specific SDKs for the usage.
 
-       === "JavaScript"
+        === "JavaScript"
             ```js
             import * as amplitude from '@amplitude/analytics-browser';
     
@@ -216,7 +216,7 @@ Use an Enrichment Plugin to modify event properties:
             ampli.eventWithGroups({requiredNumber: 1.23, requiredBoolean: false}, extra);
             ```
 
-          === "TypeScript"
+      === "TypeScript"
 
             ```ts    
             import { EnrichmentPlugin, BrowserConfig, PluginType, Event } from '@amplitude/analytics-types';


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

We received a lot of questions related to how to set groups at the event level in Ampli. 
Currently, the workaround is using middleware/plugins. So I added that example in the middleware and plugin docs. 


## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
