### PR TITLE
AMP-74857 Add support link

### DIFF
--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -55,7 +55,7 @@ as the main headline.
       amplitude.getInstance().logEvent('support request', properties);
     }
 </script>
-  <p>Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="amplitude.getInstance().logEvent('Link Click', eventProperties)">Community</a> or <a  href="http://support.amplitude.com/" onclick="trackClickSupportRequest()">submit a request</a>.
+  <p>Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="amplitude.getInstance().logEvent('Link Click', eventProperties)">Community</a> or <a href="https://support.amplitude.com/" onclick="trackClickSupportRequest()">submit a request</a>.
 
   {% endif %}
 

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -44,8 +44,18 @@ as the main headline.
         name: "community_help",
         url: window.location.href,
     };
+
+    function trackClickSupportRequest(){
+      let properties = {
+        path: window.location.pathname,
+        product: window.location.pathname.split('/')[1],
+        url: window.location.href
+      };
+      
+      amplitude.getInstance().logEvent('support request', properties);
+    }
 </script>
-  <p>Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="amplitude.getInstance().logEvent('Link Click', eventProperties)">Community</a>.
+  <p>Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="amplitude.getInstance().logEvent('Link Click', eventProperties)">Community</a> or <a  href="http://support.amplitude.com/" onclick="trackClickSupportRequest()">submit a request</a>.
 
   {% endif %}
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Close this one as moving changes to [this PR](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/pull/746)

- Add a support link at the bottom of each page
- Track [support request](https://data.amplitude.com/amplitude/Developer%20Docs%20(Prod)/events/main/latest/support%20request?view=All&tab=DETAILS&propertyValidityFilter=All%2520Properties) event 
<img width="695" alt="Screen Shot 2023-05-09 at 12 08 08" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/33d3c76b-c571-43b6-afcd-02694c9eaff0">




## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs

