### PR TITLE
fix: fix wrong link

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -752,7 +752,7 @@ For purchases on the Amazon store, you first need to set up Amazon as a data sou
     
 ## Troubleshooting and Debugging
 
---8<-- "includes/sdk-troubleshooting-and-debugging/latest-android.md"
+--8<-- "includes/sdk-troubleshooting-and-debugging/legacy-android.md"
 
 ## Advanced topics
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Put the latest-android link in legacy android. 
This is for updating the wrong link.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
