### PR TITLE
AMP-76314 Hotjar + GTM + FullStory Streaming Destination Docs

### DIFF
--- a/docs/data/destinations/fullstory-event-streaming.md
+++ b/docs/data/destinations/fullstory-event-streaming.md
@@ -1,0 +1,67 @@
+---
+title: FullStory Event Streaming
+description: Forward Amplitude events to FullStory using SDK Plugins
+---
+
+[FullStory](https://www.fullstory.com/) is a digital experience intelligence platform. Apps can leverage conversion funnels, advanced search capabilities, user session replays, and robust debugging and developer tools.
+
+## Setup
+
+### Amplitude plugin setup
+
+A variant of an [Amplitude Destination Plugin](../sdk-plugins.md#destination-type-plugin) is required to forward events to FullStory. Below is a template of a Destination Plugin tailored for FullStory. It creates an instance of the 
+FullStory [browser SDK](https://help.fullstory.com/hc/en-us/articles/360020828273-Getting-Started-with-FullStory#h_01FXB8T39JB6TPBWMR3727QMVV) and forwards tracked events from Amplitude's SDK. This template is customizable for any needs.
+
+=== "TypeScript"
+
+    ```ts
+    import { DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
+
+    export class FullstoryPlugin implements DestinationPlugin {
+      name = 'fullstory';
+      type = PluginType.DESTINATION as const;
+      fsOrg: string;
+      FS: Object
+
+      constructor(fsOrg: string) {
+        this.fsOrg = fsOrg;
+        this.FS = window.FS;
+      }
+
+      async setup(): Promise<void> {
+        window._fs_host||(window._fs_host="fullstory.com",window._fs_script="edge.fullstory.com/s/fs.js",window._fs_org=this.fsOrg,window._fs_namespace="FS",function(n,t,e,o,s,c,i,f){e in n?n.console&&n.console.log&&n.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'):((i=n[e]=function(n,t,e){i.q?i.q.push([n,t,e]):i._api(n,t,e)}).q=[],(c=t.createElement(o)).async=1,c.crossOrigin="anonymous",c.src="https://"+_fs_script,(f=t.getElementsByTagName(o)[0]).parentNode.insertBefore(c,f),i.identify=function(n,t,e){i(s,{uid:n},e),t&&i(s,t,e)},i.setUserVars=function(n,t){i(s,n,t)},i.event=function(n,t,e){i("event",{n:n,p:t},e)},i.anonymize=function(){i.identify(!1)},i.shutdown=function(){i("rec",!1)},i.restart=function(){i("rec",!0)},i.log=function(n,t){i("log",[n,t])},i.consent=function(n){i("consent",!arguments.length||n)},i.identifyAccount=function(n,t){c="account",(t=t||{}).acctId=n,i(c,t)},i.clearUserCookie=function(){},i.setVars=function(n,t){i("setVars",[n,t])},i._w={},f="XMLHttpRequest",i._w[f]=n[f],f="fetch",i._w[f]=n[f],n[f]&&(n[f]=function(){return i._w[f].apply(this,arguments)}),i._v="1.3.0")}(window,document,window._fs_namespace,"script","user"));
+        this.FS = window.FS;
+      }
+
+      async execute(event: Event): Promise<Result> {
+        if (event.event_type === '$identify') {
+          this.FS.identify(event.user_id)
+
+        } else {
+          this.FS.event(event.event_type, event.event_properties)
+        }
+
+        return {
+          code: 200,
+          event: event,
+          message: 'Event forwarded to FullStory',
+        };
+      }
+    }
+    ```
+
+### Amplitude plugin usage
+
+Inside the app's code, the plugin may then be imported and added to the Amplitude SDK instance.
+
+=== "TypeScript"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { FullstoryPlugin } from './FullstoryPlugin';
+
+    amplitude.init(AMPLITUDE_API_KEY);
+    amplitude.add(new FullstoryPlugin(FULLSTORY_KEY));
+
+    amplitude.logEvent('open app');
+    ```

--- a/docs/data/destinations/google-tag-manager-event-streaming.md
+++ b/docs/data/destinations/google-tag-manager-event-streaming.md
@@ -1,0 +1,69 @@
+---
+title: Google Tag Manager Event Streaming
+description: Forward Amplitude events to Google Tag Manager using SDK Plugins
+---
+
+[Google Tag Manager](https://developers.google.com/tag-platform/tag-manager/) is a platform to manage all your website's tags without code.
+
+## Setup
+
+### Amplitude plugin setup
+
+A variant of an [Amplitude Destination Plugin](../sdk-plugins.md#destination-type-plugin) is required to forward events to Google Tag Manager. Below is a template of a Destination Plugin tailored for Google Tag Manager. It creates an instance of the 
+Google Tag Manager [browser snippet](https://developers.google.com/tag-platform/tag-manager/web) and forwards tracked events from Amplitude's SDK. This template is customizable for any needs.
+
+=== "TypeScript"
+
+    ```ts
+
+    import { DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
+
+    export class GTMPlugin implements DestinationPlugin {
+      name = 'google-tag-manager';
+      type = PluginType.DESTINATION as const;
+      containerId: string;
+
+      constructor(containerId: string) {
+        this.containerId = containerId;
+      }
+
+      async setup(): Promise<void> {
+        if (!window.dataLayer) {
+          window.dataLayer = window.dataLayer || [];
+          window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+          const head = document.getElementsByTagName('head')[0],
+            script = document.createElement('script'),
+            dataLayer = 'datalayer' != 'dataLayer' ? '&l=' + 'datalayer' : '';
+          script.async = true;
+          script.src = 'https://www.googletagmanager.com/gtm.js?id=' + this.containerId + dataLayer;
+          head.insertBefore(script, head.firstChild);
+        }
+      }
+
+      async execute(event: Event): Promise<Result> {
+        window.dataLayer.push(event);
+
+        return {
+          code: 200,
+          event: event,
+          message: 'Event pushed onto GTM Data Layer',
+        };
+      }
+    }
+    ```
+
+### Amplitude plugin usage
+
+Inside the app's code, the plugin may then be imported and added to the Amplitude SDK instance.
+
+=== "TypeScript"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { GTMPlugin } from './GTMPlugin';
+
+    amplitude.init(AMPLITUDE_API_KEY);
+    amplitude.add(new GTMPlugin(GOOGLE_TAG_MANAGER_CONTAINER_ID));
+
+    amplitude.logEvent('open app');
+    ```

--- a/docs/data/destinations/hotjar-event-streaming.md
+++ b/docs/data/destinations/hotjar-event-streaming.md
@@ -1,0 +1,66 @@
+---
+title: Hotjar Event Streaming
+description: Forward Amplitude events to Hotjar using SDK Plugins
+---
+
+[Hotjar](https://www.hotjar.com/) is a product experience insights tool that provides behavioral analytics and feedback data with users.
+
+## Setup
+
+### Hotjar plugin setup
+
+A variant of an [Amplitude Destination Plugin](../sdk-plugins.md#destination-type-plugin) is required to forward events to Hotjar. Below is a template of a Destination Plugin tailored for Hotjar. It creates an instance of the 
+Hotjar [browser tracking code](https://help.hotjar.com/hc/en-us/articles/115011639927-What-is-the-Hotjar-Tracking-Code-) and forwards tracked events from Amplitude's SDK. This template is customizable for any needs.
+
+=== "TypeScript"
+
+    ```ts
+    import { BrowserConfig, DestinationPlugin, Event, PluginType, Result } from '@amplitude/analytics-types';
+    import { default as hj } from '@hotjar/browser';
+    export class HotjarPlugin implements DestinationPlugin {
+      name = 'hotjar';
+      type = PluginType.DESTINATION as const;
+      siteId: number;
+      hotjarVersion: number;
+
+      constructor(siteId: number, hotjarVersion: number) {
+        this.siteId = siteId;
+        this.hotjarVersion = hotjarVersion;
+      }
+
+      async setup(): Promise<void> {
+        hj.init(this.siteId, this.hotjarVersion);
+      }
+
+      async execute(event: Event): Promise<Result> {
+        if (event.event_type === '$identify') {
+          const { user_id, device_id, user_properties } = event;
+          const hotjarId = user_id || device_id || '';
+          hj.identify(hotjarId, user_properties || {});
+        } else {
+          hj.event(event.event_type);
+        }
+        return {
+          code: 0,
+          event: event,
+          message: 'Event forwarded to Hotjar API',
+        };
+      }
+    }
+    ```
+
+### Amplitude plugin usage
+
+Inside the app's code, the plugin may then be imported and added to the Amplitude SDK instance.
+
+=== "TypeScript"
+
+    ```ts
+    import * as amplitude from '@amplitude/analytics-browser';
+    import { HotjarPlugin } from './HotjarPlugin';
+
+    amplitude.init(AMPLITUDE_API_KEY);
+    amplitude.add(new HotjarPlugin(HOTJAR_SIDE_ID, HOTJAR_VERSION));
+
+    amplitude.logEvent('open app');
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -286,6 +286,7 @@ nav:
         - Google Ads: data/destinations/google-ads-event-streaming.md
         - Google Pub/Sub: data/destinations/google-pub-sub.md
         - Google Tag Manager: data/destinations/google-tag-manager-event-streaming.md
+        - Hotjar: data/destinations/hotjar-event-streaming.md
         - Hubspot: data/destinations/hubspot-event-streaming.md
         - Intercom: data/destinations/intercom.md
         - Iterable: data/destinations/iterable.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ nav:
         - Google Analytics 4 (Web): data/destinations/google-analytics-4-gtag.md
         - Google Ads: data/destinations/google-ads-event-streaming.md
         - Google Pub/Sub: data/destinations/google-pub-sub.md
+        - Google Tag Manager: data/destinations/google-tag-manager-event-streaming.md
         - Hubspot: data/destinations/hubspot-event-streaming.md
         - Intercom: data/destinations/intercom.md
         - Iterable: data/destinations/iterable.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -280,6 +280,7 @@ nav:
         - Customer.io: data/destinations/customerio.md
         - Extole: data/destinations/extole-event-streaming.md
         - Fivetran: data/destinations/fivetran-event-forwarding.md
+        - Fullstory: data/destinations/fullstory-event-streaming.md
         - Google Analytics 4 (iOS/Android): data/destinations/google-analytics-4-firebase.md
         - Google Analytics 4 (Web): data/destinations/google-analytics-4-gtag.md
         - Google Ads: data/destinations/google-ads-event-streaming.md


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

- Adds Hotjar, GTM, and FullStory docs as destinations under event streaming using Destination Plugin architecture

![Screenshot 2023-06-04 at 4 54 17 PM](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/15751908/c0a32e3e-cdbb-449c-8f77-46015a44c42e)


## Change type

- [x] Doc update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
