### PR TITLE
AMP-52578 Add `migrateLegacyData` configuration option

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -70,12 +70,11 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     ```java 
     import com.amplitude.android.Amplitude;
 
-    Amplitude amplitude =  new Amplitude(new Configuration(
-        apiKey = AMPLITUDE_API_KEY,
-        context = applicationContext,
-        flushIntervalMillis = 50000,
-        flushQueueSize = 20,
-    ));
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setFlushIntervalMillis(1000);
+    configuration.setFlushQueueSize(10);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 --8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
@@ -87,7 +86,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
 
     val amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             serverZone = ServerZone.EU
         )
@@ -99,11 +98,10 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     ```java
     import com.amplitude.android.Amplitude;
 
-    Amplitude amplitude =  new Amplitude(new Configuration(
-        apiKey = AMPLITUDE_API_KEY,
-        context = applicationContext,
-        serverZone = ServerZone.EU
-    ));
+    Configuration configuration = new Configuration("API_KEY", getApplicationContext());
+    configuration.setServerZone(ServerZone.EU);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 ### track
@@ -375,7 +373,7 @@ You can adjust the time window for which sessions are extended. The default sess
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             minTimeBetweenSessionsMillis = 10000
         )
@@ -385,7 +383,7 @@ You can adjust the time window for which sessions are extended. The default sess
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setMinTimeBetweenSessionsMillis(1000);
         return Unit.INSTANCE;
     });
@@ -399,7 +397,7 @@ You can also disable those session events.
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             trackingSessionEvents = false
         )
@@ -409,7 +407,7 @@ You can also disable those session events.
 === "Java"
 
     ```
-    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setTrackingSessionEvents(false);
         return Unit.INSTANCE;
     });
@@ -436,7 +434,7 @@ You can define your own session expiration time. The default session expiration 
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             minTimeBetweenSessionsMillis = 10000
         )
@@ -446,7 +444,7 @@ You can define your own session expiration time. The default session expiration 
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setMinTimeBetweenSessionsMillis(10000);
         return Unit.INSTANCE;
     });
@@ -538,7 +536,7 @@ Before initializing the SDK with your apiKey, create a `TrackingOptions` insta
     trackingOptions.disableCity().disableIpAddress().disableLatLng()
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             trackingOptions = trackingOptions
         )
@@ -552,7 +550,7 @@ Before initializing the SDK with your apiKey, create a `TrackingOptions` insta
     trackingOptions.disableCity().disableIpAddress().disableLatLng();
 
     // init instance
-    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setTrackingOptions(trackingOptions);
         return Unit.INSTANCE;
     });
@@ -595,7 +593,7 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             enableCoppaControl = true //Disables ADID, city, IP, and location tracking
         )
@@ -605,7 +603,7 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setEnableCoppaControl(true); //Disables ADID, city, IP, and location tracking
         return Unit.INSTANCE;
     });
@@ -625,7 +623,7 @@ After you set up the logic to fetch the advertising ID, you can enable `useAdver
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             useAdvertisingIdForDeviceId = true
         )
@@ -635,7 +633,7 @@ After you set up the logic to fetch the advertising ID, you can enable `useAdver
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setUseAdvertisingIdForDeviceId(true);
         return Unit.INSTANCE;
     });
@@ -663,7 +661,7 @@ App set ID is a unique identifier for each app install on a device. App set ID i
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             useAppSetIdForDeviceId = true
         )
@@ -673,7 +671,7 @@ App set ID is a unique identifier for each app install on a device. App set ID i
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
         configuration.setUseAppSetIdForDeviceId(true);
         return Unit.INSTANCE;
     });
@@ -690,7 +688,7 @@ By default, Amplitude can use Android location service (if available) to add the
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             locationListening = true
         )
@@ -700,10 +698,10 @@ By default, Amplitude can use Android location service (if available) to add the
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setLocationListening(true);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration("API_KEY", getApplicationContext());
+    configuration.setLocationListening(true);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 !!!note "ProGuard obfuscation"
@@ -719,7 +717,7 @@ Users may wish to opt out of tracking entirely, which means Amplitude doesn't tr
     ```kotlin
     amplitude = Amplitude(
         Configuration(
-            apiKey = AMPLITUDE_API_KEY,
+            apiKey = API_KEY,
             context = applicationContext,
             optOut = true
         )
@@ -729,10 +727,10 @@ Users may wish to opt out of tracking entirely, which means Amplitude doesn't tr
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setOptOut(true);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setOptOut(true);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 ### Push notification events

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -46,7 +46,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable COPPA control for tracking options. | `false` |
     | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
-    | `migrateLegacyData` | `Boolean`. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID).  | `false`|
+    | `migrateLegacyData` | `Boolean`. Available in `1.9.0`+. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID).  | `false`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -46,6 +46,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable COPPA control for tracking options. | `false` |
     | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
+    | `migrateLegacyData` | `Boolean`. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID).  | `false`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -50,18 +50,6 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 
-=== "Java"
-
-    ```java 
-    import com.amplitude.android.Amplitude;
-
-    Amplitude amplitude =  new Amplitude(new Configuration(
-        apiKey = AMPLITUDE_API_KEY,
-        context = applicationContext,
-        flushIntervalMillis = 50000,
-        flushQueueSize = 20,
-    ));
-    ```
 === "Kotlin"
 
     ```kotlin
@@ -77,19 +65,21 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     )
     ```
 
---8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
-
 === "Java"
 
-    ```java
+    ```java 
     import com.amplitude.android.Amplitude;
 
     Amplitude amplitude =  new Amplitude(new Configuration(
         apiKey = AMPLITUDE_API_KEY,
         context = applicationContext,
-        serverZone = ServerZone.EU
+        flushIntervalMillis = 50000,
+        flushQueueSize = 20,
     ));
     ```
+
+--8<-- "includes/sdk-quickstart/quickstart-eu-data-residency.md"
+
 === "Kotlin"
 
     ```kotlin
@@ -102,6 +92,18 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
             serverZone = ServerZone.EU
         )
     )
+    ```
+
+=== "Java"
+
+    ```java
+    import com.amplitude.android.Amplitude;
+
+    Amplitude amplitude =  new Amplitude(new Configuration(
+        apiKey = AMPLITUDE_API_KEY,
+        context = applicationContext,
+        serverZone = ServerZone.EU
+    ));
     ```
 
 ### track
@@ -368,14 +370,6 @@ Amplitude groups events together by session. Events that are logged within the s
 
 You can adjust the time window for which sessions are extended. The default session expiration time is 30 minutes.
 
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setMinTimeBetweenSessionsMillis(1000);
-        return Unit.INSTANCE;
-    });
-    ```
 === "Kotlin"
 
     ```kotlin
@@ -388,17 +382,18 @@ You can adjust the time window for which sessions are extended. The default sess
     )
     ```
 
-By default, Amplitude automatically sends the '[Amplitude] Start Session' and '[Amplitude] End Session' events. Even though these events aren't sent, sessions are still tracked by using `session_id`.
-You can also disable those session events.
-
 === "Java"
 
-    ```
+    ```java
     amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setTrackingSessionEvents(false);
+        configuration.setMinTimeBetweenSessionsMillis(1000);
         return Unit.INSTANCE;
     });
     ```
+
+By default, Amplitude automatically sends the '[Amplitude] Start Session' and '[Amplitude] End Session' events. Even though these events aren't sent, sessions are still tracked by using `session_id`.
+You can also disable those session events.
+
 === "Kotlin"
 
     ```kotlin
@@ -411,13 +406,16 @@ You can also disable those session events.
     )
     ```
 
-You can use the helper method `getSessionId` to get the value of the current `sessionId`.
-
 === "Java"
 
-    ```java
-    long sessionId = amplitude.getSessionId();
     ```
+    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setTrackingSessionEvents(false);
+        return Unit.INSTANCE;
+    });
+    ```
+
+You can use the helper method `getSessionId` to get the value of the current `sessionId`.
 
 === "Kotlin"
 
@@ -425,16 +423,13 @@ You can use the helper method `getSessionId` to get the value of the current `se
     val sessionId = amplitude.sessionId;
     ```
 
-You can define your own session expiration time. The default session expiration time is 30 minutes.
-
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setMinTimeBetweenSessionsMillis(10000);
-        return Unit.INSTANCE;
-    });
+    long sessionId = amplitude.getSessionId();
     ```
+
+You can define your own session expiration time. The default session expiration time is 30 minutes.
 
 === "Kotlin"
 
@@ -448,19 +443,28 @@ You can define your own session expiration time. The default session expiration 
     )
     ```
 
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setMinTimeBetweenSessionsMillis(10000);
+        return Unit.INSTANCE;
+    });
+    ```
+
 ### Set custom user ID
 
 If your app has its own login system that you want to track users with, you can call `setUserId` at any time.
 
-=== "Java"
-
-    ```java
-    amplitude.setUserId("USER_ID");
-    ```
-
 === "Kotlin"
 
     ```kotlin
+    amplitude.setUserId("USER_ID");
+    ```
+
+=== "Java"
+
+    ```java
     amplitude.setUserId("USER_ID");
     ```
 
@@ -478,32 +482,32 @@ You can control the level of logs that print to the developer console.
 
 Set the log level by calling `setLogLevel` with the level you want.
 
-=== "Java"
-
-    ```java
-    amplitude.getLogger().setLogMode(Logger.LogMode.DEBUG);
-    ```
-
 === "Kotlin"
 
     ```kotlin
     amplitude.logger.logMode = Logger.LogMode.DEBUG
     ```
 
-### Logged out and anonymous users
-
---8<-- "includes/logged-out-and-anonymous-users.md"
-
 === "Java"
 
     ```java
-    amplitude.reset();
+    amplitude.getLogger().setLogMode(Logger.LogMode.DEBUG);
     ```
+
+### Logged out and anonymous users
+
+--8<-- "includes/logged-out-and-anonymous-users.md"
 
 === "Kotlin"
 
     ```kotlin
     amplitude.reset()
+    ```
+
+=== "Java"
+
+    ```java
+    amplitude.reset();
     ```
 
 ### Disable tracking
@@ -513,32 +517,19 @@ Use the provided `TrackingOptions` interface to customize and toggle individua
 
 To use the `TrackingOptions` interface, import the class.
 
-=== "Java"
-
-    ```java
-    import com.amplitude.android.TrackingOptions
-    ```
-
 === "Kotlin"
 
     ```kotlin
     import com.amplitude.android.TrackingOptions
     ```
 
-Before initializing the SDK with your apiKey, create a `TrackingOptions` instance with your configuration and set it on the SDK instance.
-
 === "Java"
 
     ```java
-    TrackingOptions trackingOptions = new TrackingOptions();
-    trackingOptions.disableCity().disableIpAddress().disableLatLng();
-
-    // init instance
-    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setTrackingOptions(trackingOptions);
-        return Unit.INSTANCE;
-    });
+    import com.amplitude.android.TrackingOptions
     ```
+
+Before initializing the SDK with your apiKey, create a `TrackingOptions` instance with your configuration and set it on the SDK instance.
 
 === "Kotlin"
 
@@ -552,6 +543,19 @@ Before initializing the SDK with your apiKey, create a `TrackingOptions` insta
             trackingOptions = trackingOptions
         )
     )
+    ```
+
+=== "Java"
+
+    ```java
+    TrackingOptions trackingOptions = new TrackingOptions();
+    trackingOptions.disableCity().disableIpAddress().disableLatLng();
+
+    // init instance
+    amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setTrackingOptions(trackingOptions);
+        return Unit.INSTANCE;
+    });
     ```
 
 Tracking for each field can be individually controlled, and has a corresponding method (for example, `disableCountry`, `disableLanguage`).
@@ -586,15 +590,6 @@ Amplitude determines the user's mobile carrier using [Android's TelephonyManager
 
 COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, city, IP address and location tracking can all be enabled or disabled at one time. Apps that ask for information from children under 13 years of age must comply with COPPA.
 
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setEnableCoppaControl(true); //Disables ADID, city, IP, and location tracking
-        return Unit.INSTANCE;
-    });
-    ```
-
 === "Kotlin"
 
     ```kotlin
@@ -607,6 +602,16 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
     )
     ```
 
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setEnableCoppaControl(true); //Disables ADID, city, IP, and location tracking
+        return Unit.INSTANCE;
+    });
+    ```
+
+
 ### Advertiser ID
 
 --8<-- "includes/sdk-android/android-sdk-advertiser-id.md"
@@ -614,15 +619,6 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 #### Set advertising ID as device ID
 
 After you set up the logic to fetch the advertising ID, you can enable `useAdvertisingIdForDeviceId` to use advertising id as the device ID.
-
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setUseAdvertisingIdForDeviceId(true);
-        return Unit.INSTANCE;
-    });
-    ```
 
 === "Kotlin"
 
@@ -634,6 +630,15 @@ After you set up the logic to fetch the advertising ID, you can enable `useAdver
             useAdvertisingIdForDeviceId = true
         )
     )
+    ```
+
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setUseAdvertisingIdForDeviceId(true);
+        return Unit.INSTANCE;
+    });
     ```
 
 ### App set ID
@@ -653,15 +658,6 @@ App set ID is a unique identifier for each app install on a device. App set ID i
 
 2. Enable to use app set ID as Device ID.
 
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setUseAppSetIdForDeviceId(true);
-        return Unit.INSTANCE;
-    });
-    ```
-
 === "Kotlin"
 
     ```kotlin
@@ -674,20 +670,20 @@ App set ID is a unique identifier for each app install on a device. App set ID i
     )
     ```
 
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setUseAppSetIdForDeviceId(true);
+        return Unit.INSTANCE;
+    });
+    ```
+
 ### Location tracking
 
 Amplitude converts the IP of a user event into a location (GeoIP lookup) by default. This information may be overridden by an app's own tracking solution or user data.
 
 By default, Amplitude can use Android location service (if available) to add the specific coordinates (longitude and latitude) for the location from which an event is logged. Control this behavior by enable / disable location listening during the initialization.
-
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setLocationListening(true);
-        return Unit.INSTANCE;
-    });
-    ```
 
 === "Kotlin"
 
@@ -701,6 +697,15 @@ By default, Amplitude can use Android location service (if available) to add the
     )
     ```
 
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setLocationListening(true);
+        return Unit.INSTANCE;
+    });
+    ```
+
 !!!note "ProGuard obfuscation"
     If you use ProGuard obfuscation, add the following exception to the file:
     `-keep class com.google.android.gms.common.** { *; }`
@@ -708,15 +713,6 @@ By default, Amplitude can use Android location service (if available) to add the
 ### Opt users out of tracking
 
 Users may wish to opt out of tracking entirely, which means Amplitude doesn't track any of their events or browsing history. `OptOut` provides a way to fulfill a user's requests for privacy.
-
-=== "Java"
-
-    ```java
-    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
-        configuration.setOptOut(true);
-        return Unit.INSTANCE;
-    });
-    ```
 
 === "Kotlin"
 
@@ -730,6 +726,15 @@ Users may wish to opt out of tracking entirely, which means Amplitude doesn't tr
     )
     ```
 
+=== "Java"
+
+    ```java
+    amplitude = AmplitudeKt.Amplitude(BuildConfig.AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
+        configuration.setOptOut(true);
+        return Unit.INSTANCE;
+    });
+    ```
+
 ### Push notification events
 
 Don't send push notification events client-side via the Android SDK. Because a user must open the app to initialize the Amplitude SDK in order for the SDK to send the event, events aren't sent to the Amplitude servers until the next time the user opens the app. This can cause data delays.
@@ -739,6 +744,49 @@ You can use [mobile marketing automation partners](https://amplitude.com/integra
 ### Set log callback
 
 Implements a customized `loggerProvider` class from the LoggerProvider, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment.
+
+=== "Kotlin"
+
+    ```kotlin
+    import com.amplitude.common.Logger
+    import com.amplitude.core.LoggerProvider
+
+    class sampleLogger : Logger {
+    override var logMode: Logger.LogMode
+        get() = Logger.LogMode.DEBUG
+        set(value) {}
+
+        override fun debug(message: String) {
+            TODO("Handle debug message here")
+        }
+
+        override fun error(message: String) {
+            TODO("Handle error message here")
+        }
+
+        override fun info(message: String) {
+            TODO("Handle info message here")
+        }
+
+        override fun warn(message: String) {
+            TODO("Handle warn message here")
+        }
+    }
+
+    class sampleLoggerProvider : LoggerProvider {
+        override fun getLogger(amplitude: com.amplitude.core.Amplitude): Logger {
+            return sampleLogger()
+        }
+    }
+
+    amplitude = Amplitude(
+        Configuration(
+            apiKey = AMPLITUDE_API_KEY,
+            context = applicationContext,
+            loggerProvider = sampleLoggerProvider()
+        )
+    )
+    ```
 
 === "Java"
 
@@ -786,49 +834,6 @@ Implements a customized `loggerProvider` class from the LoggerProvider, and pass
             return new sampleLogger();
         }
     }
-    ```
-
-=== "Kotlin"
-
-    ```kotlin
-    import com.amplitude.common.Logger
-    import com.amplitude.core.LoggerProvider
-
-    class sampleLogger : Logger {
-    override var logMode: Logger.LogMode
-        get() = Logger.LogMode.DEBUG
-        set(value) {}
-
-        override fun debug(message: String) {
-            TODO("Handle debug message here")
-        }
-
-        override fun error(message: String) {
-            TODO("Handle error message here")
-        }
-
-        override fun info(message: String) {
-            TODO("Handle info message here")
-        }
-
-        override fun warn(message: String) {
-            TODO("Handle warn message here")
-        }
-    }
-
-    class sampleLoggerProvider : LoggerProvider {
-        override fun getLogger(amplitude: com.amplitude.core.Amplitude): Logger {
-            return sampleLogger()
-        }
-    }
-
-    amplitude = Amplitude(
-        Configuration(
-            apiKey = AMPLITUDE_API_KEY,
-            context = applicationContext,
-            loggerProvider = sampleLoggerProvider()
-        )
-    )
     ```
 
 ### Multiple Instances

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -383,10 +383,10 @@ You can adjust the time window for which sessions are extended. The default sess
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setMinTimeBetweenSessionsMillis(1000);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setMinTimeBetweenSessionsMillis(1000);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 By default, Amplitude automatically sends the '[Amplitude] Start Session' and '[Amplitude] End Session' events. Even though these events aren't sent, sessions are still tracked by using `session_id`.
@@ -444,10 +444,10 @@ You can define your own session expiration time. The default session expiration 
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setMinTimeBetweenSessionsMillis(10000);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setMinTimeBetweenSessionsMillis(10000);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 ### Set custom user ID
@@ -603,12 +603,12 @@ COPPA (Children's Online Privacy Protection Act) restrictions on IDFA, IDFV, cit
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setEnableCoppaControl(true); //Disables ADID, city, IP, and location tracking
-        return Unit.INSTANCE;
-    });
-    ```
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    //Disables ADID, city, IP, and location tracking
+    configuration.setEnableCoppaControl(true);
 
+    Amplitude amplitude = new Amplitude(configuration);
+    ```
 
 ### Advertiser ID
 
@@ -633,10 +633,10 @@ After you set up the logic to fetch the advertising ID, you can enable `useAdver
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setUseAdvertisingIdForDeviceId(true);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setUseAdvertisingIdForDeviceId(true);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 ### App set ID
@@ -671,10 +671,10 @@ App set ID is a unique identifier for each app install on a device. App set ID i
 === "Java"
 
     ```java
-    amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setUseAppSetIdForDeviceId(true);
-        return Unit.INSTANCE;
-    });
+    Configuration configuration = new Configuration(API_KEY, getApplicationContext());
+    configuration.setUseAppSetIdForDeviceId(true);
+
+    Amplitude amplitude = new Amplitude(configuration);
     ```
 
 ### Location tracking

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -46,7 +46,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable COPPA control for tracking options. | `false` |
     | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
-    | `migrateLegacyData` | `Boolean`. Available in `1.9.0`+. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID).  | `false`|
+    | `migrateLegacyData` | `Boolean`. Available in `1.9.0`+. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID). Learn more [here](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16). | `false`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/android-kotlin/migration.md
+++ b/docs/data/sdks/android-kotlin/migration.md
@@ -17,3 +17,27 @@ description: Use this guide to easily migrate from Amplitude's maintenance Andro
 | Customization | Plugins | Middelware |
 | Server Endpoint | HTTP V2 API | HTTP V1 API |
 | Batch API| Supported, with configuration. | Not supported.|
+
+
+## Data migration
+
+Existing [maintenance SDK](../../android) data (events, user/device ID) can be moved to the new SDK:
+
+=== "Kotlin"
+
+    ```kotlin
+    amplitude = Amplitude(
+        Configuration(
+            ...
+            migrateLegacyData = true,
+        )
+    )
+    ```
+
+=== "Java"
+
+    ```java
+    Configuration configuration = new Configuration("AMPLITUDE_API_KEY", getApplicationContext());
+    configuration.setMigrateLegacyData(true);
+    Amplitude amplitude = new Amplitude(configuration);
+    ```

--- a/docs/data/sdks/android-kotlin/migration.md
+++ b/docs/data/sdks/android-kotlin/migration.md
@@ -20,7 +20,7 @@ description: Use this guide to easily migrate from Amplitude's maintenance Andro
 
 ## Data migration
 
-Existing [maintenance SDK](../../android) data (events, user/device ID) can be moved to the new SDK:
+Existing [maintenance SDK](../../android) data (events, user/device ID) can be moved to the latest SDK by setting `migrateLegacyData` to `true` in the [Configuration](../#configuration). Learn more in [Github](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16).
 
 === "Kotlin"
 
@@ -38,5 +38,6 @@ Existing [maintenance SDK](../../android) data (events, user/device ID) can be m
     ```java
     Configuration configuration = new Configuration("AMPLITUDE_API_KEY", getApplicationContext());
     configuration.setMigrateLegacyData(true);
+    
     Amplitude amplitude = new Amplitude(configuration);
     ```

--- a/docs/data/sdks/android-kotlin/migration.md
+++ b/docs/data/sdks/android-kotlin/migration.md
@@ -18,7 +18,6 @@ description: Use this guide to easily migrate from Amplitude's maintenance Andro
 | Server Endpoint | HTTP V2 API | HTTP V1 API |
 | Batch API| Supported, with configuration. | Not supported.|
 
-
 ## Data migration
 
 Existing [maintenance SDK](../../android) data (events, user/device ID) can be moved to the new SDK:


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Add `migrateLegacyData` configuration option to Android-Kotlin SDK.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.

# Additional notes:

1. Existing Java snippets (Amplitude creation) are incorrect. For example:
* https://www.docs.developers.amplitude.com/data/sdks/android-kotlin/#configuration
* https://www.docs.developers.amplitude.com/data/sdks/sdk-quickstart/#android

Some Java snippets use valid code (for example, https://www.docs.developers.amplitude.com/data/sdks/android-kotlin/#user-sessions):
```
amplitude = AmplitudeKt.Amplitude(AMPLITUDE_API_KEY, getApplicationContext(), configuration -> {
    configuration.setMinTimeBetweenSessionsMillis(1000);
    return Unit.INSTANCE;
});
```
In this PR I use simpler code:
```
Configuration configuration = new Configuration("AMPLITUDE_API_KEY", getApplicationContext());
configuration.setMigrateLegacyData(true);
Amplitude amplitude = new Amplitude(configuration);
```

2. `Java`/ `Kotlin` tab order in https://www.docs.developers.amplitude.com/data/sdks/android-kotlin/, `Kotlin`/ `Java` in https://www.docs.developers.amplitude.com/data/sdks/sdk-quickstart/#android. In this PR - `Kotlin`/ `Java`

3. To allow `configuration.setMigrateLegacyData(true)` in Java code the SDK property `migrateLegacyData` is now writable (https://github.com/amplitude/Amplitude-Kotlin/pull/40/commits/104e91d51f5ea531024142dfad8c5e911f8a69a1)

@amplitude-dev-docs
