### PR TITLE
AMP-78252 - Update Node.js migration doc

### DIFF
--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -118,7 +118,7 @@ identifyObj.set('location', 'LAX');
 
 ### Middleware
 
-Middlewares map to plugins in the new Node.js SDK. Here are two types of plugins, enrichment plugins and destination plugins. To [learn more](../typescript-node/#plugins) about it. Here is an example of logging event information.
+Middlewares map to plugins in the new Node.js SDK. Here are two types of plugins, enrichment plugins and destination plugins. To [learn more](../#plugins) about it. Here is an example of logging event information.
 
 ```diff
 + import { add } from '@amplitude/analytics-node';

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -3,7 +3,7 @@ title: Node.JS SDK Migration Guide
 description: Use this guide to easily migrate from Amplitude's maintenance Node.JS SDK (@amplitude/node) to the new SDK (@amplitude/analytics-node).
 ---
 
-Amplitude new Node.js SDK (`@amplitude/analytics-node`) features a plugin architecture and built-in type definition. New Node.js SDK isn't backwards compatible with maintenance Node.js SDK `@amplitude/node`. 
+Amplitude latest Node.js SDK (`@amplitude/analytics-node`) features a plugin architecture and built-in type definition. Latest Node.js SDK isn't backwards compatible with maintenance Node.js SDK `@amplitude/node`. 
 
 To migrate to `@amplitude/analytics-node`, update your dependencies and instrumentation.
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -116,6 +116,45 @@ identifyObj.set('location', 'LAX');
 + });
 ```
 
+### Middleware
+
+Middlewares map to plugins in the new Node.js SDK. Here are two types of plugins, enrichment plugins and destination plugins. To [learn more](../typescript-node/#plugins) about it. Here is an example of logging event information.
+
+```diff
++ import { add } from '@amplitude/analytics-node';
++ import { NodeConfig, EnrichmentPlugin, Event, PluginType } from '@amplitude/analytics-types';
+
+- const loggingMiddleware: Middleware = (payload, next) => {
+-   console.log(`[amplitude] event=${payload.event} extra=${payload.extra}`);
+-   next(payload);
+}
+
++ export class AddLogEventPlugin implements EnrichmentPlugin {
++   name = 'log-event';
++   type = PluginType.ENRICHMENT as const;
++   config?: NodeConfig;
+
++   async setup(config: NodeConfig): Promise<undefined> {
++      this.config = config;
++      return;
++   }
+
++   async execute(event: Event): Promise<Event> {
++     console.log(`[amplitude] event=${event}`);
++     return event;
++   }
++ }
+```
+
+The `addEventMiddleware()` API maps to `add()`.
+
+```diff
++ import { add } from '@amplitude/analytics-node';
+
+- client.addEventMiddleware(new Middleware())
++ add(new Plugin());
+```
+
 ## Comparison 
 
 --8<-- "includes/sdk-migration/sdk-migration-note.md"

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -62,7 +62,7 @@ The latest Node.js SDK configuration comes in a different shape. Some configurat
 | `serverUrl` | `serverUrl` |
 | `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|
 | `minIdLength` | `minIdLength` |
-| `requestTimeoutMillis` | NOT SUPPORT |
+| `requestTimeoutMillis` | Not supported |
 | `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by the latest Node.js SDK |
 
 ### Tracking events

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -79,13 +79,11 @@ const eventProperties = {
 };
 
 - client.logEvent({
--     event_type: 'Button Clicked',
--     user_id: 'user@amplitude.com',
--     event_properties: eventProperties
-- });
-+ track('Button Clicked', eventProperties, {
-+     user_id: 'user@amplitude.com',
-+ });
++ track({
+  event_type: 'Button Clicked',
+  user_id: 'user@amplitude.com',
+  event_properties: eventProperties
+});
 ```
 
 #### `flush()`

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -16,15 +16,13 @@ To migrate to `@amplitude/analytics-node`, update your dependencies and instrume
 
 Uninstall `@amplitude/node` by either `npm uninstall @amplitude/analytics-node` or deleting your dependency list in package.json
 
-=== "@amplitude/react-native"
-
-    ```json
-    {
-      "dependencies": {
-        "@amplitude/node": "^1",
-      }
+```diff
+{
+    "dependencies": {
+-    "@amplitude/node": "^1",
     }
-    ```
+}
+```
 
 Install `@amplitude/analytics-node` by `npm install @amplitude/analytics-node`.
 
@@ -38,24 +36,14 @@ The maintenance Node.js SDK only supports namespace import. The new Node.js SDK 
 
 To initialize the SDK, call `init()`, with the user ID and configuration parameters.
 
-=== "@amplitude/node"
+```diff
+- import * as Amplitude from '@amplitude/node'
++ import { init } from '@amplitude/analytics-node';
 
-    ```javascript
-    import * as Amplitude from '@amplitude/node'
-
-    var options = {};
-    const client = Amplitude.init(AMPLITUDE_API_KEY, options);
-
-    ```
-
-=== "@amplitude/analytics-node"
-
-    ```typescript
-    import { init } from '@amplitude/analytics-node';
-
-    var options = {};
-    init(API_KEY, options);
-    ```
+var options = {};
+- const client = Amplitude.init(AMPLITUDE_API_KEY, options);
++ init(API_KEY, options);
+```
 
 ### Configuration
 
@@ -74,7 +62,7 @@ The new Node.js SDK configuration comes in a different shape. Some configuration
 | `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|
 | `minIdLength` | `minIdLength` |
 | `requestTimeoutMillis` | NOT SUPPORT |
-| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by new Node.js SDK |
+| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by the new Node.js SDK |
 
 ### Tracking events
 
@@ -82,247 +70,23 @@ The new Node.js SDK configuration comes in a different shape. Some configuration
 
 The `logEvent()` API maps to `track()`.
 
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    Amplitude.getInstance().logEvent('Button Clicked', {buttonColor: 'primary'});
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { track } from '@amplitude/analytics-react-native';
-
-    track('Button Clicked', {buttonColor: 'primary'});
-    ```
-
-#### `uploadEvents()`
-
-The `uploadEvents()` API maps to `flush()`.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    Amplitude.getInstance().uploadEvents();
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { flush } from '@amplitude/analytics-react-native';
-
-    flush();
-    ```
-
-### Set user properties
-
-#### `identify()`
-
-The `identify()` API and `Identify` type remain the same.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude, Identify } from '@amplitude/react-native';
-    
-    const identifyObj = new Identify();
-    identifyObj.set('location', 'LAX');
-    Amplitude.getInstance().identify(identifyObj);
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { Identify, identify } from '@amplitude/analytics-react-native';
-
-    const identifyObj = new Identify();
-    identifyObj.set('location', 'LAX');
-
-    identify(identifyObj);
-    ```
-
-#### `setUserProperties()`
-
-The `setUserProperties()` API has been removed, but you can now use the unified `identify()` API to add user properties.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    Amplitude.getInstance().setUserProperties({
-        membership, "paid",
-        payment, "bank",
-    })
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { Identify, identify } from '@amplitude/analytics-react-native';
-
-    const identifyObj = new amplitude.Identify()
-    identifyObj
-        .set("membership", "paid")
-        .set("payment", "bank")
-    amplitude.identify(identifyObj)
-    ```
-
-#### `clearUserProperties()`
-
-The `clearUserProperties()` API has been removed, but you can now use the unified `identify()` API to remove user properties.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    Amplitude.getInstance().clearUserProperties();
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { Identify, identify } from '@amplitude/analytics-react-native';
-
-    const identifyObj = new amplitude.Identify()
-    identifyObj.clearAll()
-    amplitude.identify(identifyObj)
-    ```
-
-#### `setUserId()`
-
-The `setUserId()` API remains the same`.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    Amplitude.getInstance().setUserId("test_user_id");
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { setUserId } from '@amplitude/analytics-react-native';
-
-    setUserId('user@amplitude.com');
-    ```
-
-### Set group properties
-
-### `groupIdentify()`
-
-You can now make an identify call without calling `getInstance()`.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    const groupType = 'plan';
-    const groupName = 'enterprise';
-    const identifyObj = new Identify()
-    identifyObj.set('key1', 'value1');
-
-    Amplitude.getInstance().groupIdentify(groupType, groupName, identifyObj);
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { Identify, groupIdentify } from '@amplitude/analytics-react-native';
-
-    const groupType = 'plan';
-    const groupName = 'enterprise';
-    const identifyObj = new Identify()
-    identifyObj.set('key1', 'value1');
-
-    groupIdentify(groupType, groupName, identifyObj);
-    ```
-
-### Tracking revenue
-
-#### `logRevenue()`
-
-The `logRevenue()` API maps to `revenue()`. `receipt` and `receiptSignature` is not supported.
-
-=== "@amplitude/react-native"
-
-    ```typescript
-    import { Amplitude } from '@amplitude/react-native';
-    
-    const userProperties = {
-        price: 3,
-        productId: 'com.company.productId',
-        quantity: 2,
-        revenueType: 'productRevenue',
-        eventProperties: {
-            key: 'value',
-        },
-    };
-
-    ampInstance.logRevenue(userProperties);
-    ```
-
-=== "@amplitude/analytics-react-native"
-
-    ```typescript
-    import { Revenue, revenue } from '@amplitude/analytics-react-native';
-
-    const event = new Revenue()
-        .setPrice(3)
-        .setProductId('com.company.productId')
-        .setQuantity(2)
-        .setRevenueType('productRevenue')
-        .setEventProperties({
-            key: 'value',
-        })
-
-    revenue(event);
-    ```
-You can also `setRevenue(6)` instead of `setPrice(3)` and `setQuantity(2)`.
-
-## Advanced topics
-
-### Identity
-
-#### Device ID
-
-As the maintenance Node.js SDK is a wrapper of the maintenance iOS, maintenance Android SDK and maintenance Browser SDK and provides mappings from Node.js to native SDK functions, device ID generation follows the native SDK of each platform. Learn more about device ID lifecycle of [maintenance iOS SDK](../../ios/#device-id-lifecycle) and [maintenance Android SDK](../../android/#device-id-lifecycle). You can also call `setAdvertisingIdForDeviceId()` or `setAppSetIdForDeviceId()` to set ADID or App Set ID as device ID.
-
-The new Node.js SDK initializes the device ID in the following order, with the device ID being set to the first valid value encountered:
-
-1. Device ID of in the configuration on initialization
-2. "deviceId" value from URL param, for example http://example.com/?deviceId=123456789. If it runs on Web.
-3. Device ID in cookie storage.
-4. A randomly generated 36-character UUID
-
-#### Advertising IDs
-
-Maintenance Node.js SDK supports setting an advertising ID as device ID by `setAdvertisingIdForDeviceId()` or `setAppSetIdForDeviceId()`. The new Node.js SDK tracks ADID  by default as `config.trackingOptions.adid` defaults to `true`. However, the new Node.js SDK doesn't support App Set ID, IDFA, or IDFV.
-
-### COPPA
-
-You can enable COPPA control by `enableCoppaControl()` in maintenance Node.js SDK. The new Node.js SDK doesn't support that API but you can still enable COPPA:
-
-* For iOS, IDFA and IDFV aren't tracked. For Android, you can turn off ADID by setting `config.trackingOptions.adid` to `false`
-* You can use an [enrichment Plugin](../#enrichment-type-plugin) to delete city in the payload.
-* You can turn off IP address tracking by setting `config.trackingOptions.ipAddress` to `false`
-* Location (latitude and longitude) isn't tracked
-
-### Session management
-
-Amplitude [defines a session](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions-in-Amplitude#how-amplitude-defines-sessions) slightly differently between mobile and web applications.
-
-The maintenance Node.js SDK follows mobile-style session tracking definition based on foreground and background switching. You can set session expiration time by `setMinTimeBetweenSessionsMillis()`. It also supports automatically log start and end session events by calling `trackingSessionEvents(true)`.
-
-The new Node.js SDK follows web-style session tracking definition based on the last event. You can customize the timeout window by `config.sessionTimeout`. It doesn't support automatic start and end session event tracking, but session is still managed by the SDK. Events that are logged within the same session have the same session ID and Amplitude still groups events together by session.
+```diff
+- import * as Amplitude from '@amplitude/node'
++ import { track } from '@amplitude/analytics-node';
+
+const eventProperties = {
+    buttonColor: 'primary',
+};
+
+- client.logEvent({
+-     event_type: 'Button Clicked',
+-     user_id: 'user@amplitude.com',
+-     event_properties: eventProperties
+- });
++ track('Button Clicked', eventProperties, {
++     user_id: 'user@amplitude.com',
++ });
+```
 
 ## Comparison 
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -29,7 +29,7 @@ Install `@amplitude/analytics-node` by `npm install @amplitude/analytics-node`.
 
 ## Instrumentation
 
-Latest Node.js SDK offers an API to instrument events. To migrate to it, you need to update a few calls. The following sections detail which calls have changed.
+The latest Node.js SDK offers an new API to instrument events. To migrate to it, you need to update a few calls. The following sections detail which calls have changed.
 
 ### Initialization
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -71,7 +71,6 @@ The new Node.js SDK configuration comes in a different shape. Some configuration
 The `logEvent()` API maps to `track()`.
 
 ```diff
-- import * as Amplitude from '@amplitude/node'
 + import { track } from '@amplitude/analytics-node';
 
 const eventProperties = {
@@ -86,6 +85,17 @@ const eventProperties = {
 + track('Button Clicked', eventProperties, {
 +     user_id: 'user@amplitude.com',
 + });
+```
+
+#### `flush()`
+
+The `flush()` API remains the same.
+
+```diff
++ import { flush } from '@amplitude/analytics-node';
+
+- client.flush();
++ flush();
 ```
 
 ## Comparison 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -57,7 +57,7 @@ The latest Node.js SDK configuration comes in a different shape. Some configurat
 | `maxCachedEvents` | `flushQueueSize` |
 | `retryTimeouts` | `flushMaxRetries` can only be set to a number instead of an array of number as in `retryTimeouts`
 | `optOut` | `optOut` |
-| `retryClass` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by latest Node.js SDK|
+| `retryClass` | Not supported. Retry logic is handled internally by latest Node.js SDK|
 | `transportClass` | `transportProvider` |
 | `serverUrl` | `serverUrl` |
 | `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -98,6 +98,24 @@ The `flush()` API remains the same.
 + flush();
 ```
 
+### Set user properties
+
+#### `identify()`
+
+The `identify()` API is very similar but has a different signature. The [old Node.js SDK](https://github.com/amplitude/Amplitude-Node/blob/2ef295e1fb698286d606ea4a2ccbbfdc4ba3fdc8/packages/node/src/nodeClient.ts#L142) has a signature `(userId: string | null, deviceId: string | null, identify: Identify)` while the [new Node.js SDK](https://github.com/amplitude/Amplitude-TypeScript/blob/8f4ea010279fb21190a2c0595d4ae8a7d9e987ce/packages/analytics-core/src/core-client.ts#L62) has a signature `(identify: Identify, eventOptions?: EventOptions)`.
+
+```diff
++ import { identify, Identify } from '@amplitude/analytics-node';
+
+const identifyObj = new Identify();
+identifyObj.set('location', 'LAX');
+
+- client.identify('user@amplitude.com',null,identifyObj);
++ identify(identifyObj, {
++   user_id: 'user@amplitude.com',
++ });
+```
+
 ## Comparison 
 
 --8<-- "includes/sdk-migration/sdk-migration-note.md"

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -1,6 +1,6 @@
 ---
 title: Node.JS SDK Migration Guide
-description: Use this guide to easily migrate from Amplitude's maintenance Node.JS SDK (@amplitude/node) to the new SDK (@amplitude/analytics-node).
+description: Use this guide to easily migrate from Amplitude's maintenance Node.JS SDK (@amplitude/node) to the latest SDK (@amplitude/analytics-node).
 ---
 
 Amplitude latest Node.js SDK (`@amplitude/analytics-node`) features a plugin architecture and built-in type definition. Latest Node.js SDK isn't backwards compatible with maintenance Node.js SDK `@amplitude/node`. 
@@ -28,11 +28,11 @@ Install `@amplitude/analytics-node` by `npm install @amplitude/analytics-node`.
 
 ## Instrumentation
 
-New Node.js SDK offers an API to instrument events. To migrate to it, you need to update a few calls. The following sections detail which calls have changed.
+Latest Node.js SDK offers an API to instrument events. To migrate to it, you need to update a few calls. The following sections detail which calls have changed.
 
 ### Initialization
 
-The maintenance Node.js SDK only supports namespace import. The new Node.js SDK supports namespace import (`import * as amplitude from '@amplitude/analytics-node'`) and named import (`import { init } from '@amplitude/analytics-node'`) as well. We are using named import in the examples of new Node.js SDK in this documentation.
+The maintenance Node.js SDK only supports namespace import. The latest Node.js SDK supports namespace import (`import * as amplitude from '@amplitude/analytics-node'`) and named import (`import { init } from '@amplitude/analytics-node'`) as well. We are using named import in the examples of latest Node.js SDK in this documentation.
 
 To initialize the SDK, call `init()`, with the user ID and configuration parameters.
 
@@ -47,7 +47,7 @@ var options = {};
 
 ### Configuration
 
-The new Node.js SDK configuration comes in a different shape. Some configurations are no longer supported.
+The latest Node.js SDK configuration comes in a different shape. Some configurations are no longer supported.
 
 |@amplitude/node|@amplitude/analytics-node|
 |-|-|
@@ -56,13 +56,13 @@ The new Node.js SDK configuration comes in a different shape. Some configuration
 | `maxCachedEvents` | `flushQueueSize` |
 | `retryTimeouts` | `flushMaxRetries` can only be set to a number instead of an array of number as in `retryTimeouts`
 | `optOut` | `optOut` |
-| `retryClass` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by new Node.js SDK|
+| `retryClass` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by latest Node.js SDK|
 | `transportClass` | `transportProvider` |
 | `serverUrl` | `serverUrl` |
 | `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|
 | `minIdLength` | `minIdLength` |
 | `requestTimeoutMillis` | NOT SUPPORT |
-| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by the new Node.js SDK |
+| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by the latest Node.js SDK |
 
 ### Tracking events
 
@@ -102,7 +102,7 @@ The `flush()` API remains the same.
 
 #### `identify()`
 
-The `identify()` API is very similar but has a different signature. The [old Node.js SDK](https://github.com/amplitude/Amplitude-Node/blob/2ef295e1fb698286d606ea4a2ccbbfdc4ba3fdc8/packages/node/src/nodeClient.ts#L142) has a signature `(userId: string | null, deviceId: string | null, identify: Identify)` while the [new Node.js SDK](https://github.com/amplitude/Amplitude-TypeScript/blob/8f4ea010279fb21190a2c0595d4ae8a7d9e987ce/packages/analytics-core/src/core-client.ts#L62) has a signature `(identify: Identify, eventOptions?: EventOptions)`.
+The `identify()` API is very similar but has a different signature. The [maintenance Node.js SDK](https://github.com/amplitude/Amplitude-Node/blob/2ef295e1fb698286d606ea4a2ccbbfdc4ba3fdc8/packages/node/src/nodeClient.ts#L142) has a signature `(userId: string | null, deviceId: string | null, identify: Identify)` while the [latest Node.js SDK](https://github.com/amplitude/Amplitude-TypeScript/blob/8f4ea010279fb21190a2c0595d4ae8a7d9e987ce/packages/analytics-core/src/core-client.ts#L62) has a signature `(identify: Identify, eventOptions?: EventOptions)`.
 
 ```diff
 + import { identify, Identify } from '@amplitude/analytics-node';
@@ -118,7 +118,7 @@ identifyObj.set('location', 'LAX');
 
 ### Middleware
 
-Middlewares map to plugins in the new Node.js SDK. Here are two types of plugins, enrichment plugins and destination plugins. To [learn more](../#plugins) about it. Here is an example of logging event information.
+Middlewares map to plugins in the latest Node.js SDK. Here are two types of plugins, enrichment plugins and destination plugins. To [learn more](../#plugins) about it. Here is an example of logging event information.
 
 ```diff
 + import { add } from '@amplitude/analytics-node';

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -3,7 +3,7 @@ title: Node.JS SDK Migration Guide
 description: Use this guide to easily migrate from Amplitude's maintenance Node.JS SDK (@amplitude/node) to the latest SDK (@amplitude/analytics-node).
 ---
 
-Amplitude latest Node.js SDK (`@amplitude/analytics-node`) features a plugin architecture and built-in type definition. Latest Node.js SDK isn't backwards compatible with maintenance Node.js SDK `@amplitude/node`. 
+Amplitude's latest Node.js SDK (`@amplitude/analytics-node`) features a plugin architecture and built-in type definitions. The latest Node.js SDK isn't backwards compatible with the maintenance Node.js SDK `@amplitude/node`. 
 
 To migrate to `@amplitude/analytics-node`, update your dependencies and instrumentation.
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -10,7 +10,7 @@ To migrate to `@amplitude/analytics-node`, update your dependencies and instrume
 ## Terminology
 
 * `@amplitude/node`: Maintenance Node.js SDK
-* `@amplitude/analytics-node`: New Node.js SDK
+* `@amplitude/analytics-node`: Latest Node.js SDK
 
 ## Dependency
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -35,7 +35,7 @@ Latest Node.js SDK offers an API to instrument events. To migrate to it, you nee
 
 The maintenance Node.js SDK only supports namespace import. The latest Node.js SDK supports namespace import (`import * as amplitude from '@amplitude/analytics-node'`) and named import (`import { init } from '@amplitude/analytics-node'`) as well. We are using named import in the examples of latest Node.js SDK in this documentation.
 
-To initialize the SDK, call `init()`, with the user ID and configuration parameters.
+To initialize the SDK, call `init()`, with a valid Amplitude API Key and configuration parameters.
 
 ```diff
 - import * as Amplitude from '@amplitude/node'

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -101,7 +101,7 @@ The `flush()` API remains the same.
 
 #### `identify()`
 
-The `identify()` API is very similar but has a different signature. The [maintenance Node.js SDK](https://github.com/amplitude/Amplitude-Node/blob/2ef295e1fb698286d606ea4a2ccbbfdc4ba3fdc8/packages/node/src/nodeClient.ts#L142) has a signature `(userId: string | null, deviceId: string | null, identify: Identify)` while the [latest Node.js SDK](https://github.com/amplitude/Amplitude-TypeScript/blob/8f4ea010279fb21190a2c0595d4ae8a7d9e987ce/packages/analytics-core/src/core-client.ts#L62) has a signature `(identify: Identify, eventOptions?: EventOptions)`.
+The `identify()` API is very similar but has a different signature. The [maintenance Node.js SDK](https://github.com/amplitude/Amplitude-Node/blob/2ef295e1fb698286d606ea4a2ccbbfdc4ba3fdc8/packages/node/src/nodeClient.ts#L142) has a signature `(userId: string | null, deviceId: string | null, identify: Identify)` while the [latest Node.js SDK](https://github.com/amplitude/Amplitude-TypeScript/blob/8f4ea010279fb21190a2c0595d4ae8a7d9e987ce/packages/analytics-core/src/core-client.ts#L62) has a signature `(identify: Identify, eventOptions?: EventOptions)`. Learn more about what `EventOptions` include [here](https://amplitude.github.io/Amplitude-TypeScript/interfaces/_amplitude_analytics_node.Types.EventOptions.html).
 
 ```diff
 + import { identify, Identify } from '@amplitude/analytics-node';

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -63,19 +63,18 @@ The new Node.js SDK configuration comes in a different shape. Some configuration
 
 |@amplitude/node|@amplitude/analytics-node|
 |-|-|
-| `debug` ||
-| `logLevel` | `LogLevel`. Configuration of the logging verbosity of the SDK.  `None` - No Logs will be surfaced. `Error` - SDK internal errors will be generated. `Warn` - Warnings will be generated around dangerous/deprecated features. `Verbose` - All SDK actions will be logged.| `LogLevel.None` |
-| `maxCachedEvents` | `number`. The maximum events in the buffer. | `16000` |
-| `retryTimeouts` | `number[]. ` Determines # of retries for sending failed events and how long each retry to wait for (ms). An empty array means no retries. | `[100, 100, 200, 200, 400, 400, 800, 800, 1600, 1600, 3200, 3200]` |
-| `optOut` | `boolean`. Whether you opt out from sending events. | `false` |
-| `retryClass` | ` Retry`. The class being used to handle event retrying.  | `null` |
-| `transportClass` | ` Transport`. The class being used to transport events. | `null` |
-| `serverUrl` | ` string`. If you're using a proxy server, set its url here. | `https://api2.amplitude.com/2/httpapi` |
-| `uploadIntervalInSec` | `number`. The events upload interval in seconds. | `0` |
-| `minIdLength` | `number`. Optional parameter allowing users to set minimum permitted length for user_id & device_id fields. | `5` |
-| `requestTimeoutMillis` | `number`. Configurable timeout in millionseconds. | `10000` |
-| `onRetry` | `(response: Response, attemptNumber: number, isLastRetry: boolean) => boolean) `. @param `response` - Response from the given retry attempt. @param `attemptNumber` - Index in retryTimeouts for how long Amplitude waited before this retry attempt. Starts at 0. @param `isLastRetry` - True if attemptNumber === retryTimeouts.length - 1. Lifecycle callback that is executed after a retry attempt. Called in {@link Retry.sendEventsWithRetry}.  | `null` |
-
+| `debug` | `logLevel` set to WARN level|
+| `logLevel` | `logLevel` |
+| `maxCachedEvents` | `flushQueueSize` |
+| `retryTimeouts` | `flushMaxRetries` can only be set to a number instead of an array of number as in `retryTimeouts`
+| `optOut` | `optOut` |
+| `retryClass` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by new Node.js SDK|
+| `transportClass` | `transportProvider` |
+| `serverUrl` | `serverUrl` |
+| `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|
+| `minIdLength` | `minIdLength` |
+| `requestTimeoutMillis` | NOT SUPPORT |
+| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by new Node.js SDK |
 
 ### Tracking events
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -63,7 +63,7 @@ The latest Node.js SDK configuration comes in a different shape. Some configurat
 | `uploadIntervalInSec` | `flushIntervalMillis` is in milliseconds while `uploadIntervalInSec` is in seconds|
 | `minIdLength` | `minIdLength` |
 | `requestTimeoutMillis` | Not supported |
-| `onRetry` | CUSTOMIZATION NOT SUPPORT. Retry logic is handled by the latest Node.js SDK |
+| `onRetry` | Not supported. Retry logic is handled internally by the latest Node.js SDK |
 
 ### Tracking events
 

--- a/docs/data/sdks/typescript-node/migration.md
+++ b/docs/data/sdks/typescript-node/migration.md
@@ -14,12 +14,13 @@ To migrate to `@amplitude/analytics-node`, update your dependencies and instrume
 
 ## Dependency
 
-Uninstall `@amplitude/node` by either `npm uninstall @amplitude/analytics-node` or deleting your dependency list in package.json
+Update package.json to uninstall the maintennace Node.js SDK and install the latest Node.js SDK.
 
 ```diff
 {
     "dependencies": {
--    "@amplitude/node": "^1",
+-    "@amplitude/node": "*",
++    "@amplitude/analytics-node": "^1",
     }
 }
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -458,7 +458,6 @@ nav:
       - Node.js:
         - data/sdks/typescript-node/index.md
         - Ampli Codegen: data/sdks/typescript-node/ampli.md
-        - Migration Guide: data/sdks/typescript-node/migration.md
       - Android:
         - data/sdks/android-kotlin/index.md
         - Ampli Codegen: data/sdks/android-kotlin/ampli.md
@@ -501,6 +500,7 @@ nav:
       - Node.js:
         - data/sdks/node/index.md
         - Ampli Codegen: data/sdks/node/ampli.md
+        - Migration Guide: data/sdks/typescript-node/migration.md
     - Other Topics:
       - Dynamic Configuration: data/dynamic-configuration.md
       - Plugins: data/sdk-plugins.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

https://pr-830.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-node/migration/

Maintenance Node.js has limited APIs so this migration is not too long. Let me know if there is anything is missing here.

## Change type

- [x] New documentation.

@amplitude-dev-docs
