### PR TITLE
AMP-78784 `migrateLegacyData` configuration option is enabled by default

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -47,7 +47,7 @@ Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started wi
     | `trackingOptions` | `TrackingOptions`. Options to control the values tracked in SDK. | `enable` |
     | `enableCoppaControl` | `Boolean`. Whether to enable COPPA control for tracking options. | `false` |
     | `instanceName` | `String`. The name of the instance. Instances with the same name will share storage and identity. For isolated storage and identity use a unique `instanceName` for each instance.  | `$default_instance`|
-    | `migrateLegacyData` | `Boolean`. Available in `1.9.0`+. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID). Learn more [here](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16). | `false`|
+    | `migrateLegacyData` | `Boolean`. Available in `1.9.0`+. Whether to migrate [maintenance Android SDK](../android) data (events, user/device ID). Learn more [here](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16). | `true`|
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -254,10 +254,10 @@ Amplitude(
 
 After enabling this function, Amplitude will track the following events:
 
-- `[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation.
-- `[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application.
-- `[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open.
-- `[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application.
+* `[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation.
+* `[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application.
+* `[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open.
+* `[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application.
 
 #### Tracking screen views
 
@@ -383,8 +383,8 @@ amplitude.setDeviceId(UUID.randomUUID().toString())
 
 `reset` is a shortcut to anonymize users after they log out, by:
 
-- setting `userId` to `null`
-- setting `deviceId` to a new value based on current configuration
+* setting `userId` to `null`
+* setting `deviceId` to a new value based on current configuration
 
 With an empty `userId` and a completely new `deviceId`, the current user would appear as a brand new user in dashboard.
 
@@ -627,11 +627,11 @@ Don't assign users a user ID that could change, because each unique user ID is a
 
 You can control the level of logs that print to the developer console.
 
-- 'INFO': Shows informative messages about events.
-- 'WARN': Shows error messages and warnings. This level logs issues that might be a problem and cause some oddities in the data. For example, this level would display a warning for properties with null values.
-- 'ERROR': Shows error messages only.
-- 'DISABLE': Suppresses all log messages.
-- 'DEBUG': Shows error messages, warnings, and informative messages that may be useful for debugging.
+* 'INFO': Shows informative messages about events.
+* 'WARN': Shows error messages and warnings. This level logs issues that might be a problem and cause some oddities in the data. For example, this level would display a warning for properties with null values.
+* 'ERROR': Shows error messages only.
+* 'DISABLE': Suppresses all log messages.
+* 'DEBUG': Shows error messages, warnings, and informative messages that may be useful for debugging.
 
 Set the log level by calling `setLogLevel` with the level you want.
 

--- a/docs/data/sdks/android-kotlin/migration.md
+++ b/docs/data/sdks/android-kotlin/migration.md
@@ -21,7 +21,7 @@ description: Use this guide to easily migrate from Amplitude's maintenance Andro
 
 ## Data migration
 
-Existing [maintenance SDK](../../android) data (events, user/device ID) can be moved to the latest SDK by setting `migrateLegacyData` to `true` in the [Configuration](../#configuration). Learn more in [Github](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16).
+Existing [maintenance SDK](../../android) data (events, user/device ID) are moved to the latest SDK by default. It can be disabled by setting `migrateLegacyData` to `false` in the [Configuration](../#configuration). Learn more in [Github](https://github.com/amplitude/Amplitude-Kotlin/blob/main/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt#L9-L16).
 
 === "Kotlin"
 
@@ -29,7 +29,7 @@ Existing [maintenance SDK](../../android) data (events, user/device ID) can be m
     amplitude = Amplitude(
         Configuration(
             ...
-            migrateLegacyData = true,
+            migrateLegacyData = false,
         )
     )
     ```
@@ -38,7 +38,7 @@ Existing [maintenance SDK](../../android) data (events, user/device ID) can be m
 
     ```java
     Configuration configuration = new Configuration("AMPLITUDE_API_KEY", getApplicationContext());
-    configuration.setMigrateLegacyData(true);
+    configuration.setMigrateLegacyData(false);
     
     Amplitude amplitude = new Amplitude(configuration);
     ```


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Enable `migrateLegacyData` configuration option by default.

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
