### PR TITLE
AMP-82699: add datalayer message warning to client gtm docs

### DIFF
--- a/docs/data/sources/google-tag-manager-client.md
+++ b/docs/data/sources/google-tag-manager-client.md
@@ -13,8 +13,10 @@ This is the client-side Google Tag Manager Template for Amplitude Analytics. The
  
     While this updated template offers additional features and improvements,it may result in slightly different behavior that could potentially affect your existing analytics charts. However, we've made these changes configurable to maintain consistency. If you wish to retain the legacy behavior, it's essential to review the following [list of breaking changes](./#breaking-changes-checklist) and adjust your configuration accordingly.
 
+--8<-- "includes/gtm/data-layer-messages-warning.md"
+
 !!!warning
-    Due to inherent limitations of GTM, certain features, such as plugins, are not well supported in this GTM template. You are still able to add plugins using the Custom HTML tag, but because of how the SDK gets loaded in GTM, this could lead to missing data.
+    Due to inherent limitations of GTM, certain features, such as plugins, are not supported in this GTM template. You are still able to add plugins using the Custom HTML tag, but because of how the SDK gets loaded in GTM, this could lead to missing data.
 
 !!!note
     Ensure to consistently update your Amplitude GTM template to the latest version for an enhanced feature set, crucial bug fixes, and a significantly improved user experience.
@@ -368,4 +370,3 @@ The new template changes the way to parse the device related info which might ef
     | <div class="big-column">Before</div>  | Current |
     | --- | --- | --- | --- |
     | [Client-side user agent parsing](https://github.com/amplitude/ua-parser-js).  | Server-side user agent parsing by Amplitude ingestion endpoints. |
-    

--- a/docs/data/sources/google-tag-manager/index.md
+++ b/docs/data/sources/google-tag-manager/index.md
@@ -25,9 +25,7 @@ Amplitude GTM templates are custom templates which define tags and variables so 
 
 Google tags are snippets of code that measure user activity such as time on page, clicks, and purchases.
 
-!!! warning "Messages are queued"
-
-    To enforce the processing order of messages pushed to the data layer, add an event name to a message as it is pushed to the data layer, and then listen for that event name with a Custom Event trigger. Learn more about [how Google processes data layer information](https://developers.google.com/tag-platform/devguides/datalayer?hl=en#how_data_layer_information_is_processed).
+--8<-- "includes/gtm/data-layer-messages-warning.md"
 
 ### Server Container
 

--- a/docs/data/sources/google-tag-manager/index.md
+++ b/docs/data/sources/google-tag-manager/index.md
@@ -25,7 +25,7 @@ Amplitude GTM templates are custom templates which define tags and variables so 
 
 Google tags are snippets of code that measure user activity such as time on page, clicks, and purchases.
 
---8<-- "includes/gtm/data-layer-messages-warning.md"
+Learn more about the [client-side container](/data/sources/google-tag-manager-client).
 
 ### Server Container
 
@@ -34,6 +34,8 @@ Google tags are snippets of code that measure user activity such as time on page
 Client-side container communicates with the server-side container through HTTP requests with the standardized **Event Data** format.
 
 The client container might be also required because it needs to parse an incoming HTTP request and generate an event data object for tags to utilize.
+
+Learn more about the [service-side container](/data/sources/google-tag-manager-server).
 
 ## Client-side vs server-side
 

--- a/includes/gtm/data-layer-messages-warning.md
+++ b/includes/gtm/data-layer-messages-warning.md
@@ -1,0 +1,3 @@
+!!! warning "Messages are queued"
+
+    To enforce the processing order of messages pushed to the data layer, add an event name to a message as it is pushed to the data layer, and then listen for that event name with a Custom Event trigger. Learn more about [how Google processes data layer information](https://developers.google.com/tag-platform/devguides/datalayer?hl=en#how_data_layer_information_is_processed).


### PR DESCRIPTION
## Description

* add datalayer message warning to client gtm docs

<img width="727" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/5790872/0658a292-d6db-4027-8c63-119dfa0bb364">
