### PR TITLE
fix(docs): Update description for `flushIntervalMillis`

### DIFF
--- a/includes/sdk-ts/shared-ts-configuration.md
+++ b/includes/sdk-ts/shared-ts-configuration.md
@@ -1,7 +1,7 @@
 ???config "Configuration Options"
     | <div class="big-column">Name</div>  | Description | Default Value |
     | --- | --- | --- |
-    |`flushIntervalMillis`| `number`. Sets the interval of uploading events to Amplitude in millionseconds. | 1,000 (1 second) |
+    |`flushIntervalMillis`| `number`. Sets the interval of uploading events to Amplitude in milliseconds. | 1,000 (1 second) |
     |`flushQueueSize`| `number`. Sets the maximum number of events that are batched in a single upload attempt. | 30 events |
     |`flushMaxRetries`| `number`. Sets the maximum number of reties for failed upload attempts. This is only applicable to retyable errors. | 5 times.|
     |`logLevel` | `LogLevel.None` or `LogLevel.Error` or `LogLevel.Warn` or `LogLevel.Verbose` or `LogLevel.Debug`. Sets the log level. | `LogLevel.Warn` |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Type in description. Says `millionseconds` when it should be `milliseconds`.

## Deadline

The instructions are confusing and change is low risk. Should update now.

## Change type

- [x] Doc bug fix. Fixes #810 . Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
