### PR TITLE
feat: add SDK sizes

### DIFF
--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -19,6 +19,9 @@ The Kotlin Android SDK lets you send events to Amplitude. This library is open-s
 --8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
     [Android SDK Migration Guide](/data/sdks/android-kotlin/migration/).
 
+--8<-- "includes/size/java.md"
+    selecting "Amplitude Android Kotlin SDK".
+    
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#android) to get started with Amplitude Android Kotlin SDK.

--- a/docs/data/sdks/android-kotlin/index.md
+++ b/docs/data/sdks/android-kotlin/index.md
@@ -20,7 +20,7 @@ The Kotlin Android SDK lets you send events to Amplitude. This library is open-s
     [Android SDK Migration Guide](/data/sdks/android-kotlin/migration/).
 
 --8<-- "includes/size/java.md"
-    selecting "Amplitude Android Kotlin SDK".
+    selecting ["Amplitude Android Kotlin SDK"](https://mvnrepository.com/artifact/com.amplitude/analytics-android).
     
 ## Getting started
 

--- a/docs/data/sdks/android/index.md
+++ b/docs/data/sdks/android/index.md
@@ -19,6 +19,9 @@ This is the official documentation for the Amplitude Analytics Android SDK.
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Android](./ampli.md).
 
+--8<-- "includes/size/java.md"
+    selecting "Android SDK".
+
 ## Install
 
 ### Add dependencies

--- a/docs/data/sdks/browser-2/index.md
+++ b/docs/data/sdks/browser-2/index.md
@@ -18,6 +18,9 @@ The Browser SDK lets you send events to Amplitude. This library is open-source, 
 !!!note "Migration guide"
     This is the documentation for the Amplitude Browser SDK 2.0. If you are using the Browser SDK 1.0, refer to the migration documentation: [Browser SDK 2.0 Migration Guide](/data/sdks/browser-2/migration/). If you are using the maintenance SDK, refer to the migration documentation: [Browser SDK Migration Guide](/data/sdks/typescript-browser/migration/).
 
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/analytics-browser@2.2.3`.
+
 ## Getting started
 
 Use [this quickstart guide](../sdk-quickstart#browser) to get started with Amplitude Browser SDK.

--- a/docs/data/sdks/browser-2/index.md
+++ b/docs/data/sdks/browser-2/index.md
@@ -19,7 +19,7 @@ The Browser SDK lets you send events to Amplitude. This library is open-source, 
     This is the documentation for the Amplitude Browser SDK 2.0. If you are using the Browser SDK 1.0, refer to the migration documentation: [Browser SDK 2.0 Migration Guide](/data/sdks/browser-2/migration/). If you are using the maintenance SDK, refer to the migration documentation: [Browser SDK Migration Guide](/data/sdks/typescript-browser/migration/).
 
 --8<-- "includes/size/browser.md"
-    For example you can search `@amplitude/analytics-browser@2.2.3`.
+    For example you can search [`@amplitude/analytics-browser`](https://bundlephobia.com/package/@amplitude/analytics-browser) at a specific version.
 
 ## Getting started
 

--- a/docs/data/sdks/flutter/index.md
+++ b/docs/data/sdks/flutter/index.md
@@ -13,6 +13,9 @@ This is the official documentation for the Amplitude Analytics Flutter SDK.
 
 --8<-- "includes/no-ampli.md"
 
+!!!info "SDK bundle size"
+    You can get an estimate of the SDK bundle size by downloading the `tar.gz` file of the version you are using [here](https://pub.dev/packages/amplitude_flutter/versions). Note this is NOT the final size, because flutter has tree shaking.
+
 ## Installation
 
 ### Add dependencies

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -16,8 +16,10 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
+/*cspell:disable*/
 --8<-- "includes/size/ios.md"
     `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.4.14`.
+/*cspell:enable*/
 
 ## Getting started
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -17,6 +17,7 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
 --8<-- "includes/size/ios.md"
+    `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.4.14`.
 
 ## Getting started
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -16,6 +16,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
+--8<-- "includes/size/ios.md"
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#ios-beta) to get started with Amplitude iOS SDK.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -22,6 +22,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
+--8<-- "includes/size/ios.md"
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#ios) to get started with Amplitude iOS SDK.

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -23,6 +23,7 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
 --8<-- "includes/size/ios.md"
+    `./measure_cocoapod_size.py --cocoapods Amplitude:8.17.1`.
 
 ## Getting started
 

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -22,8 +22,10 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
+/*cspell:disable*/
 --8<-- "includes/size/ios.md"
     `./measure_cocoapod_size.py --cocoapods Amplitude:8.17.1`.
+/*cspell:enable*/
 
 ## Getting started
 

--- a/docs/data/sdks/java/index.md
+++ b/docs/data/sdks/java/index.md
@@ -15,6 +15,9 @@ This is the documentation for the **Amplitude Analytics Java SDK**, not the Andr
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for JRE](./ampli.md).
 
+--8<-- "includes/size/java.md"
+    selecting "Amplitude Java SDK".
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#java) to get started with Amplitude Java SDK.

--- a/docs/data/sdks/javascript/index.md
+++ b/docs/data/sdks/javascript/index.md
@@ -20,6 +20,9 @@ This is the official documentation for the Amplitude Analytics JavaScript SDK.
 
 --8<-- "includes/sdk-browser-supported-version.md"
 
+--8<-- "includes/size/browser.md"
+    For example you can search `amplitude-js@8.21.2`.
+
 ## Install
 
 Install the Amplitude Analytics JavaScript SDK in your project.

--- a/docs/data/sdks/marketing-analytics-browser/index.md
+++ b/docs/data/sdks/marketing-analytics-browser/index.md
@@ -20,6 +20,9 @@ The Marketing Analytics Browser SDK extends the Browser SDK to identify users an
 
     The Marketing Analytics Browser SDK extends the Browser SDK 1.0 with automatic web attribution and page view tracking. This doc only includes the configuration related with web attribution and page view tracking. For other functionality check the [Browser SDK](../typescript-browser).
 
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/marketing-analytics-browser@0.2.7`.
+
 ## Getting started
 
 ### Installation

--- a/docs/data/sdks/python/index.md
+++ b/docs/data/sdks/python/index.md
@@ -18,7 +18,7 @@ The Python SDK lets you send events to Amplitude. This library is open-source, c
 --8<-- "includes/ampli-vs-amplitude.md"
 
 !!!info "SDK bundle size"
-    You can get the SDK bundle size by checking pypi. For example [v1.1.3](https://pypi.org/project/amplitude-analytics/1.1.3/#files).
+    You can get the SDK bundle size by checking PyPI. For example [v1.1.3](https://pypi.org/project/amplitude-analytics/1.1.3/#files).
 
 ## Getting started
 

--- a/docs/data/sdks/python/index.md
+++ b/docs/data/sdks/python/index.md
@@ -17,6 +17,9 @@ The Python SDK lets you send events to Amplitude. This library is open-source, c
 
 --8<-- "includes/ampli-vs-amplitude.md"
 
+!!!info "SDK bundle size"
+    You can get the SDK bundle size by checking pypi. For example [v1.1.3](https://pypi.org/project/amplitude-analytics/1.1.3/#files).
+
 ## Getting started
 
 Use [this quickstart guide](../../sdks/sdk-quickstart#python) to get started with Amplitude Python SDK.

--- a/docs/data/sdks/react-native/index.md
+++ b/docs/data/sdks/react-native/index.md
@@ -20,6 +20,9 @@ This is the official documentation for the Amplitude Analytics React Native SDK.
 
 --8<-- "includes/sdk-rn/rn-notification.md"
 
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/react-native@2.16.1`.
+
 ## Compatibility Matrix
 
 The following matrix lists the support for Amplitude React Native SDK version for [different versions of React Native and React Native CLI](https://github.com/react-native-community/cli).

--- a/docs/data/sdks/typescript-browser/index.md
+++ b/docs/data/sdks/typescript-browser/index.md
@@ -4,7 +4,6 @@ description: The Amplitude Browser SDK Installation & Quick Start guide.
 icon: simple/javascript
 ---
 
-
 ![npm version](https://img.shields.io/npm/v/@amplitude/analytics-browser/v1)
 
 The Browser SDK lets you send events to Amplitude. This library is open-source, check it out on [GitHub](https://github.com/amplitude/Amplitude-TypeScript).
@@ -24,6 +23,9 @@ The Browser SDK lets you send events to Amplitude. This library is open-source, 
 
 --8<-- "includes/ampli-vs-amplitude.md"
     Click here for more documentation on [Ampli for Browser](./ampli.md).
+
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/analytics-browser@1.6.1`.
 
 ## Getting started
 

--- a/docs/data/sdks/typescript-node/index.md
+++ b/docs/data/sdks/typescript-node/index.md
@@ -19,6 +19,9 @@ The Node.js SDK lets you send events to Amplitude. This library is open-source, 
 --8<-- "includes/sdk-migration/admonition-link-to-migration-docs.md"
     [Node.JS SDK Migration Guide](/data/sdks/typescript-node/migration/).
 
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/analytics-node@0.6.0`.
+
 ## Getting started
 
 Use [this quickstart guide](../sdk-quickstart#node) to get started with Amplitude Node SDK.

--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -19,6 +19,9 @@ The React Native SDK lets you send events to Amplitude. This library is open-sou
 
 --8<-- "includes/sdk-rn/rn-notification.md"
 
+--8<-- "includes/size/browser.md"
+    For example you can search `@amplitude/analytics-react-native@0.5.1`.
+
 ## Compatibility Matrix
 
 The following matrix lists the support for Amplitude React Native SDK version for [different versions of React Native and React Native CLI](https://github.com/react-native-community/cli).

--- a/includes/size/browser.md
+++ b/includes/size/browser.md
@@ -1,0 +1,2 @@
+!!!info "SDK bundle size"
+    You can get the SDK bundle size by searching the package name with the version you are using in [bundle phobia](https://bundlephobia.com/).

--- a/includes/size/ios.md
+++ b/includes/size/ios.md
@@ -1,2 +1,2 @@
 !!!info "SDK bundle size"
-    You can get the SDK bundle size by using the [Cocoapods size measurement tool](https://github.com/google/cocoapods-size).
+    You can get the SDK bundle size by using the [Cocoapods size measurement tool](https://github.com/google/cocoapods-size). Clone this repo and go in the root directory. Open your terminal and type, for example, 

--- a/includes/size/ios.md
+++ b/includes/size/ios.md
@@ -1,0 +1,2 @@
+!!!info "SDK bundle size"
+    You can get the SDK bundle size by using the [Cocoapods size measurement tool](https://github.com/google/cocoapods-size).

--- a/includes/size/java.md
+++ b/includes/size/java.md
@@ -1,0 +1,2 @@
+!!!info "SDK bundle size"
+    You can get the SDK bundle size by checking [Mave repository](https://mvnrepository.com/artifact/com.amplitude). Select the version you are using and you can find size in the "Files" raw after 

--- a/includes/size/java.md
+++ b/includes/size/java.md
@@ -1,2 +1,2 @@
 !!!info "SDK bundle size"
-    You can get the SDK bundle size by checking [Maven repository](https://mvnrepository.com/artifact/com.amplitude). Select the version you are using and you can find size in the "Files" raw after 
+    You can get the SDK bundle size by checking [Maven repository](https://mvnrepository.com/artifact/com.amplitude). Select the version you are using and you can find the size in the "Files" row after 

--- a/includes/size/java.md
+++ b/includes/size/java.md
@@ -1,2 +1,2 @@
 !!!info "SDK bundle size"
-    You can get the SDK bundle size by checking [Mave repository](https://mvnrepository.com/artifact/com.amplitude). Select the version you are using and you can find size in the "Files" raw after 
+    You can get the SDK bundle size by checking [Maven repository](https://mvnrepository.com/artifact/com.amplitude). Select the version you are using and you can find size in the "Files" raw after 


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Add info on how to check SDK sizes based on https://amplitude.atlassian.net/wiki/spaces/GOV/pages/1787166927/Amplitude+SDK+Non+Functional+Requirement

Example:
![image](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/31029607/f90f442a-b31f-4f6d-8526-40aa91a69965)


## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
