### PR TITLE
fix: Java group and group property docs

### DIFF
--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -204,34 +204,34 @@ client.logEvent(event);
     If Joe is in 'orgId' '10', then the `groupName` would be '10':
 
     ```java
-    Event event = new Event("$identify", "test_user_id");
+    Event event = new Event("$identify");
 
-    JSONObject groupProps = new JSONObject();
+    JSONObject groups = new JSONObject();
     try {
-        groupProps.put("orgId", 10);
+        groups.put("orgId", 10);
     } catch (JSONException e) {
         e.printStackTrace();
         System.err.println("Invalid JSON");
     }
 
-    event.groupProperties = groupProps;
+    event.groups = groups;
     client.logEvent(event);
     ```
 
     If Joe is in 'sport' 'tennis' and 'soccer', then the `groupName` would be '["tennis", "soccer"]'.
 
     ```java
-    Event event = new Event("$identify", "test_user_id");
+    Event event = new Event("$identify");
 
-    JSONObject groupProps = new JSONObject();
+    JSONObject groups = new JSONObject();
     try {
-        groupProps.put("sport", new String[] {"tennis", "soccer"});
+        groups.put("sport", new String[] {"tennis", "soccer"});
     } catch (JSONException e) {
         e.printStackTrace();
         System.err.println("Invalid JSON");
     }
 
-    event.groupProperties = groupProps;
+    event.groups = groupProps;
     client.logEvent(event);
     ```
 
@@ -248,6 +248,29 @@ try {
     System.err.println("Invalid JSON");
 }
 event.groups = groups;
+
+client.logEvent(event);
+```
+
+After setting groups, you can then set or update the properties of particular groups. However, these updates will only affect events going forward. 
+
+--8<-- "includes/editions-growth-enterprise-with-accounts.md"
+
+```java
+Event event = new Event("$groupidentify");
+
+JsonObject groups = new JSONObject();
+JSONObject groupProps = new JSONObject();
+
+try {
+    groups.put("orgId", 10);
+    groupProps.put("Hover Time", 10).put("prop_2", "value_2");
+} catch (JSONException e) {
+    e.printStackTrace();
+    System.err.println("Invalid JSON");
+}
+event.groups = groups
+event.groupProperties = groupProps
 
 client.logEvent(event);
 ```

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -263,8 +263,8 @@ JsonObject groups = new JSONObject();
 JSONObject groupProps = new JSONObject();
 
 try {
-    groups.put("orgId", 10);
-    groupProps.put("Hover Time", 10).put("prop_2", "value_2");
+    groups.put("org", "engineering");
+    groupProps.put("technology", "java");
 } catch (JSONException e) {
     e.printStackTrace();
     System.err.println("Invalid JSON");

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -204,7 +204,7 @@ client.logEvent(event);
     If Joe is in 'orgId' '10', then the `groupName` would be '10':
 
     ```java
-    Event event = new Event("$identify");
+    Event event = new Event("$identify", "test_user_id");
 
     JSONObject groups = new JSONObject();
     try {
@@ -221,7 +221,7 @@ client.logEvent(event);
     If Joe is in 'sport' 'tennis' and 'soccer', then the `groupName` would be '["tennis", "soccer"]'.
 
     ```java
-    Event event = new Event("$identify");
+    Event event = new Event("$identify", "test_user_id");
 
     JSONObject groups = new JSONObject();
     try {

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -215,6 +215,7 @@ client.logEvent(event);
     }
 
     event.groups = groups;
+    event.userProperties = groups
     client.logEvent(event);
     ```
 
@@ -232,6 +233,7 @@ client.logEvent(event);
     }
 
     event.groups = groupProps;
+    event.userProperties = groups
     client.logEvent(event);
     ```
 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description
https://pr-956.d19s7xzcva2mw3.amplifyapp.com/data/sdks/java/#events-with-groups
Java SDK doesn't have `setGroup()` and `groupIdentify()` APIs.
- fix the equivalent of `setGroup()`
- add an equivalent of `groupIdentify()` 

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
