### PR TITLE
AMP-76355 update tiktok ads doc for limitation

### DIFF
--- a/docs/data/destinations/tiktok-cohort.md
+++ b/docs/data/destinations/tiktok-cohort.md
@@ -3,10 +3,6 @@ title: Send Amplitude Cohorts to TikTok Ads
 description: Use Amplitude's TikTok Ads integration to send audiences to TikTok Ads to create more peronalized campaigns.
 ---
 
-!!!Beta "This feature is in Beta release"
-
-    This feature is in Closed Beta and is in active development. Contact <integrations@amplitude.com> if you are interested in using this integration.
-
 [TikTok](https://www.tiktok.com/) is the world's leading destination for short-form mobile videos. Their mission is to capture and present the world's creativity, knowledge, and moments that matter in everyday life.
 
 The TikTok Ads integration allows you to send audiences from Amplitude to TikTok Ads to create more personalized campaigns. 
@@ -23,8 +19,10 @@ The TikTok Ads integration allows you to send audiences from Amplitude to TikTok
 - This integration must be enabled on a per-project basis.
 - TikTok Ads requires SHA256 encryption. If your amplitude key isn't encrypted, Amplitude applies SHA256 when syncing cohort data. 
 - You can't change the TikTok Key after you save the integration. If you need to use a different key, disconnect the integration in Amplitude and set it up again.
+- TikTok Ads API has the hard limit of 24 calls per day per Audience/Cohort [here](https://ads.tiktok.com/marketing_api/docs?id=1708580518247426). For Amplitude this means:
+  1. The maximum size of cohort sync is 4.8 million users.
+  2. If the TikTok Ads Audience has hourly sync and users are added/removed every hour, some sync can fail.
 
-[^1]: Currently in testing. See [TikTok's documentation](https://ads.tiktok.com/marketing_api/docs?id=1701890985340929) for more information.
 
 ## Setup
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
TikTok ads no longer in Beta, thus remove those sections. 

The linked JIRA has fix to bump the cohort size supported from 2.4 million to 4.8 million, also this is due to TikTok Ads API limitation, thus update related consideration so customers know what to expect. 

Added PM @Brandoncharleskhoo1 so he is aware, and wait for repo owner to approve. 

## Deadline

When do these changes need to be live on the site? 

N/A. Update doc so most accurate info is displayed to customers. 


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
