### PR TITLE
fix: add more swift configuration

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -36,6 +36,11 @@ let amplitude = Amplitude(configuration: Configuration(
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
+    | `apiKey` | The apiKey of your project. | `nil` |
+    | `instanceName` | The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. | `default_instance` |
+    | `storageProvider` | Implements a custom `storageProvider` class from `Storage`. | `PersistentStorage` |
+    | `logLevel` | The log level enums: `LogLevelEnum.OFF`, `LogLevelEnum.ERROR`, `LogLevelEnum.WARN`, `LogLevelEnum.LOG`, `LogLevelEnum.DEBUG` | `LogLevelEnum.WARN` | 
+    | `loggerProvider` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLoggerProvider` |
     | `flushIntervalMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
     | `flushQueueSize` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
     | `flushMaxRetries` | Maximum retry times.  | `5` |
@@ -174,6 +179,45 @@ You can assign a new device ID using `deviceId`. When setting a custom device I
 
 ```swift
 amplitude.setDeviceId(NSUUID().uuidString)
+```
+
+### Custom storage
+
+Every iOS app gets a slice of storage just for itself, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory. However, if you need to expose the Documents folder in the native iOS "Files" app and don't want expose "amplitude" prefixed folder, you can customize your own storage provider to persist events on initialization.
+
+```swift
+//public protocol Storage {
+//    func write(key: StorageKey, value: Any?) throws
+//    func read<T>(key: StorageKey) -> T?
+//    func getEventsString(eventBlock: URL) -> String?
+//    func remove(eventBlock: URL)
+//    func splitBlock(eventBlock: URL, events: [BaseEvent])
+//    func rollover()
+//    func reset()
+//    func getResponseHandler(
+//        configuration: Configuration,
+//        eventPipeline: EventPipeline,
+//        eventBlock: URL,
+//        eventsString: String
+//    ) -> ResponseHandler
+//}
+//
+//public enum StorageKey: String, CaseIterable {
+//    case LAST_EVENT_ID = "last_event_id"
+//    case PREVIOUS_SESSION_ID = "previous_session_id"
+//    case LAST_EVENT_TIME = "last_event_time"
+//    case OPT_OUT = "opt_out"
+//    case EVENTS = "events"
+//    case USER_ID = "user_id"
+//    case DEVICE_ID = "device_id"
+//}
+
+Amplitude(
+    configuration: Configuration(
+        apiKey: "8c0fefcbd0effe2d799eb51be70053f8",
+        storageProvider: YourOwnStorage() // YourOwnStorage() should implement Storage
+        )
+    )
 ```
 
 ### Reset when user logs out

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -183,7 +183,9 @@ amplitude.setDeviceId(NSUUID().uuidString)
 
 ### Custom storage
 
-If you don't want to store the data in the Amplitude-defined location, you can customize your own storage.
+By default, Amplitude persists data in file storage. Every iOS app gets dedicated of storage, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory.
+
+If you don't want to store the data in the Amplitude-defined location, you can customize your own storage by implementing the [Storage protocol](https://github.com/amplitude/Amplitude-Swift/blob/211d0c05830fab47e74fa9a053615cf422618a02/Sources/Amplitude/Types.swift#L62-L86) and setting the `storageProvider` in your configuration.
 
 Every iOS app gets a slice of storage just for itself, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory. However, if you need to expose the Documents folder in the native iOS "Files" app and don't want expose "amplitude" prefixed folder, you can customize your own storage provider to persist events on initialization.
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -37,7 +37,7 @@ let amplitude = Amplitude(configuration: Configuration(
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
     | `apiKey` | The apiKey of your project. | `nil` |
-    | `instanceName` | The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. | `default_instance` |
+    | `instanceName` | The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. | "default_instance" |
     | `storageProvider` | Implements a custom `storageProvider` class from `Storage`. | `PersistentStorage` |
     | `logLevel` | The log level enums: `LogLevelEnum.OFF`, `LogLevelEnum.ERROR`, `LogLevelEnum.WARN`, `LogLevelEnum.LOG`, `LogLevelEnum.DEBUG` | `LogLevelEnum.WARN` | 
     | `loggerProvider` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLoggerProvider` |

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -214,7 +214,7 @@ Every iOS app gets a slice of storage just for itself, meaning that you can read
 
 Amplitude(
     configuration: Configuration(
-        apiKey: "8c0fefcbd0effe2d799eb51be70053f8",
+        apiKey: "YOUR-API-KEY",
         storageProvider: YourOwnStorage() // YourOwnStorage() should implement Storage
         )
     )

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -192,8 +192,8 @@ Amplitude(
     configuration: Configuration(
         apiKey: "YOUR-API-KEY",
         storageProvider: YourOwnStorage() // YourOwnStorage() should implement Storage
-        )
     )
+)
 ```
 
 ### Reset when user logs out

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -40,7 +40,7 @@ let amplitude = Amplitude(configuration: Configuration(
     | `instanceName` | The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance. | "default_instance" |
     | `storageProvider` | Implements a custom `storageProvider` class from `Storage`. | `PersistentStorage` |
     | `logLevel` | The log level enums: `LogLevelEnum.OFF`, `LogLevelEnum.ERROR`, `LogLevelEnum.WARN`, `LogLevelEnum.LOG`, `LogLevelEnum.DEBUG` | `LogLevelEnum.WARN` | 
-    | `loggerProvider` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLoggerProvider` |
+    | `loggerProvider` | Implements a custom `loggerProvider` class from the Logger, and pass it in the configuration during the initialization to help with collecting any error messages from the SDK in a production environment. | `ConsoleLogger` |
     | `flushIntervalMillis` | The amount of time SDK will attempt to upload the unsent events to the server or reach `flushQueueSize` threshold. | `30000` |
     | `flushQueueSize` | SDK will attempt to upload once unsent event count exceeds the event upload threshold or reach `flushIntervalMillis` interval.  | `30` |
     | `flushMaxRetries` | Maximum retry times.  | `5` |
@@ -182,6 +182,8 @@ amplitude.setDeviceId(NSUUID().uuidString)
 ```
 
 ### Custom storage
+
+If you don't want to store the data in the Amplitude-defined location, you can customize your own storage.
 
 Every iOS app gets a slice of storage just for itself, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory. However, if you need to expose the Documents folder in the native iOS "Files" app and don't want expose "amplitude" prefixed folder, you can customize your own storage provider to persist events on initialization.
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -183,39 +183,11 @@ amplitude.setDeviceId(NSUUID().uuidString)
 
 ### Custom storage
 
-By default, Amplitude persists data in file storage. Every iOS app gets dedicated of storage, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory.
-
 If you don't want to store the data in the Amplitude-defined location, you can customize your own storage by implementing the [Storage protocol](https://github.com/amplitude/Amplitude-Swift/blob/211d0c05830fab47e74fa9a053615cf422618a02/Sources/Amplitude/Types.swift#L62-L86) and setting the `storageProvider` in your configuration.
 
 Every iOS app gets a slice of storage just for itself, meaning that you can read and write your app's files there without worrying about colliding with other apps. By default, Amplitude uses this file storage and creates an "amplitude" prefixed folder inside the app "Documents" directory. However, if you need to expose the Documents folder in the native iOS "Files" app and don't want expose "amplitude" prefixed folder, you can customize your own storage provider to persist events on initialization.
 
 ```swift
-//public protocol Storage {
-//    func write(key: StorageKey, value: Any?) throws
-//    func read<T>(key: StorageKey) -> T?
-//    func getEventsString(eventBlock: URL) -> String?
-//    func remove(eventBlock: URL)
-//    func splitBlock(eventBlock: URL, events: [BaseEvent])
-//    func rollover()
-//    func reset()
-//    func getResponseHandler(
-//        configuration: Configuration,
-//        eventPipeline: EventPipeline,
-//        eventBlock: URL,
-//        eventsString: String
-//    ) -> ResponseHandler
-//}
-//
-//public enum StorageKey: String, CaseIterable {
-//    case LAST_EVENT_ID = "last_event_id"
-//    case PREVIOUS_SESSION_ID = "previous_session_id"
-//    case LAST_EVENT_TIME = "last_event_time"
-//    case OPT_OUT = "opt_out"
-//    case EVENTS = "events"
-//    case USER_ID = "user_id"
-//    case DEVICE_ID = "device_id"
-//}
-
 Amplitude(
     configuration: Configuration(
         apiKey: "YOUR-API-KEY",


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Fix: https://amplitude.atlassian.net/browse/DXOC-853

- add more configuration fields:  https://pr-779.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios-swift/#configuration
![image](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/754423a2-3045-4fa5-a904-a1ee7a8191f3)

- add custom storage section: https://pr-779.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios-swift/#custom-storage

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
