### PR TITLE
feat: AMP-82725 TS RN doc updates for GA

### DIFF
--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -8,10 +8,10 @@ search:
 
 ![npm version](https://img.shields.io/npm/v/@amplitude/analytics-node)
 
-The Node.js SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
+The Node.js SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/v1.x/packages/analytics-node).
 
 !!!info "Node SDK Resources"
-    [:material-github: GitHub](https://amplitude.github.io/Amplitude-TypeScript) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
+    [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/v1.x/packages/analytics-node) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases?q=analytics-node&expanded=true) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
 
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Node](../typescript-node/ampli.md).

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -657,9 +657,18 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 
 ### Location
 
-The SDK will set the `country` based on network information. However, to remove permissions from the SDK that may not be required for all customers, we extracted precise location support from the core SDK. To use location you will now need to create an enrichment Plugin to set the location yourself. 
+The Amplitude ingestion servers resolve event location in the following order:
 
-Here is an [example](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/examples/plugins/react-native-get-location-plugin/LocationPlugin.ts) of how to set `location_lat` and `location_lng` for more granular location tracking.
+1. User-provided `city`, `country`, `region`
+2. Resolved from `location_lat` and `location_lng`
+3. Resolved from `ip`
+
+By default, location will be determined by the `ip` on the server side. If you want more provide more granular location you can set `city`, `country` and `region` individually, or set `location_lat` and `location_lng` which will then be resolved to `city`, `country` and `region` on the server. 
+We do not automatically set precise location in the SDK to avoid extra permissions that my not be needed by all customers.
+
+To set fine grain location, you can use an enrichment Plugin. Here is an [example](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/examples/plugins/react-native-get-location-plugin/LocationPlugin.ts) of how to set `location_lat` and `location_lng`.
+
+Note that disabling IP tracking via `ipTracking: false` in [TrackingOptions](/data/sdks/typescript-react-native/#optional-tracking) will prevent location from being resolved on the backend. In this case you may want to create a Plugin like above to set any relevant location information yourself.
 
 ### Carrier
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -655,6 +655,16 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
+## Location
+
+The SDK will set the `country` based on network information. However, to remove permissions from the SDK that may not be required for all customers, we extracted precise location support from the core SDK. To use location you will now need to create an enrichment Plugin to set the location yourself. 
+
+Here is an [example](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/examples/plugins/react-native-get-location-plugin/LocationPlugin.ts) of how to set `location_lat` and `location_lng` for more granular location tracking.
+
+## Carrier
+
+Carrier support works on Android, but Apple stopped supporting it in iOS 16. In earlier versions of iOS, we fetch carrier info using `CTCarrier` and `serviceSubscriberCellularProviders` which are [deprecated](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024511-servicesubscribercellularprovide) with [no replacement](https://developer.apple.com/forums/thread/714876?answerId=728276022#728276022).
+
 ### Advertising Identifiers
 
 Different platforms have different advertising identifiers. Due to user privacy concerns, Amplitude does not automatically collect these identifiers. However, it is easy to enable them using the instructions below. It is important to note that some identifiers are no longer recommended for use by the platform providers. Please read the notes below before deciding to enable them.

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -85,6 +85,7 @@ init(API_KEY, 'user@amplitude.com', {
 --8<-- "includes/sdk-ts-browser/shared-configurations.md"
     |`storageProvider`| `Storage<Event[]>`. Implements a custom `storageProvider` class from Storage. | `MemoryStorage` |
     |`trackingSessionEvents`| `boolean`. Whether to automatically log start and end session events corresponding to the start and end of a user's session. | `false` |
+    |`migrateLegacyData`| `boolean`. Available in `1.3.4`+. Whether to migrate [maintenance SDK](../react-native) data (events, user/device ID). | `true` |
 
 --8<-- "includes/sdk-ts/shared-batch-configuration.md"
 

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -6,10 +6,10 @@ icon: simple/react
 
 ![npm version](https://img.shields.io/npm/v/@amplitude/analytics-react-native)
 
-The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native).
+The React Native SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/v1.x/packages/analytics-react-native).
 
 !!!info "React Native SDK Resources"
-    [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/main/packages/analytics-react-native) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
+    [:material-github: GitHub](https://github.com/amplitude/Amplitude-TypeScript/tree/v1.x/packages/analytics-react-native) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-TypeScript/releases?q=analytics-react-native&expanded=true) · [:material-book: API Reference](https://amplitude.github.io/Amplitude-TypeScript/)
 
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for React Native](../typescript-react-native/ampli.md).

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -655,13 +655,13 @@ amplitude.init(API_KEY, OPTIONAL_USER_ID, {
 });
 ```
 
-## Location
+### Location
 
 The SDK will set the `country` based on network information. However, to remove permissions from the SDK that may not be required for all customers, we extracted precise location support from the core SDK. To use location you will now need to create an enrichment Plugin to set the location yourself. 
 
 Here is an [example](https://github.com/amplitude/Amplitude-TypeScript/blob/v1.x/examples/plugins/react-native-get-location-plugin/LocationPlugin.ts) of how to set `location_lat` and `location_lng` for more granular location tracking.
 
-## Carrier
+### Carrier
 
 Carrier support works on Android, but Apple stopped supporting it in iOS 16. In earlier versions of iOS, we fetch carrier info using `CTCarrier` and `serviceSubscriberCellularProviders` which are [deprecated](https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/3024511-servicesubscribercellularprovide) with [no replacement](https://developer.apple.com/forums/thread/714876?answerId=728276022#728276022).
 

--- a/docs/data/sdks/typescript-react-native/migration.md
+++ b/docs/data/sdks/typescript-react-native/migration.md
@@ -258,3 +258,13 @@ The maintenance React Native SDK supports automatically log start and end events
 | Logger provider | Amplitude Logger. Fully customizable. | Depends on the native iOS, Android, Amplitude JavaScript logger provider. |
 | Customization | Plugins | Middleware |
 | Server Endpoint | HTTP V2 API |  HTTP V1 API |
+
+## Data migration
+
+Starting [v1.3.4](https://github.com/amplitude/Amplitude-TypeScript/releases/tag/%40amplitude%2Fanalytics-react-native%401.3.4), existing [maintenance SDK](../../react-native) data (events, user/device ID) are moved to the latest SDK by default. It can be disabled by setting `migrateLegacyData` to `false` in the [Configuration](../#configuration).
+
+```typescript
+init(API_KEY, OPTIONAL_USER_ID, {
+  migrateLegacyData: false,
+})
+```

--- a/docs/data/sdks/typescript-react-native/migration.md
+++ b/docs/data/sdks/typescript-react-native/migration.md
@@ -3,9 +3,9 @@ title: React Native SDK Migration Guide
 description: Use this guide to easily migrate from Amplitude's maintenance React Native SDK (@amplitude/react-native) to the latest SDK (@amplitude/analytics-react-native).
 ---
 
---8<-- "includes/sdk-missing-migration.md"
+Amplitude's latest React Native SDK (`@amplitude/analytics-react-native`) features a plugin architecture, built-in type definition and broader platform support.
 
-Amplitude's latest React Native SDK (`@amplitude/analytics-react-native`) features a plugin architecture, built-in type definition and broader platform support. Latest React Native SDK isn't backwards compatible with maintenance React Native SDK `@amplitude/react-native`. 
+The latest React Native SDK isn't fully backwards compatible with maintenance React Native SDK `@amplitude/react-native`. However, it will transfer user, device, and event data to the new SDK automatically in versions `v1.3.4` and above.
 
 To migrate to `@amplitude/analytics-react-native`, update your dependencies and instrumentation.
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

* https://pr-929.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-react-native/
* https://pr-929.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-react-native/migration/
* https://pr-929.d19s7xzcva2mw3.amplifyapp.com/data/sdks/typescript-node/

[AMP-82725](https://amplitude.atlassian.net/browse/AMP-82725) - React Native SDK (TS) doc updates for GA

## Description
* `migrateLegacyData` usage
* Location info
* Carrier info
* Fix repo links for `1.x` TS SDKs (RN + Node)

@amplitude-dev-docs


[AMP-82725]: https://amplitude.atlassian.net/browse/AMP-82725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ