### PR TITLE
AMP-75025 replace emojis

### DIFF
--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -75,11 +75,23 @@ as the main headline.
       });
     }
 </script>
+
 <div style="display: flex; align-items: center;" >
   <h5>Was this page helpful?</h5>
-  <button id="happyButton" style="cursor: pointer; margin: 5%;" onclick="trackFeedback(true)">👍 Yes</button>
-  <button id="sadButton" style="cursor: pointer;" onclick="trackFeedback(false)">👎 No</button>
+  <button id="happyButton" style="cursor: pointer; margin: 5%;" onclick="trackFeedback(true)">
+    <span class="twemoji">
+      {% include ".icons/fontawesome/regular/thumbs-up.svg" %}
+    </span>
+    Yes
+  </button>
+  <button id="sadButton" style="cursor: pointer;" onclick="trackFeedback(false)">
+    <span class="twemoji">
+      {% include ".icons/fontawesome/regular/thumbs-down.svg" %}
+    </span>
+    No
+  </button>
 </div>
+
 <div id="feedbackMessage"></div>
   {% endif %}
 

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -40,23 +40,23 @@ as the main headline.
   <hr>
   <!-- Tracks link clicks out to the community for doc improvements-->
 <script>
-    function trackCommunity(){
-      var communityEventProperties = {
-        name: "community_help",
-        url: window.location.href,
-      };
-
-      amplitude.getInstance().logEvent('Link Click', eventProperties)
-    }
-
-    function trackClickSupportRequest(){
-      let properties = {
+    function getPageInfo() {
+      return {
         path: window.location.pathname,
         product: window.location.pathname.split('/')[1],
         url: window.location.href
       };
+    }
 
-      amplitude.getInstance().logEvent('support request', properties);
+    function trackCommunity(){
+      amplitude.getInstance().logEvent('Link Click', {
+        ...getPageInfo(),
+        name: "community_help"
+      })
+    }
+
+    function trackClickSupportRequest(){
+      amplitude.getInstance().logEvent('support request', getPageInfo());
     }
 
     function trackFeedback(isUseful){
@@ -68,15 +68,9 @@ as the main headline.
       feedbackMessage.innerHTML = isUseful ? "Glad to hear that!" : 'Still have questions? Ask them in the <a id="linkToCommunityHelp" href="https://community.amplitude.com" onclick="trackCommunity()">Community</a> or <a href="https://support.amplitude.com/" onclick="trackClickSupportRequest()">submit a request</a>.';
       document.getElementById("feedbackMessage").appendChild(feedbackMessage);
 
-      var path = document.location.pathname;
-      var product = document.location.pathname.split('/')[1];
-      var url = document.location.href;
-
       /* Send feedback value */
       amplitude.getInstance().logEvent('feedback', {
-        path: path,
-        product: product,
-        url: url,
+        ...getPageInfo(),
         isUseful: isUseful
       });
     }


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- Replace emojis with svg icons
<img width="339" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/86001b81-5599-4954-8b94-f493a5c6c5db">

- Fix "click community link" is not tracked
  - it was accidentally deleted in https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/pull/746
- Add a `getPageInfo()` function to get commonly used info
  - path: /data/sdks/typescript-browser/
  - product: data
  - url: https://www.docs.developers.amplitude.com/data/sdks/



## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
