### PR TITLE
Update typescript-react-native

### DIFF
--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -70,7 +70,7 @@ pod install
 ## Usage
 
 !!!info "Web vs Mobile"
-    The configuration of the SDK is shared across web and mobile platforms, but many of these options simply don't apply when running the SDK on native platforms (for example iOS, Android). For example, the when the SDK is run on web, the identity is stored in the browser cookie by default, whereas on native platforms identity is stored in async storage.
+    The configuration of the SDK is shared across web and mobile platforms, but many of these options simply don't apply when running the SDK on native platforms (for example iOS, Android). For example, when the SDK is run on web, the identity is stored in the browser cookie by default, whereas on native platforms identity is stored in async storage.
 
 ### Initialize the SDK
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Updating what looks like a copy error in the  [typescript-react-native](https://www.docs.developers.amplitude.com/data/sdks/typescript-react-native/#installation) section on the docs

**Updated box** 👇 
<img width="793" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/11654513/0ccbcdb7-eac4-4d31-9459-d175248f74b3">


## Deadline

N/A

## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [x] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
