### PR TITLE
AMP-78233 - move migration docs under maintenance SDKs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -450,25 +450,23 @@ nav:
         - v2.0:
           - data/sdks/browser-2/index.md
           - Ampli Codegen: data/sdks/browser-2/ampli.md
-          - Migration Guide: data/sdks/browser-2/migration.md
         - v1.0:
           - data/sdks/typescript-browser/index.md
           - Marketing Analytics Browser: data/sdks/marketing-analytics-browser/index.md
           - Ampli Codegen: data/sdks/typescript-browser/ampli.md
-          - Migration Guide: data/sdks/typescript-browser/migration.md
+          - Migration Guide: data/sdks/browser-2/migration.md
       - Node.js:
         - data/sdks/typescript-node/index.md
         - Ampli Codegen: data/sdks/typescript-node/ampli.md
       - Android:
         - data/sdks/android-kotlin/index.md
         - Ampli Codegen: data/sdks/android-kotlin/ampli.md
-        - Migration Guide: data/sdks/android-kotlin/migration.md
       - iOS:
         - data/sdks/ios/index.md
         - Ampli Codegen: data/sdks/ios/ampli.md
+        - Migration Guide: data/sdks/ios-swift/migration.md
       - iOS (Beta):
         - data/sdks/ios-swift/index.md
-        - Migration Guide: data/sdks/ios-swift/migration.md
       - Java:
         - data/sdks/java/index.md
         - Ampli Codegen: data/sdks/java/ampli.md
@@ -491,9 +489,11 @@ nav:
       - Browser:
         - data/sdks/javascript/index.md
         - Ampli Codegen: data/sdks/javascript/ampli.md
+        - Migration Guide: data/sdks/typescript-browser/migration.md
       - Android:
         - data/sdks/android/index.md
         - Ampli Codegen: data/sdks/android/ampli.md
+        - Migration Guide: data/sdks/android-kotlin/migration.md
       - React Native:
         - data/sdks/react-native/index.md
         - Ampli Codegen: data/sdks/react-native/ampli.md


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Move:
- Browser V1 to V2 migration doc under Browser V1 (currently under V2)
- Browser JS to V1 migration doc under JS (currently under V1)
- Maintenance Android to Kotlin migration doc under maintenance Android (currently under Kotlin)
- iOS to Swift migration doc under iOS (currently under Swift)

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
