### PR TITLE
update browser debugging

### DIFF
--- a/includes/sdk-troubleshooting-and-debugging/browser.md
+++ b/includes/sdk-troubleshooting-and-debugging/browser.md
@@ -63,7 +63,7 @@ If you have set up an API proxy and run into configuration issues related to tha
 
 ##### Events fired but no network requests
 
-If you [set the logger to "Debug" level](./#debug-mode), and see track calls in the developer console, the `track()` method has been called. If you don't see the corresponding event in Amplitude, the Amplitude Instrumentation Explorer Chrome extension, or the network request tab of the browser, the event wasn't sent to Amplitude. Events are fired and placed in the SDK's internal queue upon a successful `track()` call, but sometimes these queued events may not send successfully. This can happen when an in-progress HTTP request is cancelled. For example, if you close the browser or leave the page with a `history.push()` event in React.
+If you [set the logger to "Debug" level](./#debug-mode), and see track calls in the developer console, the `track()` method has been called. If you don't see the corresponding event in Amplitude, the Amplitude Instrumentation Explorer Chrome extension, or the network request tab of the browser, the event wasn't sent to Amplitude. Events are fired and placed in the SDK's internal queue upon a successful `track()` call, but sometimes these queued events may not send successfully. This can happen when an in-progress HTTP request is cancelled. For example, if you close the browser or leave the page.
 
 There are two ways to address this issue:
 

--- a/includes/sdk-troubleshooting-and-debugging/browser.md
+++ b/includes/sdk-troubleshooting-and-debugging/browser.md
@@ -63,11 +63,11 @@ If you have set up an API proxy and run into configuration issues related to tha
 
 ##### Events fired but no network requests
 
-If you [set the logger to "Debug" level](./#debug-mode), and you observe the `track()` method being printed in the developer console, it means the track() method has been called. However, if you don't see the corresponding event in Amplitude, the Amplitude Instrumentation Explorer Chrome extension, or the network request tab of the browser, it indicates that the event wasn't sent to Amplitude. Events are fired and placed in the SDK's internal queue upon a successful `track()` call, but sometimes these queued events may not be sent successfully. This can occur, for instance, when an HTTP request is in progress and gets canceled, such as when leaving the page using `history.push()` in React or closing the browser.
+If you [set the logger to "Debug" level](./#debug-mode), and see track calls in the developer console, the `track()` method has been called. If you don't see the corresponding event in Amplitude, the Amplitude Instrumentation Explorer Chrome extension, or the network request tab of the browser, the event wasn't sent to Amplitude. Events are fired and placed in the SDK's internal queue upon a successful `track()` call, but sometimes these queued events may not send successfully. This can happen when an in-progress HTTP request is cancelled. For example, if you close the browser or leave the page with a `history.push()` event in React.
 
-To address this issue, there are two solutions:
+There are two ways to address this issue:
 
-1. If you're using standard network requests, you might want to set the transport to `beacon` during initialization or set the transport to `beacon` upon page exit. However, because `sendBeacon` will send events in the background, it doesn't return server responses and thus cannot retry on failure responses like 4xx or 5xx errors. Also, note that only scheduled requests will be sent out in the background with a sendBeacon configuration. Please refer to the [sendBeacon](./#use-sendbeacon) section for more instructions.
+1. If you use standard network requests, set the transport to `beacon` during initialization or set the transport to `beacon` upon page exit. `sendBeacon` doesn't work in this case because it sends events in the background, and doesn't return server responses like `4xx` or `5xx`. As a result, it doesn't retry on failure. `sendBeacon` sends only scheduled requests in the background. For more information, see the [sendBeacon](./#use-sendbeacon) section.
 
 2. To make track() synchronous, [add the `await` keyword](./#callback) before the call.
 

--- a/includes/sdk-troubleshooting-and-debugging/browser.md
+++ b/includes/sdk-troubleshooting-and-debugging/browser.md
@@ -61,8 +61,14 @@ Cross-origin resource sharing (CORS) prevents a malicious site from reading anot
 
 If you have set up an API proxy and run into configuration issues related to that on a platform you’ve selected, that’s no longer an SDK issue but an integration issue between your application and the service provider.
 
-##### Event Dropping When Closes the Browser or Leaves the Page
+##### Events fired but no network requests
 
-If you're using standard network requests, scheduled requests might be dropped if the user closes the browser or leaves the page. To solve this issue, you might want to set the transport to `beacon` during initialization or set the transport to `beacon` upon page exit. However, because `sendBeacon` will send events in the background, it doesn't return server responses and thus cannot retry on failure responses like 4xx or 5xx errors. Also, note that only scheduled requests will be sent out in the background with a `sendBeacon` configuration.
+If you [set the logger to "Debug" level](./#debug-mode), and you observe the `track()` method being printed in the developer console, it means the track() method has been called. However, if you don't see the corresponding event in Amplitude, the Amplitude Instrumentation Explorer Chrome extension, or the network request tab of the browser, it indicates that the event wasn't sent to Amplitude. Events are fired and placed in the SDK's internal queue upon a successful `track()` call, but sometimes these queued events may not be sent successfully. This can occur, for instance, when an HTTP request is in progress and gets canceled, such as when leaving the page using `history.push()` in React or closing the browser.
 
-Please refer to the [sendBeacon](./#use-sendbeacon) section for more instructions.
+To address this issue, there are two solutions:
+
+1. If you're using standard network requests, you might want to set the transport to `beacon` during initialization or set the transport to `beacon` upon page exit. However, because `sendBeacon` will send events in the background, it doesn't return server responses and thus cannot retry on failure responses like 4xx or 5xx errors. Also, note that only scheduled requests will be sent out in the background with a sendBeacon configuration. Please refer to the [sendBeacon](./#use-sendbeacon) section for more instructions.
+
+2. To make track() synchronous, [add the `await` keyword](./#callback) before the call.
+
+


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

Update Browser debugging docs to include solutions for this customer https://amplitude.atlassian.net/browse/AMP-80960

https://pr-959.d19s7xzcva2mw3.amplifyapp.com/data/sdks/browser-2/#events-fired-but-no-network-requests

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
