### PR TITLE
Fix: Android session tracking config

### DIFF
--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -168,8 +168,8 @@ Accurate session tracking requires that you enable `enableForegroundTracking(ge
     | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
     | `optOut` | Opt the user out of tracking. | `false` |
     | `trackingSessionEvents` | Automatic tracking of "Start Session" and "End Session" events that count toward event volume. | `false` |
-    | `sessionTimeoutMillis` | The amount of time for session timeout if enable foreground tracking. | `1800000` |
-    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if disable foreground tracking. | `300000` |
+    | `sessionTimeoutMillis` | The amount of time for session timeout if disable foreground tracking. Foreground tracking is disabled by default. | `1800000` |
+    | `minTimeBetweenSessionsMillis` | The amount of time for session timeout if enable foreground tracking by `enableForegroundTracking()` | `300000` |
     | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/` |
     | `useDynamicConfig` |  Find the best server url automatically based on users' geo location. | `false` |
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Descriptions of the two configs should be reversed according to the code 
https://github.com/amplitude/Amplitude-Android/blob/d950578798ca66939fead51e7698c00f9c9f9b00/src/main/java/com/amplitude/api/AmplitudeClient.java#L1531

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
