### PR TITLE
AMP-82079 Update S3 import IAM Policy

### DIFF
--- a/docs/data/sources/amazon-s3.md
+++ b/docs/data/sources/amazon-s3.md
@@ -98,9 +98,58 @@ Follow these steps to give Amplitude read access to your AWS S3 bucket.
 3. Create a new IAM policy, for example, `AmplitudeS3ReadOnlyAccess`. Use the entire example code that follows, but be sure to update **{{}}** in highlighted text.
 
     - **{{bucket_name}}**: the s3 bucket name where your data is imported from.
-    - **{{prefix}}**: the prefix of files that you want to import, for example `/prefix`. For folders, make sure prefix ends with `/`. But for root folder, keep prefix as empty.
+    - **{{prefix}}**: the optional prefix of files that you want to import, for example `filePrefix`. For folders, make sure prefix ends with `/`, for example `folder/`. For the root folder, keep prefix as empty.
 
-    ```json hl_lines="16 30 41"
+    Example 1: IAM policy without prefix:
+    ```json hl_lines="16 29 40"
+    {
+      "Version":"2012-10-17",
+      "Statement":[
+        {
+          "Sid":"AllowListingOfDataFolder",
+          "Action":[
+            "s3:ListBucket"
+          ],
+          "Effect":"Allow",
+          "Resource":[
+            "arn:aws:s3:::{{bucket_name}}"
+          ],
+          "Condition":{
+            "StringLike":{
+              "s3:prefix":[
+                "*"
+              ]
+            }
+          }
+        },
+        {
+          "Sid":"AllowAllS3ReadActionsInDataFolder",
+          "Effect":"Allow",
+          "Action":[
+            "s3:GetObject",
+            "s3:ListObjects"
+          ],
+          "Resource":[
+            "arn:aws:s3:::{{bucket_name}}/*"
+          ]
+        },
+        {
+          "Sid":"AllowUpdateS3EventNotification",
+          "Effect":"Allow",
+          "Action":[
+            "s3:PutBucketNotification",
+            "s3:GetBucketNotification"
+          ],
+          "Resource":[
+            "arn:aws:s3:::{{bucket_name}}"
+          ]
+        }
+      ]
+    }
+    ```
+  
+    Example 2: IAM policy with a prefix. For a folder, make sure the prefix ends with `/`, for example `folder/`:
+    ```json hl_lines="16 29 40"
     {
       "Version":"2012-10-17",
       "Statement":[
@@ -129,7 +178,7 @@ Follow these steps to give Amplitude read access to your AWS S3 bucket.
             "s3:ListObjects"
           ],
           "Resource":[
-            "arn:aws:s3:::{{bucket_name}}{{prefix}}*"
+            "arn:aws:s3:::{{bucket_name}}/{{prefix}}*"
           ]
         },
         {


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

The original IAM policy is not only error prone but also wrong. It took me a while to figure out the correct IAM policy, hence I added two examples to the dev doc here for the two common cases:
1. IAM policy for a root folder/ no need for a prefix
2. IAM policy with a prefix

These policy have been tested.

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes AMP-82079
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs
