### PR TITLE
update site URL to match redirect target URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: Amplitude Developer Center
-site_url: https://docs.developers.amplitude.com
+site_url: https://www.docs.developers.amplitude.com
 site_author: Amplitude
 site_description: >-
     Developer resources for Amplitude's digital analytics platform.


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

In Amplify, we redirect `docs.developers.amplitude.com` to `www.docs.developers.amplitude.com`. This causes an issue with our canonical 
tags where the tag uses a base url of `docs.developers.amplitude.com` with the page residing at `www.docs.developers.amplitude.com`.

Google calls this "Alternate page with proper canonical tag" and does not index pages where this is an issue.

This PR updates the base URL of the site to include the `www`, which should cause the canonical tags to match the actual site URL.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [x] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
