### PR TITLE
AMP-78975 [event streaming] braze identify forwarding update

### DIFF
--- a/docs/data/destinations/branch.md
+++ b/docs/data/destinations/branch.md
@@ -28,13 +28,6 @@ Enter your **Branch Key**.
 Under **Send Events**, make sure the toggle is enabled ("Events are sent to Branch") if you want to stream events to Branch. When enabled, events are automatically forwarded to Branch when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration. Events are sent to Branch as [Branch custom events](https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events#track-custom-events) and can have a maximum event name length of 40 characters.
 
 1. In **Select and filter events** choose which events you want to send. Choose only the events you need in Branch. _Transformed events aren't supported._
-
-    !!!warning "Events for anonymous users cannot be streamed"
-
-        Branch requires that all events have a user ID present. If you have selected any events to send to Branch that may not have a user ID, add a filter to send only events where the user ID is present. Otherwise, your delivery metrics may be affected.
-
-        ![Setting up a filter for anonymous users on events](/../assets/images/streaming-anonymous-users-filter.png)
-
 2. In **Map properties to destination**:
     _Transformed user properties aren't supported._
 
@@ -70,25 +63,25 @@ When satisfied with your configuration, at the top of the page toggle the **Stat
 
 ### Supported Branch properties
 
-- **Developer Identity**    
+- **Developer Identity**
 - **Browser Fingerprint ID**
-- **IDFA**              
-- **IDFV**              
-- **OS**                
-- **Android ID**        
-- **AAID**              
-- OS Version            
-- Environment           
-- User Agent            
-- HTTP Origin           
-- HTTP Referrer         
-- Country               
-- IP Address            
-- Language              
-- Device Brand          
-- Branch Device Token   
+- **IDFA**
+- **IDFV**
+- **OS**
+- **Android ID**
+- **AAID**
+- OS Version
+- Environment
+- User Agent
+- HTTP Origin
+- HTTP Referrer
+- Country
+- IP Address
+- Language
+- Device Brand
+- Branch Device Token
 - Downloaded App Version
-- Device Model          
-- Screen DPI            
-- Screen Height         
-- Screen Width          
+- Device Model
+- Screen DPI
+- Screen Height
+- Screen Width

--- a/docs/data/destinations/braze.md
+++ b/docs/data/destinations/braze.md
@@ -61,7 +61,7 @@ Under **Send Events**, make sure the toggle is enabled ("Events are sent to Braz
 
 ### Configure user forwarding
 !!!warning "Temporarily Disabled"
-    We're actively working on improving user forwarding to address concerns around high call volumes and to provide more functionality to customers. All existing active user forwarding syncs will continue to operate, but the ability to enable it on any sync configurations where it's not already enabled has been temporarily removed.
+    We're actively working on improving the experience of user forwarding to Braze, including addressing concerns around high call volumes which can incur additional costs in Braze. All enabled user forwarding syncs will continue to run. Temporarily, no new user forwarding syncs can be enabled. If an enabled user forwarding sync is disabled, it can not be re-enabled at this time. Event forwarding to Braze is unaffected by this and can still be configured as normal. User forwarding destinations other than Braze are also unaffected and can still be configured as normal.
 
 Under **Send Users**, make sure the toggle is enabled ("Users are sent to Braze") if you want to stream users and their properties to Braze. When enabled, users are automatically created or updated in Braze when an event is sent to Amplitude. [Amplitude Identify API](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/) calls are also forwarded to Braze. Users aren't sent on a schedule or on-demand using this integration.
 

--- a/docs/data/destinations/braze.md
+++ b/docs/data/destinations/braze.md
@@ -60,12 +60,14 @@ Under **Send Events**, make sure the toggle is enabled ("Events are sent to Braz
 2. (optional) In **Select additional properties**, select any more event and user properties you want to send to Braze. If you don't select any properties here, Amplitude doesn't send any. These properties are sent to Braze as [Braze custom event properties](https://www.braze.com/docs/user_guide/data_and_analytics/custom_data/custom_events/#custom-event-properties). _Transformed event properties and transformed user properties aren't supported._
 
 ### Configure user forwarding
+!!!warning "Temporarily Disabled"
+    We're actively working on improving user forwarding to address concerns around high call volumes and to provide more functionality to customers. All existing active user forwarding syncs will continue to operate, but the ability to enable it on any sync configurations where it's not already enabled has been temporarily removed.
 
 Under **Send Users**, make sure the toggle is enabled ("Users are sent to Braze") if you want to stream users and their properties to Braze. When enabled, users are automatically created or updated in Braze when an event is sent to Amplitude. [Amplitude Identify API](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/) calls are also forwarded to Braze. Users aren't sent on a schedule or on-demand using this integration.
 
 (optional) In **Select additional properties**, select any more user properties you want to send to Braze. If you don't select any properties here, Amplitude doesn't send any. These properties are sent to Braze as [Braze custom attributes](https://www.braze.com/docs/user_guide/data_and_analytics/custom_data/custom_attributes/). _Transformed user properties aren't supported._
 
-!!!warning "User Forwarding Volumes"
+!!!note "User Forwarding Volumes"
     When Send Users is enabled, all [Amplitude Identify calls](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/) and event calls that update user properties will trigger a call to be sent to Braze, even if the updated property isn't selected in **Select additional properties**. This may result in high volumes of calls and properties received by Braze. Every included property will count against your Braze data points. Check your Braze account for the charges associated with the volume of calls and properties expected.
 
 ### Enable sync


### PR DESCRIPTION
# Amplitude Developer Docs PR
We are temporarily disabling braze identify forwarding for syncs where it is not currently enabled.


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
