### PR TITLE
AMP-77883-fix-disablecookie-false

### DIFF
--- a/docs/guides/cookies-consent-mgmt-guide.md
+++ b/docs/guides/cookies-consent-mgmt-guide.md
@@ -90,7 +90,7 @@ Finally, be aware that this action will disable the cookie storage BUT Amplitude
 
 ## Disabling cookies and LocalStorage/SessionStorage (opt-out storage)
 
-Amplitude cookies can be fully disabled altogether using the *`disableCookies`* option and setting it to value **"false"**. 
+Amplitude cookies can be fully disabled altogether using the *`disableCookies`* option and setting it to value **"true"**. 
 
 The main consideration here is that Amplitude stores the metadata already referred (e.g. device_id, etc.) and failed events (to be retry sending) in storage. If storage is set to none, then that information can’t be saved for it to be available when the user revisits the site. That means that any new visit by a non-identified user will generate a new random device_id because the SDK checks the cookie/storage to see whether it has an amplitude device_id, and if it is not there, it generates a new one. Therefore, every visit by a non-identified user will have a different device_id and therefore it will be considered as a new unique user in Amplitude. 
 

--- a/docs/guides/cookies-consent-mgmt-guide.md
+++ b/docs/guides/cookies-consent-mgmt-guide.md
@@ -90,7 +90,7 @@ Finally, be aware that this action will disable the cookie storage BUT Amplitude
 
 ## Disabling cookies and LocalStorage/SessionStorage (opt-out storage)
 
-Amplitude cookies can be fully disabled altogether using the *`disableCookies`* option and setting it to value **“none"**. 
+Amplitude cookies can be fully disabled altogether using the *`disableCookies`* option and setting it to value **"false"**. 
 
 The main consideration here is that Amplitude stores the metadata already referred (e.g. device_id, etc.) and failed events (to be retry sending) in storage. If storage is set to none, then that information can’t be saved for it to be available when the user revisits the site. That means that any new visit by a non-identified user will generate a new random device_id because the SDK checks the cookie/storage to see whether it has an amplitude device_id, and if it is not there, it generates a new one. Therefore, every visit by a non-identified user will have a different device_id and therefore it will be considered as a new unique user in Amplitude. 
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

https://amplitude.atlassian.net/browse/AMP-77883
Update Cookie docs to correctly show disabledCookies uses true (not “none”)

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
