### PR TITLE
fix(docs): Type when referencing the event name for Page URL

### DIFF
--- a/includes/sdk-ts-browser/tracking-page-views-advanced.md
+++ b/includes/sdk-ts-browser/tracking-page-views-advanced.md
@@ -30,5 +30,5 @@ The following information is tracked in the page view events.
 |`event_properties.[Amplitude] Page Location`| `string`. The page location. | location.href or ''. |
 |`event_properties.[Amplitude] Page Path`| `string`. The page path. | location.path or ''.|
 |`event_properties.[Amplitude] Page Title`| `string`. The page title. | document.title or ''.|
-|`event_properties.[Amplitude] Page Title`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
+|`event_properties.[Amplitude] Page URL`| `string`. The value of page url. | location.href.split('?')[0] or ``.|
 |`event_properties.${CampaignParam}`| `string`. The value of `UTMParameters` `ReferrerParameters` `ClickIdParameters` if has any. Check [here](./#web-attribution) for the possilbe keys. | Any undefined campaignParam or `undefined`. |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Event name is defined here:
https://github.com/amplitude/Amplitude-TypeScript/blob/7d0281ceefd6087b27f854bd3865a49eaf8f745a/packages/plugin-page-view-tracking-browser/src/page-view-tracking.ts#L32

this was incorrectly referenced as "Page Title" again.

## Deadline

Now.

## Change type

- [x] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
