### PR TITLE
Experiment Python SDK - auto assignment tracking

### DIFF
--- a/docs/experiment/sdks/nodejs-sdk.md
+++ b/docs/experiment/sdks/nodejs-sdk.md
@@ -220,7 +220,7 @@ initializeLocal(apiKey: string, config?: LocalEvaluationConfig): LocalEvaluation
 | `config` | optional | The client [configuration](#configuration) used to customize SDK client behavior. |
 
 !!!tip "Flag Polling Interval"
-    Use the `flagConfigPollingIntervalMillis` [configuration](#configuration-1) to determine the time flag configs take to update once modified (default 30s).
+    Use the `flagConfigPollingIntervalMillis` [configuration](#configuration_1) to determine the time flag configs take to update once modified (default 30s).
 
 #### Configuration
 
@@ -268,7 +268,7 @@ await experiment.start();
 Executes the [evaluation logic](../general/evaluation/implementation.md) using the flags pre-fetched on [`start()`](#start). You must give evaluate a user object argument. You can optionally pass an array of flag keys if you require only a specific subset of required flag variants.
 
 !!!tip "Automatic Assignment Tracking"
-    Set [`assignmentConfig`](#configuration-1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
+    Set [`assignmentConfig`](#configuration_1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
 
 ```js
 evaluate(user: ExperimentUser, flagKeys?: string[]): Promise<Variants>

--- a/docs/experiment/sdks/python-sdk.md
+++ b/docs/experiment/sdks/python-sdk.md
@@ -247,12 +247,24 @@ Experiment.initialize_local(api_key, config = None) : LocalEvaluationClient
 You can configure the SDK client on initialization.
 
 ???config "Configuration Options"
+
+    **LocalEvaluationConfig**
+
     | <div class="big-column">Name</div> | Description | Default Value |
     | --- | --- | --- |
     | `debug` | Set to `true` to enable debug logging. | `false` |
     | `server_url` | The host to fetch flag configurations from. | `https://api.lab.amplitude.com` |
     | `flag_config_polling_interval_millis` | The interval to poll for updated flag configs after calling [`start()`](#start) | `30000` |
     | `flag_config_poller_request_timeout_millis` | The timeout for the request made by the flag config poller | `10000` |
+    | `assignment_config` | Configuration for automatically tracking assignment events after an evaluation. | `None` |
+
+    **AssignmentConfig**
+
+    | <div class="big-column">Name</div> | Description | Default Value |
+    | --- | --- | --- |
+    | `api_key` | The analytics API key and NOT the experiment deployment key | *required* |
+    | `cache_capacity` | The maximum number of assignments stored in the assignment cache | `65536` |
+    | [Analytics SDK Options](../../data/sdks/typescript-node/index.md#configuration) | Options to configure the underlying Amplitude Analytics SDK used to track assignment events |  |
 
 !!!info "EU Data Center"
     If you're using Amplitude's EU data center, configure the `serverUrl` option on initialization to `https://api.lab.eu.amplitude.com`
@@ -274,6 +286,9 @@ experiment.start()
 ### Evaluate
 
 Executes the [evaluation logic](../general/evaluation/implementation.md) using the flags pre-fetched on [`start()`](#start). Evaluate must be given a user object argument and can optionally be passed an array of flag keys if only a specific subset of required flag variants are required.
+
+!!!tip "Automatic Assignment Tracking"
+    Set [`assignment_config`](#configuration_1) to automatically track an assignment event to Amplitude when `evaluate()` is called.
 
 ```go
 evaluate(self, user: User, flag_keys: List[str]) : Dict[str, Variant]


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Experiment Python SDK - auto assignment tracking


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [X] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [X] My documentation follows the style guidelines of this project.
- [X] I previewed my documentation on a local server using `mkdocs serve`.
- [X] Running `mkdocs serve` didn't generate any failures.
- [X] I have performed a self-review of my own documentation.


@amplitude-dev-docs
