### PR TITLE
remove Intercom source upgrade info for now

### DIFF
--- a/docs/data/sources/intercom.md
+++ b/docs/data/sources/intercom.md
@@ -58,25 +58,3 @@ To disconnect the Intercom integration, navigate to this URL, replacing `**your_
 `https://app.intercom.com/a/apps/**your_Intercom_app_id**/appstore?app_package_code=amplitude&installed=true`
 
 This is the only way to stop the flow of events from Intercom to Amplitude, and it's controlled from the Intercom side of the integration.
-
-## Intercom source upgrade
-
-On April 17, 2023, there will be a change to events imported into Amplitude from Intercom. This is an upgrade that imports more event types, and will also result in a change to some event names. Customers who set up their Intercom source before April 17, 2023 should use the following information to make changes to their charts and workflows where necessary.
-
-### Changed event names
-
-| Changed Event Names | Description                  | New Event Name           |
-|---------------------|------------------------------|--------------------------|
-| contact.signed_up   | Lead signs up                | contact.lead.signed_up   |
-| contact.created     | Lead created                 | contact.lead.created     |
-| contact.added_email | Lead added email             | contact.lead.added_email |
-| contact.tag.created | Lead tagged                  | contact.lead.tag.created |
-| contact.tag.deleted | Lead untagged                | contact.lead.tag.deleted |
-| user.created        | User created                 | contact.user.created     |
-| user.deleted        | User deleted                 | contact.deleted          |
-| user.unsubscribed   | User unsubscribed from email | contact.unsubscribed     |
-| user.email.updated  | User email updated           | contact.email.updated    |
-| user.tag.created    | User tagged                  | contact.user.tag.created |
-| user.tag.deleted    | User untagged                | contact.user.tag.deleted |
-
-See a full list of events that will be imported in the [Intercom documentation](https://developers.intercom.com/intercom-api-reference/reference/webhook-models-1).


### PR DESCRIPTION
# Amplitude Developer Docs PR
This project has been delayed so we should not have it in the docs as it's confusing to users

## Description

Removed section on integration upgrade that was supposed to happen but hasn't happened yet.

## Deadline

When do these changes need to be live on the site?
asap

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
