### PR TITLE
fix: fix flutter default eve upload threshold and event upload period millis

### DIFF
--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -89,12 +89,12 @@ To support high performance environments, the SDK sends events in batches. Every
 
 ```dart
 // Events queued in memory will flush when number of events exceed upload threshold
-// Default value is 10
-Amplitude.getInstance().setEventUploadThreshold(20);
+// Default value is 30
+Amplitude.getInstance().setEventUploadThreshold(40);
 
 // Events queue will flush every certain milliseconds based on setting
-// Default value is 10,000 milliseconds
-Amplitude.getInstance().setEventUploadPeriodMillis(20000);
+// Default value is 30,000 milliseconds
+Amplitude.getInstance().setEventUploadPeriodMillis(40000);
 ```
 
 #### EU data residency

--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -90,11 +90,11 @@ To support high performance environments, the SDK sends events in batches. Every
 ```dart
 // Events queued in memory will flush when number of events exceed upload threshold
 // Default value is 30
-Amplitude.getInstance().setEventUploadThreshold(40);
+Amplitude.getInstance().setEventUploadThreshold(1);
 
 // Events queue will flush every certain milliseconds based on setting
 // Default value is 30,000 milliseconds
-Amplitude.getInstance().setEventUploadPeriodMillis(40000);
+Amplitude.getInstance().setEventUploadPeriodMillis(10000);
 ```
 
 #### EU data residency


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
Fix the wrong default threshold value in the snippet comment.
 
https://discourse.amplitude.com/t/flutter-sdk-clarifications-on-the-default-values-for-seteventuploadthreshold-and-seteventuploadperiodmillis/10680

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
