### PR TITLE
SKY-3470 fix versioning in examples

### DIFF
--- a/docs/experiment/apis/management-api/deployments.md
+++ b/docs/experiment/apis/management-api/deployments.md
@@ -13,7 +13,7 @@ title: Management API Deployment Endpoints
 ## List deployments
 
 ```bash
-GET https://experiment.amplitude.com/deployments
+GET https://experiment.amplitude.com/api/1/deployments
 ```
 
 Fetch a list of deployments that experiments or flags can be assigned to.

--- a/docs/experiment/apis/management-api/experiments.md
+++ b/docs/experiment/apis/management-api/experiments.md
@@ -675,7 +675,7 @@ A successful request returns a `200 OK` response and `OK` text.
 ## Remove variant
 
 ```bash
-DELETE https://experiment.amplitude.com/experiments/{id}/variants/{variantKey}
+DELETE https://experiment.amplitude.com/api/1/experiments/{id}/variants/{variantKey}
 ```
 
 Remove a variant from an experiment.
@@ -1019,7 +1019,7 @@ A successful request returns a `200 OK` response.
 !!!example "Example cURL"
     ```bash
     curl --request PATCH \
-      --url 'https://experiment.amplitude.com/experiments/<id>' \
+      --url 'https://experiment.amplitude.com/api/1/experiments/<id>' \
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \
@@ -1031,7 +1031,7 @@ A successful request returns a `200 OK` response.
 ## Create
 
 ```bash
-POST https://experiment.amplitude.com/experiments
+POST https://experiment.amplitude.com/api/1/experiments
 ```
 
 Create a new experiment.
@@ -1150,7 +1150,7 @@ A successful request returns a `200 OK` response and a JSON object with the expe
 !!!example "Example cURL"
     ```bash
     curl --request POST \
-      --url 'https://experiment.amplitude.com/experiments/new' \
+      --url 'https://experiment.amplitude.com/api/1/experiments' \
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \

--- a/docs/experiment/apis/management-api/flags.md
+++ b/docs/experiment/apis/management-api/flags.md
@@ -638,7 +638,7 @@ A successful request returns a `200 OK` response and `OK` text.
 ## Remove variant
 
 ```bash
-DELETE https://experiment.amplitude.com/flags/{id}/variants/{variantKey}
+DELETE https://experiment.amplitude.com/api/1/flags/{id}/variants/{variantKey}
 ```
 
 Remove a variant from a flag.
@@ -942,7 +942,7 @@ A successful request returns a `200 OK` response.
 ## Create
 
 ```bash
-POST https://experiment.amplitude.com/flags
+POST https://experiment.amplitude.com/api/1/flags
 ```
 
 Create a new flag.
@@ -1055,7 +1055,7 @@ A successful request returns a `200 OK` response and a JSON object with the flag
 !!!example "Example cURL"
     ```bash
     curl --request POST \
-      --url 'https://experiment.amplitude.com/flags' \
+      --url 'https://experiment.amplitude.com/api/1/flags' \
       --header 'Content-Type: application/json' \
       --header 'Accept: application/json' \
       --header 'Authorization: Bearer <management-api-key>' \


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Fix bugs in examples.

## Deadline

When do these changes need to be live on the site?


## Change type

- [x] Doc bug fix. Fixes #[SKY-3470]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[SKY-3470]: https://amplitude.atlassian.net/browse/SKY-3470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ