### PR TITLE
Remove unnecessary statement in Session tracking

### DIFF
--- a/docs/data/sdks/browser-2/index.md
+++ b/docs/data/sdks/browser-2/index.md
@@ -244,8 +244,6 @@ amplitude.init(API_KEY, {
 
 #### Tracking sessions
 
-Amplitude tracks session events by default. The default behavior sends a page view event on initialization. The event type for this event is "[Amplitude] Page Viewed".
-
 Amplitude tracks session events by default. A session is the period of time a user has your website open. See [How Amplitude defines sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions-in-Amplitude#how-amplitude-defines-sessions) for more information. When a new session starts, Amplitude tracks a session start event and is the first event of the session. The event type for session start is "[Amplitude] Start Session". When an existing session ends, a session end is tracked and is the last event of the session. The event type for session end is "[Amplitude] End Session".
 
 You can opt out of session tracking by setting `config.defaultTracking.sessions` to `false`. Refer to the code sample below.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Looks like a copy pasta error duplicating info from the page views section. In the context of session tracking this first section removed is confusing.

## Deadline

Now


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
