### PR TITLE
feat: add new doc related page view events

### DIFF
--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -90,6 +90,15 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 --8<-- "includes/sdk-ts-browser/marketing-analytics.md"
 
+The following are the event info got tracked in the page view events
+
+|<div class="big-column">Name</div>| Description| Default Value|
+|---|----|---|
+|`event_type`| `string`. The event type for page view event. Configurable through enrichment plugin. | `Page View` |
+|`event_properties.page_title`| `string`. The page title. The value of document.title for the current page. | document.title or ''|
+|`event_properties.page_location`| `string`. The page location. The value of location.href or ''| location.href or '' |
+|`event_propertiespage_path.`| `string`. The page path. The value of location.path or '' | location.path or ''|
+
 ### Use the Marketing Analytics SDK with Ampli
 
 You can use Ampli with this SDK by passing an instance of the Marketing Analytics SDK to `ampli.load()`. See the [Ampli documentation](../typescript-browser/ampli.md#load) for the Browser SDK for more details on configuration. 

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -90,7 +90,7 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 --8<-- "includes/sdk-ts-browser/marketing-analytics.md"
 
-The following are the event info got tracked in the page view events
+The following information is tracked in the page view events.
 
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -94,10 +94,13 @@ The following are the event info got tracked in the page view events
 
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|
-|`event_type`| `string`. The event type for page view event. Configurable through enrichment plugin. | `Page View` |
-|`event_properties.page_title`| `string`. The page title. The value of document.title for the current page. | document.title or ''|
-|`event_properties.page_location`| `string`. The page location. The value of location.href or ''| location.href or '' |
-|`event_propertiespage_path.`| `string`. The page path. The value of location.path or '' | location.path or ''|
+|`event_type`| `string`. The event type for page view event. Configurable through enrichment plugin. | `Page View`. |
+|`event_properties.page_domain`| `string`. The page domain. | location.hostname or ''. |
+|`event_properties.page_location`| `string`. The page location. | location.href or ''. |
+|`event_properties.page_path`| `string`. The page path. | location.path or ''.|
+|`event_properties.page_title`| `string`. The page title. | document.title or ''.|
+|`event_properties.page_url`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
+|`event_properties.[CampaignParam]`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
 
 ### Use the Marketing Analytics SDK with Ampli
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -148,6 +148,7 @@ You can also use advanced configuration for better control of when page views ev
     |-|-|-|
     `defaultTracking.pageViews.trackOn` | Optional. `"attribution"` or `() => boolean` | Provides advanced control on when page view events are tracked.<br /><br />You can omit or set the value to `undefined`,  and configure page view events to be tracked on initialization.<br /><br />You can set the value to `"attribution"` and configure page view events to be tracked only when web attribution are tracked.<br /><br />You can set the value to a function that returns a boolean (`true` or `false`) and configure page view events to be tracked based on your criteria.|
     `defaultTracking.pageViews.trackHistoryChanges` | Optional. `"pathOnly"` or `"all"` | Provides advanced control for single page application on when page views are tracked.<br /><br />You can omit or set the value to `"all"`,  and configure page view events to be tracked on any navigation change to the URL within your single page application. For example: navigating from `https://amplitude.com/#company` to `https://amplitude.com/#blog`.<br /><br />You can omit or set the value to "pathOnly",  and configure page view events to be tracked on navigation change to the URL path only within your single page application. For example: navigating from `https://amplitude.com/company` to `https://amplitude.com/blog`.|
+    `defaultTracking.pageViews.eventType` | Optional. `String` | Customize the event_type for page view event. |
 
 For example, you can configure Amplitude to track page views only when the URL path contains a certain substring, let’s say “home”. Refer to the code sample for how to achieve this.
 
@@ -162,6 +163,15 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
   },
 });
 ```
+
+The following are the event info got tracked in the page view events.
+
+|<div class="big-column">Name</div>| Description| Default Value|
+|---|----|---|
+|`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed`, `[Amplitude] Page View` for version previous 1.9.1 |
+|`event_properties.page_title`| `string`. The page title. The value of document.title for the current page. | document.title or ''|
+|`event_properties.page_location`| `string`. The page location. The value of location.href or ''| location.href or '' |
+|`event_propertiespage_path.`| `string`. The page path. The value of location.path or '' | location.path or ''|
 
 #### Tracking sessions
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -88,10 +88,13 @@ amplitude.track('Button Clicked', eventProperties);
 
 Starting version 1.9.1, Browser SDK now tracks default events. Browser SDK can be configured to track the following events automatically:
 
-* Page views
+* Page views (1)
+{ .annotate }
 * Sessions
 * Form interactions
 * File downloads
+
+1. If you want to track page views before 1.9.0, you need to enable config.attribution.trackPageViews([More details](./#configuration).) or add `page-view-tracking` plugin([More details](../marketing-analytics-browser/#page-view).) The event type for page views, will be different.
 
 ???config "Tracking default events options"
     |<div class="big-column">Name</div>|Value|Description|
@@ -165,9 +168,6 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 ```
 
 The following information is tracked in the page view events.
-
-!!!note "Page views"
-    The configuration for enabling Page views, along with the event name for Page views, may differ in versions prior to 1.9.1.
 
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -166,6 +166,9 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 The following information is tracked in the page view events.
 
+!!!note "Page views"
+    The configuration for enabling Page views, along with the event name for Page views, may differ in versions prior to 1.9.1.
+
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|
 |`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed` from version 1.9.1. |
@@ -175,9 +178,6 @@ The following information is tracked in the page view events.
 |`event_properties.[Amplitude] Page Title`| `string`. The page title. | document.title or ''.|
 |`event_properties.[Amplitude] Page Title`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
 |`event_properties.${CampaignParam}`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
-
-!!!note "Page views"
-    The configuration for enabling Page views, along with the event name for Page views, may differ in versions prior to 1.9.1.
 
 #### Tracking sessions
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -168,13 +168,16 @@ The following information is tracked in the page view events.
 
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|
-|`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed` from version 1.9.1 |
+|`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed` from version 1.9.1. |
 |`event_properties.[Amplitude] Page Domain`| `string`. The page domain. | location.hostname or ''. |
 |`event_properties.[Amplitude] Page Location`| `string`. The page location. | location.href or ''. |
 |`event_properties.[Amplitude] Page Path`| `string`. The page path. | location.path or ''.|
 |`event_properties.[Amplitude] Page Title`| `string`. The page title. | document.title or ''.|
 |`event_properties.[Amplitude] Page Title`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
 |`event_properties.${CampaignParam}`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
+
+!!!note "Page views"
+    The configuration for enabling Page views, along with the event name for Page views, may differ in versions prior to 1.9.1.
 
 #### Tracking sessions
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -88,13 +88,13 @@ amplitude.track('Button Clicked', eventProperties);
 
 Starting version 1.9.1, Browser SDK now tracks default events. Browser SDK can be configured to track the following events automatically:
 
-* Page views (1)
-{ .annotate }
+* Page views [^1]
 * Sessions
 * Form interactions
 * File downloads
 
-1. If you want to track page views before 1.9.0, you need to enable config.attribution.trackPageViews([More details](./#configuration).) or add `page-view-tracking` plugin([More details](../marketing-analytics-browser/#page-view).) The event type for page views, will be different.
+[^1]:
+    If you want to track page views before 1.9.0, you need to enable config.attribution.trackPageViews([More details](./#configuration).) or add `page-view-tracking` plugin([More details](../marketing-analytics-browser/#page-view).) The event type for page views, will be different.
 
 ???config "Tracking default events options"
     |<div class="big-column">Name</div>|Value|Description|

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -169,9 +169,12 @@ The following are the event info got tracked in the page view events.
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|
 |`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed`, `[Amplitude] Page View` for version previous 1.9.1 |
-|`event_properties.page_title`| `string`. The page title. The value of document.title for the current page. | document.title or ''|
-|`event_properties.page_location`| `string`. The page location. The value of location.href or ''| location.href or '' |
-|`event_propertiespage_path.`| `string`. The page path. The value of location.path or '' | location.path or ''|
+|`event_properties.page_domain`| `string`. The page domain. | location.hostname or ''. |
+|`event_properties.page_location`| `string`. The page location. | location.href or ''. |
+|`event_properties.page_path`| `string`. The page path. | location.path or ''.|
+|`event_properties.page_title`| `string`. The page title. | document.title or ''.|
+|`event_properties.page_url`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
+|`event_properties.[CampaignParam]`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
 
 #### Tracking sessions
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -164,17 +164,17 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-The following are the event info got tracked in the page view events.
+The following information is tracked in the page view events.
 
 |<div class="big-column">Name</div>| Description| Default Value|
 |---|----|---|
-|`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed`, `[Amplitude] Page View` for version previous 1.9.1 |
-|`event_properties.page_domain`| `string`. The page domain. | location.hostname or ''. |
-|`event_properties.page_location`| `string`. The page location. | location.href or ''. |
-|`event_properties.page_path`| `string`. The page path. | location.path or ''.|
-|`event_properties.page_title`| `string`. The page title. | document.title or ''.|
-|`event_properties.page_url`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
-|`event_properties.[CampaignParam]`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
+|`event_type`| `string`. The event type for page view event. Configurable through `defaultTracking.pageViews.eventType` or enrichment plugin. | `[Amplitude] Page Viewed` from version 1.9.1 |
+|`event_properties.[Amplitude] Page Domain`| `string`. The page domain. | location.hostname or ''. |
+|`event_properties.[Amplitude] Page Location`| `string`. The page location. | location.href or ''. |
+|`event_properties.[Amplitude] Page Path`| `string`. The page path. | location.path or ''.|
+|`event_properties.[Amplitude] Page Title`| `string`. The page title. | document.title or ''.|
+|`event_properties.[Amplitude] Page Title`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
+|`event_properties.${CampaignParam}`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |
 
 #### Tracking sessions
 

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -94,7 +94,7 @@ Starting version 1.9.1, Browser SDK now tracks default events. Browser SDK can b
 * File downloads
 
 [^1]:
-    If you want to track page views before 1.9.0, you need to enable config.attribution.trackPageViews([More details](./#configuration).) or add `page-view-tracking` plugin([More details](../marketing-analytics-browser/#page-view).) The event type for page views, will be different.
+    If you want to track page views before 1.9.0, you need to enable config.attribution.trackPageViews ([More details](./#configuration)) or add `page-view-tracking` plugin ([More details](../marketing-analytics-browser/#page-view)). The event type for page views will be different.
 
 ???config "Tracking default events options"
     |<div class="big-column">Name</div>|Value|Description|

--- a/includes/sdk-ts-browser/marketing-analytics.md
+++ b/includes/sdk-ts-browser/marketing-analytics.md
@@ -52,6 +52,8 @@ Click IDs are campaign identifiers included as URL parameters. Ad platforms use 
 |`MSCLKID`| Microsoft Click Identifier |
 |`TTCLID`| TikTok Click Identifier |
 |`TWCLID`| Twitter Click Identifier from URL parameter |
+|`LI_FAT_ID`| Linkedin Click identifier |
+|`RDT_CID`| Reddit campaign tracking/attribution Click identifier |
 
 #### First-touch attribution
 
@@ -73,6 +75,8 @@ Amplitude captures the initial attribution data at the start of the first sessio
 - `initial_ttclid`
 - `initial_twclid`
 - `initial_wbraid`
+- `initial_li_fat_id`
+- `initial_rdt_cid`
 
 #### Multi-touch attribution
 
@@ -98,6 +102,8 @@ Amplitude tracks the following as user properties:
 - `ttclid`
 - `twclid`
 - `wbraid`
+- `li_fat_id`
+- `rdt_cid`
 
 For users who initially visits a page directly or organically, by default, the initial value is set to `"EMPTY"`. If you prefer a different initial value, set `attriubtion.initialEmptyValue` to any string value.
 

--- a/includes/sdk-ts-browser/marketing-analytics.md
+++ b/includes/sdk-ts-browser/marketing-analytics.md
@@ -52,8 +52,8 @@ Click IDs are campaign identifiers included as URL parameters. Ad platforms use 
 |`MSCLKID`| Microsoft Click Identifier |
 |`TTCLID`| TikTok Click Identifier |
 |`TWCLID`| Twitter Click Identifier from URL parameter |
-|`LI_FAT_ID`| Linkedin Click identifier |
-|`RDT_CID`| Reddit campaign tracking/attribution Click identifier |
+|`LI_FAT_ID`| Linkedin Click identifier (From @amplitude/plugin-web-attribution-browser@0.7.0) |
+|`RDT_CID`| Reddit campaign tracking/attribution Click identifier (From @amplitude/plugin-web-attribution-browser@0.7.0) |
 
 #### First-touch attribution
 
@@ -75,8 +75,8 @@ Amplitude captures the initial attribution data at the start of the first sessio
 - `initial_ttclid`
 - `initial_twclid`
 - `initial_wbraid`
-- `initial_li_fat_id`
-- `initial_rdt_cid`
+- `initial_li_fat_id` (From @amplitude/plugin-web-attribution-browser@0.7.0)
+- `initial_rdt_cid` (From @amplitude/plugin-web-attribution-browser@0.7.0)
 
 #### Multi-touch attribution
 
@@ -102,8 +102,8 @@ Amplitude tracks the following as user properties:
 - `ttclid`
 - `twclid`
 - `wbraid`
-- `li_fat_id`
-- `rdt_cid`
+- `li_fat_id` (From @amplitude/plugin-web-attribution-browser@0.7.0)
+- `rdt_cid` (From @amplitude/plugin-web-attribution-browser@0.7.0)
 
 For users who initially visits a page directly or organically, by default, the initial value is set to `"EMPTY"`. If you prefer a different initial value, set `attriubtion.initialEmptyValue` to any string value.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
1. add the new clickIds in docs. https://amplitude.atlassian.net/wiki/spaces/GOV/pages/2058289286/Browser+SDK#Cookie-Usage
2. add details for page view events

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
