### PR TITLE
AMP-78774 - carrier cannot be tracked

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -15,6 +15,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 --8<-- "includes/no-ampli.md"
     To use Ampli see the [non-Beta SDK](../../sdks/ios/) and [Ampli Wrapper](../../sdks/ios/ampli/) instead. For customers beginning with Amplitude Experiment, please note that this SDK does not support the [Amplitude Experiment integration](https://www.docs.developers.amplitude.com/experiment/sdks/ios-sdk/#initialize). 
 
+--8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#ios-beta) to get started with Amplitude iOS SDK.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -20,6 +20,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for iOS](./ampli.md).
 
+--8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#ios) to get started with Amplitude iOS SDK.

--- a/includes/sdk-ios/apple-deprecate-carrier.md
+++ b/includes/sdk-ios/apple-deprecate-carrier.md
@@ -1,0 +1,3 @@
+!!! failure "Carrier cannot be tracked in iOS 16+"
+    The SDK fetches carrier information by using `serviceSubscriberCellularProviders` and `CTCarrier` which are [deprecated](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024511-servicesubscribercellularprovide) with [no replacement](https://developer.apple.com/forums/thread/714876?answerId=728276022#728276022) starting from iOS 16. Amplitude will keep updated with Apple and re-enable carrier tracking as soon as Apple releases a replacement.
+


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

https://amplitude.atlassian.net/browse/AMP-78774

<img width="875" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/4d7f29dd-0703-4af4-aa66-15670a12d9fc">


## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
