### PR TITLE
docs: add default events for android kotlin sdk

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -153,7 +153,7 @@ amplitude.identify(identify)
 
 ### Tracking default events
 
-Starting from release v1.10.0, the SDK is able to track more default events now. It can be configured to track the following events automatically:
+Starting from release v1.10.1, the SDK is able to track more default events now. It can be configured to track the following events automatically:
 
 * Sessions [^1]
 * App lifecycles

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -36,7 +36,8 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `flushEventsOnClose` | `Boolean`. Flushing of unsent events on app close. | `true` |
     | `callback` | `EventCallBack`. Callback function after event sent. | `null` |
     | `optOut` | `Boolean`. Opt the user out of tracking. | `false` |
-    | `trackingSessionEvents` | `Boolean`. Automatic tracking of "Start Session" and "End Session" events that count toward event volume. | `false` |
+    | `trackingSessionEvents` | `Boolean`. Deprecated. Automatic tracking of "Start Session" and "End Session" events that count toward event volume. | `false` |
+    | `defaultTracking` | `DefaultTrackingOptions`. Options to control the default events tracking. | Check [Tracking default events](#tracking-default-events) |
     | `minTimeBetweenSessionsMillis` | `Long`. The amount of time for session timeout. The value is in milliseconds. | `300000` |
     | `serverUrl` | `String`. The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` | `ServerZone.US` or `ServerZone.EU`. The server zone to send to, will adjust server url based on this config. | `ServerZone.US` |
@@ -149,6 +150,150 @@ identify.set("color", "green")
 amplitude.identify(identify)
 
 ```
+
+### Tracking default events
+
+Starting from release v1.10.0, the SDK is able to track more default events now. It can be configured to track the following events automatically:
+
+* Sessions [^1]
+* App lifecycles
+* Screen views
+* Deep links
+
+[^1]:
+    Session tracking is the same as supported in previous versions, which was previously enabled/disabled via the [`trackingSessionEvents`](#configuration) configuration.
+
+???config "Tracking default events options"
+    | <div class="big-column">Name</div> | Type | Default Value | Description |
+    |-|-|-|-|
+    `config.defaultTracking.sessions` | Optional. `boolean` | `true` | Enables session tracking. This configuration replaces [`trackingSessionEvents`](#configuration). If value is `true`, Amplitude tracks session start and session end events.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
+    `config.defaultTracking.appLifecycles` | Optional. `boolean` | `false` | Enables application lifecycle events tracking. If value is `true`, Amplitude tracks application installed, application updated, application opened, and application backgrounded events.<br /><br />Event properties tracked includes: `[Amplitude] Version`,<br /> `[Amplitude] Build`,<br /> `[Amplitude] Previous Version`, `[Amplitude] Previous Build`, `[Amplitude] From Background`<br /><br />See [Tracking application lifecycles](#tracking-application-lifecycles) for more information.|
+    `config.defaultTracking.screenViews` | Optional. `boolean` | `false` | Enables screen views tracking. If value is `true`, Amplitude tracks screen viewed events.<br /><br />Event properties tracked includes: `[Amplitude] Screen Name`<br /><br />See [Tracking screen views](#tracking-screen-views) for more information.|
+    `config.defaultTracking.deepLinks` | Optional. `boolean` | `false` | Enables deep link tracking. If value is `true`, Amplitude tracks deep link opened events.<br /><br />Event properties tracked includes: `[Amplitude] Link URL`, `[Amplitude] Link Referrer`<br /><br />See [Tracking deep links](#tracking-deep-links) for more information.|
+
+You can enable Amplitude to start tracking all events mentioned above, use the code sample below. Otherwise, you can omit the configuration to keep only session tracking enabled.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions.ALL
+    )
+)
+```
+
+!!!note
+    Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
+
+Similarly, you can disable Amplitude to track all events mentioned above with the code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions.NONE
+    )
+)
+```
+
+You can also customize the tracking with `DefaultTrackingOptions`, see code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions(
+            appLifecycles = true,
+            sessions = false,
+            deepLinks = true,
+            screenViews = false
+        )
+    )
+)
+```
+
+#### Tracking sessions
+
+You can enable Amplitude to start tracking session events by setting `configuration.defaultTracking.sessions` to `true`. Refer to the code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions(
+            sessions = true
+        )
+    )
+)
+```
+
+For more information about session tracking, refer to [User sessions](#user-sessions).
+
+!!!note
+    `configuration.trackingSessionEvents` is deprecated and replaced with `configuration.defaultTracking.sessions`.
+
+#### Tracking application lifecycles
+
+You can enable Amplitude to start tracking application lifecycle events by setting `configuration.defaultTracking.appLifecycles` to `true`. Refer to the code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions(
+            appLifecycles = true
+        )
+    )
+)
+```
+
+After enabling this function, Amplitude will track the following events:
+
+- `[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation.
+- `[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application.
+- `[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open.
+- `[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application.
+
+#### Tracking screen views
+
+You can enable Amplitude to start tracking screen view events by setting `configuration.defaultTracking.screenViews` to `true`. Refer to the code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions(
+            screenViews = true
+        )
+    )
+)
+```
+
+After enabling this function, Amplitude will track the `[Amplitude] Screen Viewed` event with the screen name property. This property value is read from the activity label, application label, and activity name successively.
+
+#### Tracking deep links
+
+You can enable Amplitude to start tracking deep link events by setting `configuration.defaultTracking.deepLinks` to `true`. Refer to the code sample below.
+
+```kotlin
+Amplitude(
+    Configuration(
+        apiKey = API_KEY,
+        context = applicationContext,
+        defaultTracking = DefaultTrackingOptions(
+            deepLinks = true
+        )
+    )
+)
+```
+
+After enabling this function, Amplitude will track the `[Amplitude] Deep Link Opened` event with the URL and referrer information.
 
 ### User groups
 
@@ -399,7 +544,9 @@ You can also disable those session events.
         Configuration(
             apiKey = API_KEY,
             context = applicationContext,
-            trackingSessionEvents = false
+            defaultTracking = DefaultTrackingOptions(
+                sessions = false
+            )
         )
     )
     ```
@@ -407,8 +554,10 @@ You can also disable those session events.
 === "Java"
 
     ```
+    defaultTrackingOptions = new DefaultTrackingOptions();
+    defaultTrackingOptions.setSessions(false);
     amplitude = AmplitudeKt.Amplitude(API_KEY, getApplicationContext(), configuration -> {
-        configuration.setTrackingSessionEvents(false);
+        configuration.setDefaultTracking(defaultTrackingOptions);
         return Unit.INSTANCE;
     });
     ```

--- a/docs/data/sdks/android-kotlin/migration.md
+++ b/docs/data/sdks/android-kotlin/migration.md
@@ -12,11 +12,12 @@ description: Use this guide to easily migrate from Amplitude's maintenance Andro
 | Package | [com.amplitude:analytics-android](https://mvnrepository.com/artifact/com.amplitude/analytics-android) | [com.amplitude:android-sdk](https://mvnrepository.com/artifact/com.amplitude/android-sdk) |
 | SSL Pinning | TBD | Supported. Check [here](../../android/#ssl-pinning) for the setup. |
 | Configuration | Configuration is implemented by the configuration object. Configurations need to be passed into Amplitude Object during initialization. [More configurations](../#configuration). | Support explicity setter methods. [More configurations](../../android/#configuration). |
-| Logger provider | ConsoleLoggerProvider() by default. Fully customizable. | Amplitude Logger. Not customizable. |
-| Storage Provider | InMemoryStorageProvider() by default. File storage. Fully customizable. | SQLite Database. |       
+| Logger Provider | ConsoleLoggerProvider() by default. Fully customizable. | Amplitude Logger. Not customizable. |
+| Storage Provider | InMemoryStorageProvider() by default. File storage. Fully customizable. | SQLite Database. |
 | Customization | Plugins | Middelware |
 | Server Endpoint | HTTP V2 API | HTTP V1 API |
 | Batch API| Supported, with configuration. | Not supported.|
+| Default Event Tracking| Support sessions, app lifecycles, screen views, and deep links trackings. [More details](../../android-kotlin/#tracking-default-events). | Support sessions tracking only, disabled by default.|
 
 ## Data migration
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description
This PR adds the default events tracking section for Android Kotlin SDK.

<img width="809" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/8689754/0c253788-6ec2-43e1-a285-51f7751f5608">

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
