### PR TITLE
AMP-73520: Added language mapping description to http-api

### DIFF
--- a/docs/analytics/apis/http-v2-api.md
+++ b/docs/analytics/apis/http-v2-api.md
@@ -100,6 +100,10 @@ If the event doesn't have a `user_id` or `device_id` value, the upload may be re
     * "0"
     * "-1"
 
+### Language Field
+
+--8<-- "includes/http-api/shared-language-mapping.md"
+
 ## Upload request
 
 Send a POST request to `https://api2.amplitude.com/2/httpapi`. 

--- a/includes/http-api/shared-language-mapping.md
+++ b/includes/http-api/shared-language-mapping.md
@@ -1,0 +1,1396 @@
+
+If the `language` field in the request contains a tag, the tag will be changed to its human-friendly language name. For example, if a request contains `"language": "en-US"`, it will be changed to `"language": "English"` before it is stored.
+
+The following table shows the list of mappings. Language tags are case-insensitive.
+
+??? info "Language Mappings"
+    | <div class="big-column">Language Tag</div>  | Language Value |
+    | --- | --- |
+    |`"aa"` | "Afar" |
+    |`"ab"` | "Abkhazian" |
+    |`"abkhazian"` | "Abkhazian" |
+    |`"ace"` | "Achinese" |
+    |`"ach"` | "Acoli" |
+    |`"achinese"` | "Achinese" |
+    |`"acoli"` | "Acoli" |
+    |`"ada"` | "Adangme" |
+    |`"adangme"` | "Adangme" |
+    |`"ady"` | "Adyghe" |
+    |`"adyghe"` | "Adyghe" |
+    |`"ae"` | "Avestan" |
+    |`"af"` | "Afrikaans" |
+    |`"afar"` | "Afar" |
+    |`"afh"` | "Afrihili" |
+    |`"afrihili"` | "Afrihili" |
+    |`"afrikaans"` | "Afrikaans" |
+    |`"aghem"` | "Aghem" |
+    |`"agq"` | "Aghem" |
+    |`"ain"` | "Ainu" |
+    |`"ainu"` | "Ainu" |
+    |`"ak"` | "Akan" |
+    |`"akan"` | "Akan" |
+    |`"akk"` | "Akkadian" |
+    |`"akkadian"` | "Akkadian" |
+    |`"akoose"` | "Akoose" |
+    |`"albanian"` | "Albanian" |
+    |`"albanian (albania)"` | "Sanskrit" |
+    |`"ale"` | "Aleut" |
+    |`"aleut"` | "Aleut" |
+    |`"alt"` | "Southern Altai" |
+    |`"am"` | "Amharic" |
+    |`"american english"` | "English" |
+    |`"amharic"` | "Amharic" |
+    |`"an"` | "Aragonese" |
+    |`"ancient egyptian"` | "Ancient Egyptian" |
+    |`"ancient greek"` | "Ancient Greek" |
+    |`"ang"` | "Old English" |
+    |`"angielski (stany zjednoczone)"` | "English" |
+    |`"angielski (wielka brytania)"` | "English" |
+    |`"angika"` | "Angika" |
+    |`"anglais (royaume-uni)"` | "English" |
+    |`"anglais (singapour)"` | "English" |
+    |`"anp"` | "Angika" |
+    |`"ar"` | "Arabic" |
+    |`"ar-001"` | "Arabic" |
+    |`"ar_eg"` | "Arabic" |
+    |`"arabe (arabie saoudite)"` | "Arabic" |
+    |`"arabia"` | "Arabic" |
+    |`"arabic"` | "Arabic" |
+    |`"arabic (egypt)"` | "Arabic" |
+    |`"arabic (iraq)"` | "Arabic" |
+    |`"arabic (jordan)"` | "Arabic" |
+    |`"arabic (kuwait)"` | "Arabic" |
+    |`"arabic (saudi arabia)"` | "Arabic" |
+    |`"arabic (yemen)"` | "Arabic" |
+    |`"aragonese"` | "Aragonese" |
+    |`"aramaic"` | "Aramaic" |
+    |`"arapaho"` | "Arapaho" |
+    |`"arawak"` | "Arawak" |
+    |`"arbic"` | "Arabic" |
+    |`"arc"` | "Aramaic" |
+    |`"armenian"` | "Armenian" |
+    |`"armenian (armenia)"` | "Armenian" |
+    |`"arn"` | "Mapuche" |
+    |`"aromanian"` | "Aromanian" |
+    |`"arp"` | "Arapaho" |
+    |`"arw"` | "Arawak" |
+    |`"as"` | "Assamese" |
+    |`"asa"` | "Asu" |
+    |`"assamese"` | "Assamese" |
+    |`"ast"` | "Asturian" |
+    |`"asturian"` | "Asturian" |
+    |`"asturianu"` | "Asturian" |
+    |`"asu"` | "Asu" |
+    |`"atsam"` | "Atsam" |
+    |`"australian english"` | "English" |
+    |`"austrian german"` | "German" |
+    |`"av"` | "Avaric" |
+    |`"avaric"` | "Avaric" |
+    |`"avestan"` | "Avestan" |
+    |`"awa"` | "Awadhi" |
+    |`"awadhi"` | "Awadhi" |
+    |`"ay"` | "Aymara" |
+    |`"aymara"` | "Aymara" |
+    |`"az"` | "Azerbaijani" |
+    |`"azerbaijani"` | "Azerbaijani" |
+    |`"azeri"` | "Azerbaijani" |
+    |`"azərbaycan"` | "Azerbaijani" |
+    |`"azərbaycanca"` | "Azerbaijani" |
+    |`"ba"` | "Bashkir" |
+    |`"bafia"` | "Bafia" |
+    |`"bafut"` | "Bafut" |
+    |`"bahasa indonesia"` | "Indonesian" |
+    |`"bahasa malaysia"` | "Malay" |
+    |`"bahasa melayu"` | "Malay" |
+    |`"bal"` | "Baluchi" |
+    |`"balinese"` | "Balinese" |
+    |`"baluchi"` | "Baluchi" |
+    |`"bamanakan"` | "Bambara" |
+    |`"bambara"` | "Bambara" |
+    |`"bamun"` | "Bamun" |
+    |`"ban"` | "Balinese" |
+    |`"bas"` | "Basaa" |
+    |`"basaa"` | "Basaa" |
+    |`"bashkir"` | "Bashkir" |
+    |`"basque"` | "Basque" |
+    |`"bax"` | "Bamun" |
+    |`"bbj"` | "Ghomala" |
+    |`"be"` | "Belarusian" |
+    |`"bej"` | "Beja" |
+    |`"beja"` | "Beja" |
+    |`"belarusian"` | "Belarusian" |
+    |`"bem"` | "Bemba" |
+    |`"bemba"` | "Bemba" |
+    |`"bena"` | "Bena" |
+    |`"bengali"` | "Bengali" |
+    |`"bengali (bangladesh)"` | "Bengali" |
+    |`"bez"` | "Bena" |
+    |`"bfd"` | "Bafut" |
+    |`"bg"` | "Bulgarian" |
+    |`"bho"` | "Bhojpuri" |
+    |`"bhojpuri"` | "Bhojpuri" |
+    |`"bi"` | "Bislama" |
+    |`"bik"` | "Bikol" |
+    |`"bikol"` | "Bikol" |
+    |`"bin"` | "Bini" |
+    |`"bini"` | "Bini" |
+    |`"bislama"` | "Bislama" |
+    |`"bkm"` | "Kom" |
+    |`"bla"` | "Siksika" |
+    |`"blin"` | "Blin" |
+    |`"blissymbols"` | "Blissymbols" |
+    |`"bm"` | "Bambara" |
+    |`"bn"` | "Bengali" |
+    |`"bo"` | "Tibetan" |
+    |`"bodo"` | "Bodo" |
+    |`"bosanski"` | "Bosnian" |
+    |`"bosnian"` | "Bosnian" |
+    |`"bosnian (latin, bosnia and herzegovina)"` | "Bosnian" |
+    |`"br"` | "Breton" |
+    |`"bra"` | "Braj" |
+    |`"braj"` | "Braj" |
+    |`"brazilian portuguese"` | "Portuguese" |
+    |`"breton"` | "Breton" |
+    |`"brezhoneg"` | "Breton" |
+    |`"british english"` | "English" |
+    |`"brx"` | "Bodo" |
+    |`"bs"` | "Bosnian" |
+    |`"bss"` | "Akoose" |
+    |`"bua"` | "Buriat" |
+    |`"bug"` | "Buginese" |
+    |`"buginese"` | "Buginese" |
+    |`"bulgarian"` | "Bulgarian" |
+    |`"bulgarian (bulgaria)"` | "Bulgarian" |
+    |`"bulu"` | "Bulu" |
+    |`"bum"` | "Bulu" |
+    |`"buriat"` | "Buriat" |
+    |`"burmese"` | "Burmese" |
+    |`"byn"` | "Blin" |
+    |`"byv"` | "Medumba" |
+    |`"ca"` | "Catalan" |
+    |`"ca_es"` | "Catalan" |
+    |`"cad"` | "Caddo" |
+    |`"caddo"` | "Caddo" |
+    |`"canadian english"` | "English" |
+    |`"canadian french"` | "French" |
+    |`"cantonese"` | "Cantonese" |
+    |`"car"` | "Carib" |
+    |`"carib"` | "Carib" |
+    |`"catalan"` | "Catalan" |
+    |`"català"` | "Catalan" |
+    |`"cay"` | "Cayuga" |
+    |`"cayuga"` | "Cayuga" |
+    |`"cch"` | "Atsam" |
+    |`"ce"` | "Chechen" |
+    |`"ceb"` | "Cebuano" |
+    |`"cebuano"` | "Cebuano" |
+    |`"central atlas tamazight"` | "Central Atlas Tamazight" |
+    |`"cgg"` | "Chiga" |
+    |`"ch"` | "Chamorro" |
+    |`"chadian arabic"` | "Chadian Arabic" |
+    |`"chagatai"` | "Chagatai" |
+    |`"chamorro"` | "Chamorro" |
+    |`"chb"` | "Chibcha" |
+    |`"chechen"` | "Chechen" |
+    |`"cherokee"` | "Cherokee" |
+    |`"cheyenne"` | "Cheyenne" |
+    |`"chg"` | "Chagatai" |
+    |`"chibcha"` | "Chibcha" |
+    |`"chiga"` | "Chiga" |
+    |`"chimakonde"` | "Makonde" |
+    |`"chinese"` | "Chinese" |
+    |`"chinese (hong kong s.a.r.)"` | "Chinese" |
+    |`"chinese (simplified, china)"` | "Chinese" |
+    |`"chinese (simplified, prc)"` | "Chinese" |
+    |`"chinese (simplified, singapore)"` | "Chinese" |
+    |`"chinese (taiwan)"` | "Chinese" |
+    |`"chinese (traditional, hong kong s.a.r.)"` | "Chinese" |
+    |`"chinese (traditional, hong kong sar)"` | "Chinese" |
+    |`"chinese (traditional, taiwan)"` | "Chinese" |
+    |`"chinesisch (vereinfacht, china)"` | "Chinese" |
+    |`"chinook jargon"` | "Chinook Jargon" |
+    |`"chipewyan"` | "Chipewyan" |
+    |`"chishona"` | "Shona" |
+    |`"chk"` | "Chuukese" |
+    |`"chm"` | "Mari" |
+    |`"chn"` | "Chinook Jargon" |
+    |`"cho"` | "Choctaw" |
+    |`"choctaw"` | "Choctaw" |
+    |`"chp"` | "Chipewyan" |
+    |`"chr"` | "Cherokee" |
+    |`"church slavic"` | "Church Slavic" |
+    |`"chuukese"` | "Chuukese" |
+    |`"chuvash"` | "Chuvash" |
+    |`"chy"` | "Cheyenne" |
+    |`"ckb"` | "Sorani Kurdish" |
+    |`"classical newari"` | "Classical Newari" |
+    |`"classical syriac"` | "Classical Syriac" |
+    |`"co"` | "Corsican" |
+    |`"colognian"` | "Colognian" |
+    |`"comorian"` | "Comorian" |
+    |`"congo swahili"` | "Congo Swahili" |
+    |`"cop"` | "Coptic" |
+    |`"coptic"` | "Coptic" |
+    |`"cornish"` | "Cornish" |
+    |`"corsican"` | "Corsican" |
+    |`"cr"` | "Cree" |
+    |`"cree"` | "Cree" |
+    |`"creek"` | "Creek" |
+    |`"crh"` | "Crimean Turkish" |
+    |`"crimean turkish"` | "Crimean Turkish" |
+    |`"croatian"` | "Croatian" |
+    |`"croatian (croatia)"` | "Croatian" |
+    |`"cs"` | "Czech" |
+    |`"csb"` | "Kashubian" |
+    |`"cu"` | "Church Slavic" |
+    |`"cv"` | "Chuvash" |
+    |`"cy"` | "Welsh" |
+    |`"cymraeg"` | "Welsh" |
+    |`"czech"` | "Czech" |
+    |`"czech (czech republic)"` | "Czech" |
+    |`"da"` | "Danish" |
+    |`"dak"` | "Dakota" |
+    |`"dakota"` | "Dakota" |
+    |`"danish"` | "Danish" |
+    |`"danish (denmark)"` | "Danish" |
+    |`"dansk"` | "Danish" |
+    |`"dansk (danmark)"` | "Danish" |
+    |`"dar"` | "Dargwa" |
+    |`"dargwa"` | "Dargwa" |
+    |`"dav"` | "Taita" |
+    |`"davvisámegiella"` | "Northern Sami" |
+    |`"dazaga"` | "Dazaga" |
+    |`"de"` | "German" |
+    |`"de-at"` | "German" |
+    |`"de-ch"` | "German" |
+    |`"de_de"` | "German" |
+    |`"del"` | "Delaware" |
+    |`"delaware"` | "Delaware" |
+    |`"den"` | "Slave" |
+    |`"deutsch"` | "German" |
+    |`"deutsch (deutschland)"` | "German" |
+    |`"deutsch (liechtenstein)"` | "German" |
+    |`"deutsch (schweiz)"` | "German" |
+    |`"dgr"` | "Dogrib" |
+    |`"dholuo"` | "Luo" |
+    |`"din"` | "Dinka" |
+    |`"dinka"` | "Dinka" |
+    |`"divehi"` | "Divehi" |
+    |`"dje"` | "Zarma" |
+    |`"dogri"` | "Dogri" |
+    |`"dogrib"` | "Dogrib" |
+    |`"doi"` | "Dogri" |
+    |`"dsb"` | "Lower Sorbian" |
+    |`"dua"` | "Duala" |
+    |`"duala"` | "Duala" |
+    |`"dum"` | "Middle Dutch" |
+    |`"dutch"` | "Dutch" |
+    |`"dutch (belgium)"` | "Flemish" |
+    |`"dutch (netherlands)"` | "Dutch" |
+    |`"duálá"` | "Duala" |
+    |`"dv"` | "Divehi" |
+    |`"dyo"` | "Jola-Fonyi" |
+    |`"dyu"` | "Dyula" |
+    |`"dyula"` | "Dyula" |
+    |`"dz"` | "Dzongkha" |
+    |`"dzg"` | "Dazaga" |
+    |`"dzongkha"` | "Dzongkha" |
+    |`"eastern frisian"` | "Eastern Frisian" |
+    |`"ebu"` | "Embu" |
+    |`"ee"` | "Ewe" |
+    |`"eesti"` | "Estonian" |
+    |`"eesti (eesti)"` | "Estonian" |
+    |`"efi"` | "Efik" |
+    |`"efik"` | "Efik" |
+    |`"egy"` | "Ancient Egyptian" |
+    |`"eka"` | "Ekajuk" |
+    |`"ekajuk"` | "Ekajuk" |
+    |`"ekegusii"` | "Gusii" |
+    |`"el"` | "Greek" |
+    |`"el_gr"` | "Greek" |
+    |`"elamite"` | "Elamite" |
+    |`"elx"` | "Elamite" |
+    |`"embu"` | "Embu" |
+    |`"en"` | "English" |
+    |`"en-au"` | "English" |
+    |`"en-ca"` | "English" |
+    |`"en-gb"` | "English" |
+    |`"en-us"` | "English" |
+    |`"en_gb"` | "English" |
+    |`"en_ie"` | "English" |
+    |`"en_us"` | "English" |
+    |`"engels (verenigde staten)"` | "English" |
+    |`"engelsk (usa)"` | "English" |
+    |`"engelska (storbritannien)"` | "English" |
+    |`"engelska (usa)"` | "English" |
+    |`"engleski (ujedinjeno kraljevstvo)"` | "English" |
+    |`"english"` | "English" |
+    |`"english (australia)"` | "English" |
+    |`"english (canada)"` | "English" |
+    |`"english (caribbean)"` | "English" |
+    |`"english (india)"` | "English" |
+    |`"english (ireland)"` | "English" |
+    |`"english (malaysia)"` | "English" |
+    |`"english (new zealand)"` | "English" |
+    |`"english (philippines)"` | "English" |
+    |`"english (republic of the philippines)"` | "English" |
+    |`"english (singapore)"` | "English" |
+    |`"english (south africa)"` | "English" |
+    |`"english (trinidad and tobago)"` | "English" |
+    |`"english (united kingdom)"` | "English" |
+    |`"english (united states)"` | "English" |
+    |`"english (zimbabwe)"` | "English" |
+    |`"enm"` | "Middle English" |
+    |`"eo"` | "Esperanto" |
+    |`"erzya"` | "Erzya" |
+    |`"es"` | "Spanish" |
+    |`"es-419"` | "Spanish" |
+    |`"es-es"` | "Spanish" |
+    |`"es-mx"` | "Spanish" |
+    |`"es_es"` | "Spanish" |
+    |`"español"` | "Spanish" |
+    |`"español de américa"` | "Spanish" |
+    |`"español de españa"` | "Spanish" |
+    |`"español de méxico"` | "Spanish" |
+    |`"esperanto"` | "Esperanto" |
+    |`"estonian"` | "Estonian" |
+    |`"estonian (estonia)"` | "Estonian" |
+    |`"et"` | "Estonian" |
+    |`"eu"` | "Basque" |
+    |`"european portuguese"` | "Portuguese" |
+    |`"european spanish"` | "Spanish" |
+    |`"euskara"` | "Basque" |
+    |`"euskera"` | "Basque" |
+    |`"ewe"` | "Ewe" |
+    |`"ewo"` | "Ewondo" |
+    |`"ewondo"` | "Ewondo" |
+    |`"eʋegbe"` | "Ewe" |
+    |`"fa"` | "Persian" |
+    |`"fa_ir"` | "Persian" |
+    |`"fan"` | "Fang" |
+    |`"fang"` | "Fang" |
+    |`"fanti"` | "Fanti" |
+    |`"farese"` | "Faroese" |
+    |`"faroese"` | "Faroese" |
+    |`"farsi"` | "Persian" |
+    |`"fasi"` | "Persian" |
+    |`"fat"` | "Fanti" |
+    |`"ff"` | "Fulah" |
+    |`"fi"` | "Finnish" |
+    |`"fijian"` | "Fijian" |
+    |`"fil"` | "Filipino" |
+    |`"filipino"` | "Filipino" |
+    |`"filipino (philippines)"` | "Filipino" |
+    |`"finnish"` | "Finnish" |
+    |`"finnish (finland)"` | "Finnish" |
+    |`"fj"` | "Fijian" |
+    |`"flemish"` | "Flemish" |
+    |`"fo"` | "Faroese" |
+    |`"fon"` | "Fon" |
+    |`"fr"` | "French" |
+    |`"fr-ca"` | "French" |
+    |`"fr-ch"` | "French" |
+    |`"fr_ca"` | "French" |
+    |`"fr_fr"` | "French" |
+    |`"francese (francia)"` | "French" |
+    |`"français"` | "French" |
+    |`"français canadien"` | "French" |
+    |`"français suisse"` | "French" |
+    |`"french"` | "French" |
+    |`"french (belgium)"` | "French" |
+    |`"french (canada)"` | "French" |
+    |`"french (france)"` | "French" |
+    |`"french (switzerland)"` | "French" |
+    |`"friulian"` | "Friulian" |
+    |`"frm"` | "Middle French" |
+    |`"fro"` | "Old French" |
+    |`"frr"` | "Northern Frisian" |
+    |`"frs"` | "Eastern Frisian" |
+    |`"fulah"` | "Fulah" |
+    |`"fur"` | "Friulian" |
+    |`"furlan"` | "Friulian" |
+    |`"fy"` | "Western Frisian" |
+    |`"fyrom"` | "Macedonian" |
+    |`"føroyskt"` | "Faroese" |
+    |`"ga"` | "Ga" |
+    |`"gaa"` | "Ga" |
+    |`"gaeilge"` | "Irish" |
+    |`"gaelg"` | "Manx" |
+    |`"galego"` | "Galician" |
+    |`"galician"` | "Galician" |
+    |`"ganda"` | "Ganda" |
+    |`"gay"` | "Gayo" |
+    |`"gayo"` | "Gayo" |
+    |`"gba"` | "Gbaya" |
+    |`"gbaya"` | "Gbaya" |
+    |`"gd"` | "Scottish Gaelic" |
+    |`"geez"` | "Geez" |
+    |`"georgian"` | "Georgian" |
+    |`"georgian (georgia)"` | "Georgian" |
+    |`"german"` | "German" |
+    |`"german (austria)"` | "German" |
+    |`"german (germany)"` | "German" |
+    |`"german (switzerland)"` | "Swiss German" |
+    |`"gez"` | "Geez" |
+    |`"ghomala"` | "Ghomala" |
+    |`"gikuyu"` | "Kikuyu" |
+    |`"gil"` | "Gilbertese" |
+    |`"gilbertese"` | "Gilbertese" |
+    |`"gl"` | "Galician" |
+    |`"gmh"` | "Middle High German" |
+    |`"gn"` | "Guarani" |
+    |`"goh"` | "Old High German" |
+    |`"gon"` | "Gondi" |
+    |`"gondi"` | "Gondi" |
+    |`"gor"` | "Gorontalo" |
+    |`"gorontalo"` | "Gorontalo" |
+    |`"got"` | "Gothic" |
+    |`"gothic"` | "Gothic" |
+    |`"grb"` | "Grebo" |
+    |`"grc"` | "Ancient Greek" |
+    |`"grebo"` | "Grebo" |
+    |`"greek"` | "Greek" |
+    |`"greek (greece)"` | "Greek" |
+    |`"gsw"` | "Swiss German" |
+    |`"gu"` | "Gujarati" |
+    |`"guarani"` | "Guarani" |
+    |`"gujarati"` | "Gujarati" |
+    |`"gusii"` | "Gusii" |
+    |`"guz"` | "Gusii" |
+    |`"gv"` | "Manx" |
+    |`"gwi"` | "Gwichʼin" |
+    |`"gwichʼin"` | "Gwichʼin" |
+    |`"gàidhlig"` | "Scottish Gaelic" |
+    |`"ha"` | "Hausa" |
+    |`"hai"` | "Haida" |
+    |`"haida"` | "Haida" |
+    |`"haitian"` | "Haitian" |
+    |`"hausa"` | "Hausa" |
+    |`"haw"` | "Hawaiian" |
+    |`"hawaiian"` | "Hawaiian" |
+    |`"he"` | "Hebrew" |
+    |`"hebreo"` | "Hebrew" |
+    |`"hebrew"` | "Hebrew" |
+    |`"hebrew (israel)"` | "Hebrew" |
+    |`"herero"` | "Herero" |
+    |`"hi"` | "Hindi" |
+    |`"hibena"` | "Bena" |
+    |`"hil"` | "Hiligaynon" |
+    |`"hiligaynon"` | "Hiligaynon" |
+    |`"hindi"` | "Hindi" |
+    |`"hindi (india)"` | "Hindi" |
+    |`"hiri motu"` | "Hiri Motu" |
+    |`"hit"` | "Hittite" |
+    |`"hittite"` | "Hittite" |
+    |`"hmn"` | "Hmong" |
+    |`"hmong"` | "Hmong" |
+    |`"ho"` | "Hiri Motu" |
+    |`"hr"` | "Croatian" |
+    |`"hrvatski"` | "Croatian" |
+    |`"hrvatski (hrvatska)"` | "Croatian" |
+    |`"hsb"` | "Upper Sorbian" |
+    |`"ht"` | "Haitian" |
+    |`"hu"` | "Hungarian" |
+    |`"hungarian"` | "Hungarian" |
+    |`"hungarian (hungary)"` | "Hungarian" |
+    |`"hup"` | "Hupa" |
+    |`"hupa"` | "Hupa" |
+    |`"hy"` | "Armenian" |
+    |`"hz"` | "Herero" |
+    |`"ia"` | "Interlingua" |
+    |`"iba"` | "Iban" |
+    |`"iban"` | "Iban" |
+    |`"ibb"` | "Ibibio" |
+    |`"ibibio"` | "Ibibio" |
+    |`"icelandic"` | "Icelandic" |
+    |`"icelandic (iceland)"` | "Icelandic" |
+    |`"ichibemba"` | "Bemba" |
+    |`"id"` | "Indonesian" |
+    |`"ido"` | "Ido" |
+    |`"ie"` | "Interlingue" |
+    |`"ig"` | "Igbo" |
+    |`"igbo"` | "Igbo" |
+    |`"ii"` | "Sichuan Yi" |
+    |`"ik"` | "Inupiaq" |
+    |`"ikirundi"` | "Rundi" |
+    |`"ilo"` | "Iloko" |
+    |`"iloko"` | "Iloko" |
+    |`"in_id"` | "Indonesian" |
+    |`"inari sami"` | "Inari Sami" |
+    |`"indonesia"` | "Indonesian" |
+    |`"indonesian"` | "Indonesian" |
+    |`"indonesian (indonesia)"` | "Indonesian" |
+    |`"ingilizce (amerikan)"` | "English" |
+    |`"inglese (canada)"` | "English" |
+    |`"inglese (regno unito)"` | "English" |
+    |`"inglese (singapore)"` | "English" |
+    |`"inglese (stati uniti)"` | "English" |
+    |`"ingush"` | "Ingush" |
+    |`"inh"` | "Ingush" |
+    |`"interlingua"` | "Interlingua" |
+    |`"interlingue"` | "Interlingue" |
+    |`"inuktitut"` | "Inuktitut" |
+    |`"inupiaq"` | "Inupiaq" |
+    |`"io"` | "Ido" |
+    |`"irish"` | "Irish" |
+    |`"is"` | "Icelandic" |
+    |`"ishisangu"` | "Sangu" |
+    |`"isindebele"` | "South Ndebele" |
+    |`"isixhosa"` | "Xhosa" |
+    |`"isizulu"` | "Zulu" |
+    |`"it"` | "Italian" |
+    |`"it_it"` | "Italian" |
+    |`"italian"` | "Italian" |
+    |`"italian (italy)"` | "Italian" |
+    |`"italian (switzerland)"` | "Italian" |
+    |`"italiano"` | "Italian" |
+    |`"italiano (italia)"` | "Italian" |
+    |`"italiano (svizzera)"` | "Italian" |
+    |`"iu"` | "Inuktitut" |
+    |`"iw_il"` | "Hebrew" |
+    |`"ja"` | "Japanese" |
+    |`"japanese"` | "Japanese" |
+    |`"japanese (japan)"` | "Japanese" |
+    |`"javanese"` | "Javanese" |
+    |`"jbo"` | "Lojban" |
+    |`"jgo"` | "Ngomba" |
+    |`"jju"` | "Jju" |
+    |`"jmc"` | "Machame" |
+    |`"jola-fonyi"` | "Jola-Fonyi" |
+    |`"joola"` | "Jola-Fonyi" |
+    |`"jpr"` | "Judeo-Persian" |
+    |`"jrb"` | "Judeo-Arabic" |
+    |`"judeo-arabic"` | "Judeo-Arabic" |
+    |`"judeo-persian"` | "Judeo-Persian" |
+    |`"jv"` | "Javanese" |
+    |`"ka"` | "Georgian" |
+    |`"kaa"` | "Kara-Kalpak" |
+    |`"kab"` | "Kabyle" |
+    |`"kabardian"` | "Kabardian" |
+    |`"kabuverdianu"` | "Kabuverdianu" |
+    |`"kabyle"` | "Kabyle" |
+    |`"kac"` | "Kachin" |
+    |`"kachin"` | "Kachin" |
+    |`"kaj"` | "Jju" |
+    |`"kako"` | "Kako" |
+    |`"kakɔ"` | "Kako" |
+    |`"kalaallisut"` | "Kalaallisut" |
+    |`"kalenjin"` | "Kalenjin" |
+    |`"kalmyk"` | "Kalmyk" |
+    |`"kam"` | "Kamba" |
+    |`"kamba"` | "Kamba" |
+    |`"kanembu"` | "Kanembu" |
+    |`"kannada"` | "Kannada" |
+    |`"kanuri"` | "Kanuri" |
+    |`"kara-kalpak"` | "Kara-Kalpak" |
+    |`"karachay-balkar"` | "Karachay-Balkar" |
+    |`"karelian"` | "Karelian" |
+    |`"kashmiri"` | "Kashmiri" |
+    |`"kashubian"` | "Kashubian" |
+    |`"kaw"` | "Kawi" |
+    |`"kawi"` | "Kawi" |
+    |`"kazakh"` | "Kazakh" |
+    |`"kbd"` | "Kabardian" |
+    |`"kbl"` | "Kanembu" |
+    |`"kcg"` | "Tyap" |
+    |`"kde"` | "Makonde" |
+    |`"kea"` | "Kabuverdianu" |
+    |`"kernewek"` | "Cornish" |
+    |`"kfo"` | "Koro" |
+    |`"kg"` | "Kongo" |
+    |`"kha"` | "Khasi" |
+    |`"khasi"` | "Khasi" |
+    |`"khmer"` | "Khmer" |
+    |`"kho"` | "Khotanese" |
+    |`"khoekhoegowab"` | "Nama" |
+    |`"khotanese"` | "Khotanese" |
+    |`"khq"` | "Koyra Chiini" |
+    |`"ki"` | "Kikuyu" |
+    |`"kihorombo"` | "Rombo" |
+    |`"kikamba"` | "Kamba" |
+    |`"kikuyu"` | "Kikuyu" |
+    |`"kimachame"` | "Machame" |
+    |`"kimbundu"` | "Kimbundu" |
+    |`"kinyarwanda"` | "Kinyarwanda" |
+    |`"kipare"` | "Asu" |
+    |`"kirghiz"` | "Kyrgyz" |
+    |`"kiruwa"` | "Rwa" |
+    |`"kisampur"` | "Samburu" |
+    |`"kishambaa"` | "Shambala" |
+    |`"kiswahili"` | "Swahili" |
+    |`"kiswahili ya kongo"` | "Congo Swahili" |
+    |`"kitaita"` | "Taita" |
+    |`"kiteso"` | "Teso" |
+    |`"kj"` | "Kuanyama" |
+    |`"kk"` | "Kazakh" |
+    |`"kkj"` | "Kako" |
+    |`"kl"` | "Kalaallisut" |
+    |`"klingon"` | "Klingon" |
+    |`"kln"` | "Kalenjin" |
+    |`"km"` | "Khmer" |
+    |`"kmb"` | "Kimbundu" |
+    |`"kn"` | "Kannada" |
+    |`"ko"` | "Korean" |
+    |`"kok"` | "Konkani" |
+    |`"kom"` | "Kom" |
+    |`"komi"` | "Komi" |
+    |`"kongo"` | "Kongo" |
+    |`"konkani"` | "Konkani" |
+    |`"korean"` | "Korean" |
+    |`"korean (korea)"` | "Korean" |
+    |`"koro"` | "Koro" |
+    |`"kos"` | "Kosraean" |
+    |`"kosraean"` | "Kosraean" |
+    |`"koyra chiini"` | "Koyra Chiini" |
+    |`"koyra ciini"` | "Koyra Chiini" |
+    |`"koyraboro senni"` | "Koyraboro Senni" |
+    |`"kpe"` | "Kpelle" |
+    |`"kpelle"` | "Kpelle" |
+    |`"kr"` | "Kanuri" |
+    |`"krc"` | "Karachay-Balkar" |
+    |`"kreol morisien"` | "Morisyen" |
+    |`"krl"` | "Karelian" |
+    |`"kru"` | "Kurukh" |
+    |`"ks"` | "Kashmiri" |
+    |`"ksb"` | "Shambala" |
+    |`"ksf"` | "Bafia" |
+    |`"ksh"` | "Colognian" |
+    |`"ku"` | "Kurdish" |
+    |`"kuanyama"` | "Kuanyama" |
+    |`"kum"` | "Kumyk" |
+    |`"kumyk"` | "Kumyk" |
+    |`"kurdish"` | "Kurdish" |
+    |`"kurukh"` | "Kurukh" |
+    |`"kut"` | "Kutenai" |
+    |`"kutenai"` | "Kutenai" |
+    |`"kv"` | "Komi" |
+    |`"kw"` | "Cornish" |
+    |`"kwasio"` | "Kwasio" |
+    |`"ky"` | "Kyrgyz" |
+    |`"kyivunjo"` | "Vunjo" |
+    |`"kyrgyz"` | "Kyrgyz" |
+    |`"kölsch"` | "Colognian" |
+    |`"kĩembu"` | "Embu" |
+    |`"kĩmĩrũ"` | "Meru" |
+    |`"kɨlaangi"` | "Langi" |
+    |`"la"` | "Latin" |
+    |`"lad"` | "Ladino" |
+    |`"ladino"` | "Ladino" |
+    |`"lag"` | "Langi" |
+    |`"lah"` | "Lahnda" |
+    |`"lahnda"` | "Lahnda" |
+    |`"lakota"` | "Lakota" |
+    |`"lakȟólʼiyapi"` | "Lakota" |
+    |`"lam"` | "Lamba" |
+    |`"lamba"` | "Lamba" |
+    |`"langi"` | "Langi" |
+    |`"lao"` | "Lao" |
+    |`"latin"` | "Latin" |
+    |`"latin american spanish"` | "Spanish" |
+    |`"latvian"` | "Latvian" |
+    |`"latvian (latvia)"` | "Latvian" |
+    |`"latviešu"` | "Latvian" |
+    |`"lb"` | "Luxembourgish" |
+    |`"lea fakatonga"` | "Tongan" |
+    |`"lez"` | "Lezghian" |
+    |`"lezghian"` | "Lezghian" |
+    |`"lg"` | "Ganda" |
+    |`"li"` | "Limburgish" |
+    |`"lietuvių"` | "Lithuanian" |
+    |`"limburgish"` | "Limburgish" |
+    |`"lingala"` | "Lingala" |
+    |`"lingála"` | "Lingala" |
+    |`"lithuanian"` | "Lithuanian" |
+    |`"lithuanian (lithuania)"` | "Lithuanian" |
+    |`"lkt"` | "Lakota" |
+    |`"ln"` | "Lingala" |
+    |`"lo"` | "Lao" |
+    |`"lojban"` | "Lojban" |
+    |`"lol"` | "Mongo" |
+    |`"low german"` | "Low German" |
+    |`"lower sorbian"` | "Lower Sorbian" |
+    |`"loz"` | "Lozi" |
+    |`"lozi"` | "Lozi" |
+    |`"lt"` | "Lithuanian" |
+    |`"lu"` | "Luba-Katanga" |
+    |`"lua"` | "Luba-Lulua" |
+    |`"luba-katanga"` | "Luba-Katanga" |
+    |`"luba-lulua"` | "Luba-Lulua" |
+    |`"luganda"` | "Ganda" |
+    |`"lui"` | "Luiseno" |
+    |`"luiseno"` | "Luiseno" |
+    |`"lule sami"` | "Lule Sami" |
+    |`"luluhia"` | "Luyia" |
+    |`"lun"` | "Lunda" |
+    |`"lunda"` | "Lunda" |
+    |`"luo"` | "Luo" |
+    |`"lus"` | "Mizo" |
+    |`"luxembourgish"` | "Luxembourgish" |
+    |`"luy"` | "Luyia" |
+    |`"luyia"` | "Luyia" |
+    |`"lv"` | "Latvian" |
+    |`"maa"` | "Masai" |
+    |`"maba"` | "Maba" |
+    |`"macedonian"` | "Macedonian" |
+    |`"macedonian (former yugoslav republic of macedonia)"` | "Macedonian" |
+    |`"machame"` | "Machame" |
+    |`"mad"` | "Madurese" |
+    |`"madurese"` | "Madurese" |
+    |`"maf"` | "Mafa" |
+    |`"mafa"` | "Mafa" |
+    |`"mag"` | "Magahi" |
+    |`"magahi"` | "Magahi" |
+    |`"magyar"` | "Hungarian" |
+    |`"mai"` | "Maithili" |
+    |`"maithili"` | "Maithili" |
+    |`"mak"` | "Makasar" |
+    |`"makasar"` | "Makasar" |
+    |`"makhuwa-meetto"` | "Makhuwa-Meetto" |
+    |`"makonde"` | "Makonde" |
+    |`"makua"` | "Makhuwa-Meetto" |
+    |`"malagasy"` | "Malagasy" |
+    |`"malay"` | "Malay" |
+    |`"malay (malaysia)"` | "Malay" |
+    |`"malayalam"` | "Malayalam" |
+    |`"maltese"` | "Maltese" |
+    |`"malti"` | "Maltese" |
+    |`"man"` | "Mandingo" |
+    |`"manchu"` | "Manchu" |
+    |`"mandar"` | "Mandar" |
+    |`"mandingo"` | "Mandingo" |
+    |`"manipuri"` | "Manipuri" |
+    |`"manx"` | "Manx" |
+    |`"maori"` | "Maori" |
+    |`"mapuche"` | "Mapuche" |
+    |`"marathi"` | "Marathi" |
+    |`"mari"` | "Mari" |
+    |`"marshallese"` | "Marshallese" |
+    |`"marwari"` | "Marwari" |
+    |`"mas"` | "Masai" |
+    |`"masai"` | "Masai" |
+    |`"mde"` | "Maba" |
+    |`"mdf"` | "Moksha" |
+    |`"mdr"` | "Mandar" |
+    |`"medumba"` | "Medumba" |
+    |`"men"` | "Mende" |
+    |`"mende"` | "Mende" |
+    |`"mer"` | "Meru" |
+    |`"meru"` | "Meru" |
+    |`"meta'"` | "Meta'" |
+    |`"metaʼ"` | "Meta'" |
+    |`"mexican spanish"` | "Spanish" |
+    |`"mfe"` | "Morisyen" |
+    |`"mg"` | "Malagasy" |
+    |`"mga"` | "Middle Irish" |
+    |`"mgh"` | "Makhuwa-Meetto" |
+    |`"mgo"` | "Meta'" |
+    |`"mh"` | "Marshallese" |
+    |`"mi"` | "Maori" |
+    |`"mic"` | "Micmac" |
+    |`"micmac"` | "Micmac" |
+    |`"middle dutch"` | "Middle Dutch" |
+    |`"middle english"` | "Middle English" |
+    |`"middle french"` | "Middle French" |
+    |`"middle high german"` | "Middle High German" |
+    |`"middle irish"` | "Middle Irish" |
+    |`"min"` | "Minangkabau" |
+    |`"minangkabau"` | "Minangkabau" |
+    |`"mirandese"` | "Mirandese" |
+    |`"mizo"` | "Mizo" |
+    |`"mk"` | "Macedonian" |
+    |`"ml"` | "Malayalam" |
+    |`"mn"` | "Mongolian" |
+    |`"mnc"` | "Manchu" |
+    |`"mni"` | "Manipuri" |
+    |`"modern standard arabic"` | "Arabic" |
+    |`"moh"` | "Mohawk" |
+    |`"mohawk"` | "Mohawk" |
+    |`"moksha"` | "Moksha" |
+    |`"moldavian"` | "Moldavian" |
+    |`"moldovenească"` | "Moldavian" |
+    |`"mongo"` | "Mongo" |
+    |`"mongolian"` | "Mongolian" |
+    |`"mongolian (cyrillic, mongolia)"` | "Mongolian" |
+    |`"morisyen"` | "Morisyen" |
+    |`"mos"` | "Mossi" |
+    |`"mossi"` | "Mossi" |
+    |`"mr"` | "Marathi" |
+    |`"ms"` | "Malay" |
+    |`"mt"` | "Maltese" |
+    |`"mua"` | "Mundang" |
+    |`"mundang"` | "Mundang" |
+    |`"mundaŋ"` | "Mundang" |
+    |`"mus"` | "Creek" |
+    |`"mwl"` | "Mirandese" |
+    |`"mwr"` | "Marwari" |
+    |`"my"` | "Burmese" |
+    |`"my-rmm"` | "Burmese" |
+    |`"myanmar"` | "Burmese" |
+    |`"myanmar (zawgyi)"` | "Burmese" |
+    |`"mye"` | "Myene" |
+    |`"myene"` | "Myene" |
+    |`"myv"` | "Erzya" |
+    |`"na"` | "Nauru" |
+    |`"nama"` | "Nama" |
+    |`"nap"` | "Neapolitan" |
+    |`"naq"` | "Nama" |
+    |`"nauru"` | "Nauru" |
+    |`"navajo"` | "Navajo" |
+    |`"nb"` | "Norwegian" |
+    |`"nd"` | "North Ndebele" |
+    |`"ndaꞌa"` | "Ngomba" |
+    |`"ndonga"` | "Ndonga" |
+    |`"nds"` | "Low German" |
+    |`"ne"` | "Nepali" |
+    |`"neapolitan"` | "Neapolitan" |
+    |`"nederlands"` | "Dutch" |
+    |`"nederlands (nederland)"` | "Dutch" |
+    |`"nepali"` | "Nepali" |
+    |`"new"` | "Newari" |
+    |`"newari"` | "Newari" |
+    |`"ng"` | "Ndonga" |
+    |`"ngambay"` | "Ngambay" |
+    |`"ngiemboon"` | "Ngiemboon" |
+    |`"ngomba"` | "Ngomba" |
+    |`"nia"` | "Nias" |
+    |`"nias"` | "Nias" |
+    |`"niu"` | "Niuean" |
+    |`"niuean"` | "Niuean" |
+    |`"nl"` | "Dutch" |
+    |`"nl-be"` | "Flemish" |
+    |`"nl_nl"` | "Dutch" |
+    |`"nmg"` | "Kwasio" |
+    |`"nn"` | "Norwegian" |
+    |`"nnh"` | "Ngiemboon" |
+    |`"no"` | "Norwegian" |
+    |`"nog"` | "Nogai" |
+    |`"nogai"` | "Nogai" |
+    |`"non"` | "Old Norse" |
+    |`"norsk"` | "Norwegian" |
+    |`"norsk bokmål"` | "Norwegian" |
+    |`"north ndebele"` | "North Ndebele" |
+    |`"northern frisian"` | "Northern Frisian" |
+    |`"northern sami"` | "Northern Sami" |
+    |`"northern sotho"` | "Northern Sotho" |
+    |`"norwegian"` | "Norwegian" |
+    |`"norwegian (bokmal)"` | "Norwegian" |
+    |`"norwegian bokmål"` | "Norwegian" |
+    |`"norwegian nynorsk"` | "Norwegian" |
+    |`"nqo"` | "N’Ko" |
+    |`"nr"` | "South Ndebele" |
+    |`"nso"` | "Northern Sotho" |
+    |`"nuasue"` | "Yangben" |
+    |`"nuer"` | "Nuer" |
+    |`"nus"` | "Nuer" |
+    |`"nv"` | "Navajo" |
+    |`"nwc"` | "Classical Newari" |
+    |`"ny"` | "Nyanja" |
+    |`"nyamwezi"` | "Nyamwezi" |
+    |`"nyanja"` | "Nyanja" |
+    |`"nyankole"` | "Nyankole" |
+    |`"nyasa tonga"` | "Nyasa Tonga" |
+    |`"nym"` | "Nyamwezi" |
+    |`"nyn"` | "Nyankole" |
+    |`"nynorsk"` | "Norwegian" |
+    |`"nyo"` | "Nyoro" |
+    |`"nyoro"` | "Nyoro" |
+    |`"nzi"` | "Nzima" |
+    |`"nzima"` | "Nzima" |
+    |`"n’ko"` | "N’Ko" |
+    |`"oc"` | "Occitan" |
+    |`"occitan"` | "Occitan" |
+    |`"oj"` | "Ojibwa" |
+    |`"ojibwa"` | "Ojibwa" |
+    |`"old english"` | "Old English" |
+    |`"old french"` | "Old French" |
+    |`"old high german"` | "Old High German" |
+    |`"old irish"` | "Old Irish" |
+    |`"old norse"` | "Old Norse" |
+    |`"old persian"` | "Old Persian" |
+    |`"old provençal"` | "Old Provençal" |
+    |`"olusoga"` | "Soga" |
+    |`"om"` | "Oromo" |
+    |`"or"` | "Oriya" |
+    |`"oriya"` | "Oriya" |
+    |`"oromo"` | "Oromo" |
+    |`"oromoo"` | "Oromo" |
+    |`"os"` | "Ossetic" |
+    |`"osa"` | "Osage" |
+    |`"osage"` | "Osage" |
+    |`"ossetic"` | "Ossetic" |
+    |`"ota"` | "Ottoman Turkish" |
+    |`"ottoman turkish"` | "Ottoman Turkish" |
+    |`"oʻzbekcha"` | "Uzbek" |
+    |`"o‘zbek"` | "Uzbek" |
+    |`"pa"` | "Punjabi" |
+    |`"pag"` | "Pangasinan" |
+    |`"pahlavi"` | "Pahlavi" |
+    |`"pal"` | "Pahlavi" |
+    |`"palauan"` | "Palauan" |
+    |`"pali"` | "Pali" |
+    |`"pam"` | "Pampanga" |
+    |`"pampanga"` | "Pampanga" |
+    |`"pangasinan"` | "Pangasinan" |
+    |`"pap"` | "Papiamento" |
+    |`"papiamento"` | "Papiamento" |
+    |`"pashto"` | "Pashto" |
+    |`"pau"` | "Palauan" |
+    |`"peo"` | "Old Persian" |
+    |`"pershin"` | "Persian" |
+    |`"persian"` | "Persian" |
+    |`"phn"` | "Phoenician" |
+    |`"phoenician"` | "Phoenician" |
+    |`"pi"` | "Pali" |
+    |`"pl"` | "Polish" |
+    |`"pl_pl"` | "Polish" |
+    |`"pohnpeian"` | "Pohnpeian" |
+    |`"polish"` | "Polish" |
+    |`"polish (poland)"` | "Polish" |
+    |`"polska (polen)"` | "Polish" |
+    |`"polski"` | "Polish" |
+    |`"polski (polska)"` | "Polish" |
+    |`"pon"` | "Pohnpeian" |
+    |`"portugues"` | "Portuguese" |
+    |`"portugues (brasil)"` | "Portuguese" |
+    |`"portuguese"` | "Portuguese" |
+    |`"portuguese (brazil)"` | "Portuguese" |
+    |`"portuguese (portugal)"` | "Portuguese" |
+    |`"português"` | "Portuguese" |
+    |`"português do brasil"` | "Portuguese" |
+    |`"português europeu"` | "Portuguese" |
+    |`"pro"` | "Old Provençal" |
+    |`"ps"` | "Pashto" |
+    |`"pt"` | "Portuguese" |
+    |`"pt-br"` | "Portuguese" |
+    |`"pt-pt"` | "Portuguese" |
+    |`"pt_br"` | "Portuguese" |
+    |`"pt_pt"` | "Portuguese" |
+    |`"pulaar"` | "Fulah" |
+    |`"punjabi"` | "Punjabi" |
+    |`"pushto"` | "Pashto" |
+    |`"qafar"` | "Afar" |
+    |`"qu"` | "Quechua" |
+    |`"quechua"` | "Quechua" |
+    |`"raj"` | "Rajasthani" |
+    |`"rajasthani"` | "Rajasthani" |
+    |`"rap"` | "Rapanui" |
+    |`"rapanui"` | "Rapanui" |
+    |`"rar"` | "Rarotongan" |
+    |`"rarotongan"` | "Rarotongan" |
+    |`"rikpa"` | "Bafia" |
+    |`"rm"` | "Romansh" |
+    |`"rn"` | "Rundi" |
+    |`"ro"` | "Romanian" |
+    |`"ro-md"` | "Moldavian" |
+    |`"rof"` | "Rombo" |
+    |`"rom"` | "Romany" |
+    |`"romanian"` | "Romanian" |
+    |`"romanian (romania)"` | "Romanian" |
+    |`"romansh"` | "Romansh" |
+    |`"romany"` | "Romany" |
+    |`"rombo"` | "Rombo" |
+    |`"română"` | "Romanian" |
+    |`"root"` | "Root" |
+    |`"ru"` | "Russian" |
+    |`"ru_ru"` | "Russian" |
+    |`"rukiga"` | "Chiga" |
+    |`"rumantsch"` | "Romansh" |
+    |`"rundi"` | "Rundi" |
+    |`"runyankore"` | "Nyankole" |
+    |`"rup"` | "Aromanian" |
+    |`"russia"` | "Russian" |
+    |`"russian"` | "Russian" |
+    |`"russian (russia)"` | "Russian" |
+    |`"russo (russia)"` | "Russian" |
+    |`"rw"` | "Kinyarwanda" |
+    |`"rwa"` | "Rwa" |
+    |`"rwk"` | "Rwa" |
+    |`"sa"` | "Sanskrit" |
+    |`"sad"` | "Sandawe" |
+    |`"sah"` | "Sakha" |
+    |`"saho"` | "Saho" |
+    |`"sakha"` | "Sakha" |
+    |`"sam"` | "Samaritan Aramaic" |
+    |`"samaritan aramaic"` | "Samaritan Aramaic" |
+    |`"samburu"` | "Samburu" |
+    |`"samoan"` | "Samoan" |
+    |`"sandawe"` | "Sandawe" |
+    |`"sango"` | "Sango" |
+    |`"sangu"` | "Sangu" |
+    |`"sanskrit"` | "Sanskrit" |
+    |`"santali"` | "Santali" |
+    |`"saq"` | "Samburu" |
+    |`"sardinian"` | "Sardinian" |
+    |`"sas"` | "Sasak" |
+    |`"sasak"` | "Sasak" |
+    |`"sat"` | "Santali" |
+    |`"sba"` | "Ngambay" |
+    |`"sbp"` | "Sangu" |
+    |`"sc"` | "Sardinian" |
+    |`"schweizer hochdeutsch"` | "German" |
+    |`"schwiizertüütsch"` | "Swiss German" |
+    |`"scn"` | "Sicilian" |
+    |`"sco"` | "Scots" |
+    |`"scots"` | "Scots" |
+    |`"scottish gaelic"` | "Scottish Gaelic" |
+    |`"sd"` | "Sindhi" |
+    |`"se"` | "Northern Sami" |
+    |`"see"` | "Seneca" |
+    |`"seh"` | "Sena" |
+    |`"sel"` | "Selkup" |
+    |`"selkup"` | "Selkup" |
+    |`"sena"` | "Sena" |
+    |`"seneca"` | "Seneca" |
+    |`"serbian"` | "Serbian" |
+    |`"serbian (latin, serbia)"` | "Serbian" |
+    |`"serbo-croatian"` | "Serbo-Croatian" |
+    |`"serer"` | "Serer" |
+    |`"ses"` | "Koyraboro Senni" |
+    |`"sesotho"` | "Southern Sotho" |
+    |`"sesotho sa leboa"` | "Northern Sotho" |
+    |`"setswana"` | "Tswana" |
+    |`"sg"` | "Sango" |
+    |`"sga"` | "Old Irish" |
+    |`"sh"` | "Serbo-Croatian" |
+    |`"shambala"` | "Shambala" |
+    |`"shan"` | "Shan" |
+    |`"shi"` | "Tachelhit" |
+    |`"shn"` | "Shan" |
+    |`"shona"` | "Shona" |
+    |`"shqip"` | "Albanian" |
+    |`"shqipe"` | "Albanian" |
+    |`"shu"` | "Chadian Arabic" |
+    |`"shwóŋò ngiembɔɔn"` | "Ngiemboon" |
+    |`"si"` | "Sinhala" |
+    |`"sichuan yi"` | "Sichuan Yi" |
+    |`"sicilian"` | "Sicilian" |
+    |`"sid"` | "Sidamo" |
+    |`"sidamo"` | "Sidamo" |
+    |`"siksika"` | "Siksika" |
+    |`"simplified chinese"` | "Chinese" |
+    |`"sindhi"` | "Sindhi" |
+    |`"sinhala"` | "Sinhala" |
+    |`"siswati"` | "Swati" |
+    |`"sk"` | "Slovak" |
+    |`"skolt sami"` | "Skolt Sami" |
+    |`"sl"` | "Slovenian" |
+    |`"slave"` | "Slave" |
+    |`"slovak"` | "Slovak" |
+    |`"slovak (slovakia)"` | "Slovak" |
+    |`"slovenian"` | "Slovenian" |
+    |`"slovenian (slovenia)"` | "Slovenian" |
+    |`"slovenský"` | "Slovak" |
+    |`"slovenčina"` | "Slovak" |
+    |`"slovenščina"` | "Slovenian" |
+    |`"sm"` | "Samoan" |
+    |`"sma"` | "Southern Sami" |
+    |`"smj"` | "Lule Sami" |
+    |`"smn"` | "Inari Sami" |
+    |`"sms"` | "Skolt Sami" |
+    |`"sn"` | "Shona" |
+    |`"snk"` | "Soninke" |
+    |`"so"` | "Somali" |
+    |`"sog"` | "Sogdien" |
+    |`"soga"` | "Soga" |
+    |`"sogdien"` | "Sogdien" |
+    |`"somali"` | "Somali" |
+    |`"soninke"` | "Soninke" |
+    |`"soomaali"` | "Somali" |
+    |`"sorani kurdish"` | "Sorani Kurdish" |
+    |`"south ndebele"` | "South Ndebele" |
+    |`"southern altai"` | "Southern Altai" |
+    |`"southern sami"` | "Southern Sami" |
+    |`"southern sotho"` | "Southern Sotho" |
+    |`"spagnolo (uruguay)"` | "Spanish" |
+    |`"spanish"` | "Spanish" |
+    |`"spanish (argentina)"` | "Spanish" |
+    |`"spanish (bolivarian republic of venezuela)"` | "Spanish" |
+    |`"spanish (chile)"` | "Spanish" |
+    |`"spanish (colombia)"` | "Spanish" |
+    |`"spanish (costa rica)"` | "Spanish" |
+    |`"spanish (dominican republic)"` | "Spanish" |
+    |`"spanish (ecuador)"` | "Spanish" |
+    |`"spanish (el salvador)"` | "Spanish" |
+    |`"spanish (guatemala)"` | "Spanish" |
+    |`"spanish (honduras)"` | "Spanish" |
+    |`"spanish (international sort)"` | "Spanish" |
+    |`"spanish (mexico)"` | "Spanish" |
+    |`"spanish (panama)"` | "Spanish" |
+    |`"spanish (puerto rico)"` | "Spanish" |
+    |`"spanish (spain, international sort)"` | "Spanish" |
+    |`"spanish (spain, traditional sort)"` | "Spanish" |
+    |`"spanish (uruguay)"` | "Spanish" |
+    |`"sq"` | "Albanian" |
+    |`"sr"` | "Serbian" |
+    |`"sranan tongo"` | "Sranan Tongo" |
+    |`"srn"` | "Sranan Tongo" |
+    |`"srpski"` | "Serbian" |
+    |`"srr"` | "Serer" |
+    |`"ss"` | "Swati" |
+    |`"ssy"` | "Saho" |
+    |`"st"` | "Southern Sotho" |
+    |`"standard moroccan tamazight"` | "Standard Moroccan Tamazight" |
+    |`"su"` | "Sundanese" |
+    |`"suk"` | "Sukuma" |
+    |`"sukuma"` | "Sukuma" |
+    |`"sumerian"` | "Sumerian" |
+    |`"sundanese"` | "Sundanese" |
+    |`"suomi"` | "Finnish" |
+    |`"suomi (suomi)"` | "Finnish" |
+    |`"sus"` | "Susu" |
+    |`"susu"` | "Susu" |
+    |`"sux"` | "Sumerian" |
+    |`"sv"` | "Swedish" |
+    |`"svenska"` | "Swedish" |
+    |`"svenska (sverige)"` | "Swedish" |
+    |`"sw"` | "Swahili" |
+    |`"swahili"` | "Swahili" |
+    |`"swati"` | "Swati" |
+    |`"swb"` | "Comorian" |
+    |`"swc"` | "Congo Swahili" |
+    |`"swedish"` | "Swedish" |
+    |`"swedish (sweden)"` | "Swedish" |
+    |`"swiss french"` | "French" |
+    |`"swiss german"` | "Swiss German" |
+    |`"swiss high german"` | "German" |
+    |`"syc"` | "Classical Syriac" |
+    |`"syr"` | "Syriac" |
+    |`"syriac"` | "Syriac" |
+    |`"sängö"` | "Sango" |
+    |`"ta"` | "Tamil" |
+    |`"tachelhit"` | "Tachelhit" |
+    |`"tagalog"` | "Tagalog" |
+    |`"tahitian"` | "Tahitian" |
+    |`"taita"` | "Taita" |
+    |`"tajik"` | "Tajik" |
+    |`"tamashek"` | "Tamashek" |
+    |`"tamaziɣt"` | "Central Atlas Tamazight" |
+    |`"tamil"` | "Tamil" |
+    |`"taqbaylit"` | "Kabyle" |
+    |`"taroko"` | "Taroko" |
+    |`"tasawaq"` | "Tasawaq" |
+    |`"tasawaq senni"` | "Tasawaq" |
+    |`"tatar"` | "Tatar" |
+    |`"te"` | "Telugu" |
+    |`"telugu"` | "Telugu" |
+    |`"tem"` | "Timne" |
+    |`"teo"` | "Teso" |
+    |`"ter"` | "Tereno" |
+    |`"tereno"` | "Tereno" |
+    |`"teso"` | "Teso" |
+    |`"tet"` | "Tetum" |
+    |`"tetum"` | "Tetum" |
+    |`"tg"` | "Tajik" |
+    |`"th"` | "Thai" |
+    |`"th_th"` | "Thai" |
+    |`"thai"` | "Thai" |
+    |`"thai (thailand)"` | "Thai" |
+    |`"thok nath"` | "Nuer" |
+    |`"ti"` | "Tigrinya" |
+    |`"tibetan"` | "Tibetan" |
+    |`"tig"` | "Tigre" |
+    |`"tigre"` | "Tigre" |
+    |`"tigrinya"` | "Tigrinya" |
+    |`"timne"` | "Timne" |
+    |`"tiv"` | "Tiv" |
+    |`"tiếng việt"` | "Vietnamese" |
+    |`"tk"` | "Turkmen" |
+    |`"tkl"` | "Tokelau" |
+    |`"tl"` | "Tagalog" |
+    |`"tlh"` | "Klingon" |
+    |`"tli"` | "Tlingit" |
+    |`"tlingit"` | "Tlingit" |
+    |`"tmh"` | "Tamashek" |
+    |`"tn"` | "Tswana" |
+    |`"to"` | "Tongan" |
+    |`"tog"` | "Nyasa Tonga" |
+    |`"tok pisin"` | "Tok Pisin" |
+    |`"tokelau"` | "Tokelau" |
+    |`"tongan"` | "Tongan" |
+    |`"tpi"` | "Tok Pisin" |
+    |`"tr"` | "Turkish" |
+    |`"traditional chinese"` | "Chinese" |
+    |`"trv"` | "Taroko" |
+    |`"ts"` | "Tsonga" |
+    |`"tshiluba"` | "Luba-Katanga" |
+    |`"tshivenḓa"` | "Venda" |
+    |`"tsi"` | "Tsimshian" |
+    |`"tsimshian"` | "Tsimshian" |
+    |`"tsonga"` | "Tsonga" |
+    |`"tswana"` | "Tswana" |
+    |`"tt"` | "Tatar" |
+    |`"tum"` | "Tumbuka" |
+    |`"tumbuka"` | "Tumbuka" |
+    |`"turkish"` | "Turkish" |
+    |`"turkish (turkey)"` | "Turkish" |
+    |`"turkmen"` | "Turkmen" |
+    |`"tuvalu"` | "Tuvalu" |
+    |`"tuvinian"` | "Tuvinian" |
+    |`"tvl"` | "Tuvalu" |
+    |`"tw"` | "Twi" |
+    |`"twi"` | "Twi" |
+    |`"twq"` | "Tasawaq" |
+    |`"ty"` | "Tahitian" |
+    |`"tyap"` | "Tyap" |
+    |`"tyv"` | "Tuvinian" |
+    |`"tzm"` | "Central Atlas Tamazight" |
+    |`"türkçe"` | "Turkish" |
+    |`"u.k. english"` | "English" |
+    |`"u.s. english"` | "English" |
+    |`"udm"` | "Udmurt" |
+    |`"udmurt"` | "Udmurt" |
+    |`"ug"` | "Uyghur" |
+    |`"uga"` | "Ugaritic" |
+    |`"ugaritic"` | "Ugaritic" |
+    |`"uighur"` | "Uyghur" |
+    |`"uk"` | "Ukrainian" |
+    |`"ukrainian"` | "Ukrainian" |
+    |`"ukrainian (ukraine)"` | "Ukrainian" |
+    |`"umb"` | "Umbundu" |
+    |`"umbundu"` | "Umbundu" |
+    |`"upper sorbian"` | "Upper Sorbian" |
+    |`"ur"` | "Urdu" |
+    |`"urdu"` | "Urdu" |
+    |`"uyghur"` | "Uyghur" |
+    |`"uz"` | "Uzbek" |
+    |`"uzbek"` | "Uzbek" |
+    |`"vai"` | "Vai" |
+    |`"ve"` | "Venda" |
+    |`"venda"` | "Venda" |
+    |`"vi"` | "Vietnamese" |
+    |`"vi_vn"` | "Vietnamese" |
+    |`"vietnam"` | "Vietnamese" |
+    |`"vietnamese"` | "Vietnamese" |
+    |`"vietnamese (vietnam)"` | "Vietnamese" |
+    |`"vlaams"` | "Flemish" |
+    |`"vo"` | "Volapük" |
+    |`"volapük"` | "Volapük" |
+    |`"vot"` | "Votic" |
+    |`"votic"` | "Votic" |
+    |`"vun"` | "Vunjo" |
+    |`"vunjo"` | "Vunjo" |
+    |`"wa"` | "Walloon" |
+    |`"wae"` | "Walser" |
+    |`"wal"` | "Wolaytta" |
+    |`"walloon"` | "Walloon" |
+    |`"walser"` | "Walser" |
+    |`"war"` | "Waray" |
+    |`"waray"` | "Waray" |
+    |`"was"` | "Washo" |
+    |`"washo"` | "Washo" |
+    |`"welsh"` | "Welsh" |
+    |`"west-frysk"` | "Western Frisian" |
+    |`"western frisian"` | "Western Frisian" |
+    |`"wo"` | "Wolof" |
+    |`"wolaytta"` | "Wolaytta" |
+    |`"wolof"` | "Wolof" |
+    |`"xal"` | "Kalmyk" |
+    |`"xh"` | "Xhosa" |
+    |`"xhosa"` | "Xhosa" |
+    |`"xitsonga"` | "Tsonga" |
+    |`"xog"` | "Soga" |
+    |`"yangben"` | "Yangben" |
+    |`"yao"` | "Yao" |
+    |`"yap"` | "Yapese" |
+    |`"yapese"` | "Yapese" |
+    |`"yav"` | "Yangben" |
+    |`"ybb"` | "Yemba" |
+    |`"yemba"` | "Yemba" |
+    |`"yi"` | "Yiddish" |
+    |`"yiddish"` | "Yiddish" |
+    |`"yo"` | "Yoruba" |
+    |`"yoruba"` | "Yoruba" |
+    |`"yue"` | "Cantonese" |
+    |`"za"` | "Zhuang" |
+    |`"zap"` | "Zapotec" |
+    |`"zapotec"` | "Zapotec" |
+    |`"zarma"` | "Zarma" |
+    |`"zarmaciine"` | "Zarma" |
+    |`"zaza"` | "Zaza" |
+    |`"zbl"` | "Blissymbols" |
+    |`"zen"` | "Zenaga" |
+    |`"zenaga"` | "Zenaga" |
+    |`"zgh"` | "Standard Moroccan Tamazight" |
+    |`"zh"` | "Chinese" |
+    |`"zh-hans"` | "Chinese" |
+    |`"zh-hant"` | "Chinese" |
+    |`"zh_cn"` | "Chinese" |
+    |`"zhuang"` | "Zhuang" |
+    |`"zu"` | "Zulu" |
+    |`"zulu"` | "Zulu" |
+    |`"zun"` | "Zuni" |
+    |`"zuni"` | "Zuni" |
+    |`"zza"` | "Zaza" |
+    |`"èdè yorùbá"` | "Yoruba" |
+    |`"íslenska"` | "Icelandic" |
+    |`"österreichisches deutsch"` | "German" |
+    |`"čeština"` | "Czech" |
+    |`"ɓàsàa"` | "Basaa" |
+    |`"ʻōlelo hawaiʻi"` | "Hawaiian" |
+    |`"ελληνικά"` | "Greek" |
+    |`"беларуская"` | "Belarusian" |
+    |`"български"` | "Bulgarian" |
+    |`"български език"` | "Bulgarian" |
+    |`"ирон"` | "Ossetic" |
+    |`"кыргызча"` | "Kyrgyz" |
+    |`"македонски"` | "Macedonian" |
+    |`"монгол"` | "Mongolian" |
+    |`"русский"` | "Russian" |
+    |`"русский язык"` | "Russian" |
+    |`"саха тыла"` | "Sakha" |
+    |`"српски"` | "Serbian" |
+    |`"српски језик"` | "Serbian" |
+    |`"тоҷикӣ"` | "Tajik" |
+    |`"українська"` | "Ukrainian" |
+    |`"ўзбек"` | "Uzbek" |
+    |`"қазақ тілі"` | "Kazakh" |
+    |`"հայերեն"` | "Armenian" |
+    |`"עברית"` | "Hebrew" |
+    |`"ئۇيغۇرچە"` | "Uyghur" |
+    |`"اردو"` | "Urdu" |
+    |`"العربية"` | "Arabic" |
+    |`"العربية الرسمية الحديثة"` | "Arabic" |
+    |`"العربيه مصر"` | "Arabic" |
+    |`"فارسى"` | "English" |
+    |`"فارسي"` | "Persian" |
+    |`"فارسی"` | "Persian" |
+    |`"پښتو"` | "Pashto" |
+    |`"کٲشُر"` | "Kashmiri" |
+    |`"कोंकणी"` | "Konkani" |
+    |`"नेपाली"` | "Nepali" |
+    |`"बड़ो"` | "Bodo" |
+    |`"मराठी"` | "Marathi" |
+    |`"हिंदी"` | "Hindi" |
+    |`"हिन्दी"` | "Hindi" |
+    |`"অসমীয়া"` | "Assamese" |
+    |`"বাংলা"` | "Bengali" |
+    |`"ਪੰਜਾਬੀ"` | "Punjabi" |
+    |`"ગુજરાતી"` | "Gujarati" |
+    |`"ଓଡ଼ିଆ"` | "Oriya" |
+    |`"தமிழ்"` | "Tamil" |
+    |`"తెలుగు"` | "Telugu" |
+    |`"ಕನ್ನಡ"` | "Kannada" |
+    |`"മലയാളം"` | "Malayalam" |
+    |`"සිංහල"` | "Sinhala" |
+    |`"ไทย"` | "Thai" |
+    |`"ລາວ"` | "Lao" |
+    |`"པོད་སྐད་"` | "Tibetan" |
+    |`"རྫོང་ཁ"` | "Dzongkha" |
+    |`"ဗမာ"` | "Burmese" |
+    |`"ქართული"` | "Georgian" |
+    |`"ብሊን"` | "Blin" |
+    |`"ትግረ"` | "Tigre" |
+    |`"ትግርኛ"` | "Tigrinya" |
+    |`"አማርኛ"` | "Amharic" |
+    |`"ወላይታቱ"` | "Wolaytta" |
+    |`"ᏣᎳᎩ"` | "Cherokee" |
+    |`"ខ្មែរ"` | "Khmer" |
+    |`"ភាសាខ្មែរ"` | "Khmer" |
+    |`"ⵜⴰⵎⴰⵣⵉⵖⵜ"` | "Tachelhit" |
+    |`"中文"` | "Chinese" |
+    |`"日本語"` | "Japanese" |
+    |`"简体中文"` | "Chinese" |
+    |`"繁體中文"` | "Chinese" |
+    |`"ꆈꌠꉙ"` | "Sichuan Yi" |
+    |`"ꕙꔤ"` | "Vai" |
+    |`"한국어"` | "Korean" |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
HTTP API changes language tags to language name. This was not documented in our API docs and caused https://amplitude.atlassian.net/browse/AMP-73520 ticket.  This PR documents the behavior of the API.

## Deadline

ASAP.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ X] My documentation follows the style guidelines of this project.
- [ X] I previewed my documentation on a local server using `mkdocs serve`.
- [ X] Running `mkdocs serve` didn't generate any failures.
- [ X] I have performed a self-review of my own documentation.

@amplitude-dev-docs
