### PR TITLE
Add docs for Browser SDK plugin.teardown interface

### DIFF
--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -5,7 +5,7 @@ icon: simple/javascript
 ---
 
 
-![npm version](https://img.shields.io/npm/v/@amplitude/analytics-browser/latest)
+![npm version](https://img.shields.io/npm/v/@amplitude/analytics-browser/v1)
 
 The Browser SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
 

--- a/includes/data-sources-sdks-client-side.md
+++ b/includes/data-sources-sdks-client-side.md
@@ -3,7 +3,7 @@
 <div class="grid cards" markdown>
 
 - :android: [Android](/data/sdks/android-kotlin/)
-- :javascript-color: [Browser](/data/sdks/typescript-browser/)
+- :javascript-color: [Browser](/data/sdks/browser-2/)
 - :javascript-color: [Marketing Analytics Browser](/data/sdks/marketing-analytics-browser/)
 - :material-apple-ios: [iOS Swift (Beta)](/data/sdks/ios-swift/)
 - :material-apple-ios: [iOS](/data/sdks/ios/)

--- a/includes/sdk-ts-browser/shared-plugin-2-properties.md
+++ b/includes/sdk-ts-browser/shared-plugin-2-properties.md
@@ -15,3 +15,7 @@ The setup function is an optional method and is called when the plugin is added 
 For encrichment plugins, execute function is an optional method and is called on each event. This function must return a new event, otherwise the passed event is dropped from the queue. This is useful to for cases where you need to add/remove properties from events, filter events, or perform any operation for each event tracked.
 
 For destination plugins, execute function is a required method and is called on each event. This function must return a response object with keys: `event` (BaseEvent), `code` (number), and `message` (string). This is useful to for sending events for third-party endpoints.
+
+##### plugin.teardown() [optional]
+
+The teardown function is an optional method and is called when Amplitude re-initializes. This is useful for resetting unneeded persistent state created/set by setup or execute methods. Examples include, removing event listerners, mutation observers, etc.

--- a/includes/sdk-ts-browser/shared-plugins-2.md
+++ b/includes/sdk-ts-browser/shared-plugins-2.md
@@ -1,4 +1,4 @@
-Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying event properties (enrichment plugin) or sending to a third-party endpoints (destination plugin). A plugin is an `Object` with optional fields `name` and `type` and methods `setup()` and `execute()`.
+Plugins allow you to extend Amplitude SDK's behavior by, for example, modifying event properties (enrichment plugin) or sending to a third-party endpoints (destination plugin). A plugin is an `Object` with optional fields `name` and `type` and methods `setup()`, `execute()` and `teardown()`.
 
 #### `add`
 
@@ -40,7 +40,7 @@ const enrichPageUrlPlugin = (): EnrichmentPlugin => {
 }
 
 amplitude.init(API_KEY);
-amplitude.add(addEventIdPlugin());
+amplitude.add(enrichPageUrlPlugin());
 ```
 
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add docs for Browser SDK plugin.teardown interface

![Screenshot 2023-06-30 at 3 58 23 PM](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/20634289/e068f0f2-c1c2-42e6-8fcf-98d977d6cb20)

* https://pr-842.d19s7xzcva2mw3.amplifyapp.com/data/sdks/browser-2/#create-your-custom-plugin
* https://pr-842.d19s7xzcva2mw3.amplifyapp.com/data/sdks/browser-2/migration/#simplified-plugin-interface

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
