### PR TITLE
AMP-78233-add-links-to-migration-docs

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -16,6 +16,9 @@ The Kotlin Android SDK lets you send events to Amplitude. This library is open-s
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Android](./ampli.md).
 
+--8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
+    [Android SDK Migration Guide](/data/sdks/android-kotlin/migration/).
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started with Amplitude Android Kotlin SDK.

--- a/docs/data/sdks/browser-2/index.md
+++ b/docs/data/sdks/browser-2/index.md
@@ -15,6 +15,9 @@ The Browser SDK lets you send events to Amplitude. This library is open-source, 
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Browser](./ampli.md).
 
+!!!note "Migration guide"
+    This is the documentation for the Amplitude Browser SDK 2.0. If you are using the Browser SDK 1.0, refer to the migration documentation: [Browser SDK 2.0 Migration Guide](/data/sdks/browser-2/migration/). If you are using the maintenance SDK, refer to the migration documentation: [Browser SDK Migration Guide](/data/sdks/typescript-browser/migration/).
+
 ## Getting started
 
 Use [this quickstart guide](../sdk-quickstart#browser) to get started with Amplitude Browser SDK.

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -15,6 +15,8 @@ The Browser SDK lets you send events to Amplitude. This library is open-source, 
 !!!info "Browser SDK 2.0 is now available"
     An improved version of Amplitude Browser SDK is now available. Amplitude Browser SDK 2.0 features default event tracking, improved marketing attribution tracking, simplified interface and a lighter weight package. Amplitude recommends the Browser SDK 2.0 for both product analytics and marketing analytics use cases. Upgrade to the latest [Browser SDK 2.0](../browser-2/index.md). See the [Migration Guide](../browser-2/migration.md) for more help.
 
+--8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
+    [Browser SDK Migration Guide](/data/sdks/typescript-browser/migration/).
 
 !!!note "Browser SDK versus the Marketing Analytics Browser"
     Amplitude recommends the Browser SDK for most users. You can extend its functionality using plugins.

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -16,6 +16,9 @@ The Node.js SDK lets you send events to Amplitude. This library is open-source, 
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Node](../typescript-node/ampli.md).
 
+--8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
+    [Node.JS SDK Migration Guide](/data/sdks/typescript-node/migration/).
+
 ## Getting started
 
 Use [this quickstart guide](../sdk-quickstart#node) to get started with Amplitude Node SDK.

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -14,6 +14,9 @@ The React Native SDK lets you send events to Amplitude. This library is open-sou
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for React Native](../typescript-react-native/ampli.md).
 
+--8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
+    [React Native SDK Migration Guide](/data/sdks/typescript-react-native/migration/).
+
 ## Getting started
 
 ### Installation

--- a/includes/sdk-migration/admonition-link-to-migration-docs.md
+++ b/includes/sdk-migration/admonition-link-to-migration-docs.md
@@ -1,0 +1,2 @@
+!!!note "Migration guide"
+    This is the documentation for the latest Amplitude SDK. If you are using the maintenance SDK, refer to the migration documentation: 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

As described in https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/pull/845#pullrequestreview-1516861426, add an admonition for each latest SDK with an link to the migration doc

<img width="646" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/c1c3b597-ab1e-410a-9ce9-443ae8e1a70f">

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
