### PR TITLE
AMP-79700 add more instruction of creating external id for s3 import

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -70,7 +70,7 @@ When your dataset is ready for ingestion, you can set up Amazon S3 Import in Amp
 Follow these steps to give Amplitude read access to your AWS S3 bucket.
 
 1. Create a new IAM role, for example: `AmplitudeReadRole`.
-2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy to allow Amplitude to assume the role. Using the following example, and update **{{}}** in highlighted text. 
+2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy to allow Amplitude to assume the role using the following example. Please update **{{}}** in highlighted text. 
 
     - **{{amplitude_account}}**: `358203115967` for Amplitude US data center. `202493300829` for Amplitude EU data center. 
     - **{{external_id}}**: unique identifiers used when Amplitude assumes the role. You can generate it with help from [third party tools](https://www.uuidgenerator.net/). Example external id can be `vzup2dfp-5gj9-8gxh-5294-sd9wsncks7dc`.

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -160,7 +160,7 @@ In Amplitude, create the S3 Import source.
 To create the data source in Amplitude, gather information about your S3 bucket:
 
 - IAM role ARN: The IAM role that Amplitude uses to access your S3 bucket. This is the role created in [Give Amplitude access to your S3 bucket](#give-amplitude-access-to-your-s3-bucket).
-- IAM role external id: The external id for the IAM role that Amplitude uses to access your S3 bucket.
+- IAM role external id: The external id for the IAM role that Amplitude uses to access your S3 bucket. This is the external id created in [Give Amplitude access to your S3 bucket](#give-amplitude-access-to-your-s3-bucket).
 - S3 bucket name: The name of the S3 bucket with your data.
 - S3 bucket prefix: The S3 folder with your data.
 - S3 bucket region: The region where S3 bucket was created.

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -244,6 +244,7 @@ After you have added all the fields you wish to bring into Amplitude, you can vi
 
 !!!note
     The group properties import feature requires that groups are set in the [HTTP API event format](../../analytics/apis/http-v2-api.md). The converter expects a `groups` object and a `group_properties` object.
+
 ### Manual converter creation
 
 The converter file tells Amplitude how to process the ingested files. Create it in two steps: first, configure the compression type, file name, and escape characters for your files.

--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -70,10 +70,10 @@ When your dataset is ready for ingestion, you can set up Amazon S3 Import in Amp
 Follow these steps to give Amplitude read access to your AWS S3 bucket.
 
 1. Create a new IAM role, for example: `AmplitudeReadRole`.
-2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy, using the following example. Update **{{}}** in highlighted text. 
+2. Go to **Trust Relationships** for the role and add Amplitude’s account to the trust relationship policy to allow Amplitude to assume the role. Using the following example, and update **{{}}** in highlighted text. 
 
     - **{{amplitude_account}}**: `358203115967` for Amplitude US data center. `202493300829` for Amplitude EU data center. 
-    - **{{external_id}}**: unique identifiers used when assuming roles. Example can be `vzup2dfp-5gj9-8gxh-5294-sd9wsncks7dc`.
+    - **{{external_id}}**: unique identifiers used when Amplitude assumes the role. You can generate it with help from [third party tools](https://www.uuidgenerator.net/). Example external id can be `vzup2dfp-5gj9-8gxh-5294-sd9wsncks7dc`.
 
     ``` json hl_lines="7 12"
     {


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

add more instruction of creating external id for s3 import. Related issue [AMP-79700](https://amplitude.atlassian.net/browse/AMP-79700)

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[AMP-79700]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[AMP-79700]: https://amplitude.atlassian.net/browse/AMP-79700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ