### PR TITLE
Pin requests version to fix builld

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ lxml>=4.6
 paginate>=0.5.6
 readtime>=2.0
 regex>=2022.4.24
-requests>=2.26
+requests==2.26


### PR DESCRIPTION
Owners of the request module intentionally put out a minor version that had consequences for us due to the version of OpenSSL.

https://github.com/psf/requests/issues/6432

Trying to pin the version to see if that fixes the issue

# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
