### PR TITLE
fix mkdocs version to 1.4.3 to avoid build failure caused by 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 mkdocs-material==8.5.10
 jinja2>=3.0.2
 markdown>=3.2
-mkdocs>=1.4.0
+mkdocs==1.4.3
 mkdocs-material-extensions>=1.1
 pygments>=2.12
 pymdown-extensions==9.9.2


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Describe your changes. 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
