### PR TITLE
feat: add swift example for legacy ios sdk

### DIFF
--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -955,6 +955,14 @@ Before initializing the SDK with your `apiKey`, create a `AMPTrackingOptions` 
     [[Amplitude instance] setTrackingOptions:options];
     ```
 
+=== "Swift"
+
+    ```swift
+    let trackingOptions = AMPTrackingOptions().disableCity()
+                                              .disableCarrier();
+    Amplitude.instance().setTrackingOptions(trackingOptions!);
+    ```
+
 Tracking for each field can be individually controlled, and has a corresponding method (for example, `disableCountry`, `disableLanguage`).
 
 | <div class="big-column">Method</div> | Description |


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Customer asked about how to use swift to setTrackingOptions in legacy ios sdk.
https://github.com/amplitude/Amplitude-iOS/issues/459

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
