### PR TITLE
AMP-83991 added explnation for kochava device id

### DIFF
--- a/docs/data/destinations/kochava-event-streaming-post-installs.md
+++ b/docs/data/destinations/kochava-event-streaming-post-installs.md
@@ -66,7 +66,8 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 13. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. These properties are sent to Kochava. Transformed user properties aren't supported.
 14. When finished, enable the destination and **Save**.
 
-#### What is difference between Kochava Device ID and the other identifiers?
+#### What is difference between Kochava Device ID and other identifiers?
+
 Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases

--- a/docs/data/destinations/kochava-event-streaming-post-installs.md
+++ b/docs/data/destinations/kochava-event-streaming-post-installs.md
@@ -60,7 +60,7 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 7. *(Optional)* Paste your secret key to **API secret** (provided by Kochava's CS team).
 8. Under **Send Events**, make sure the toggle is enabled ("Events are sent to Kochava") if you want to stream events to Kochava. When enabled, events are automatically forwarded to Kochava when they're ingested in Amplitude. Events aren't sent on a schedule or on demand using this integration.
 9. In **Select and Filter** events choose which events you want to send. Choose only the events you need in Kochava. [Transformed events](https://help.amplitude.com/hc/en-us/articles/5913315221915-Transformations-Retroactively-modify-your-event-data-structure#:~:text=Amplitude%20Data's%20transformations%20feature%20allows,them%20to%20all%20historical%20data.) aren't supported.
-10. Click on **Mappings** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (IP address of the device on install) are required to map to save your sync configuration. You must also choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id). 
+10. Click **Mappings** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (the IP address of the device on install) are required to map to save your sync configuration. Choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id). 
 11. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. Transformed event properties and transformed user properties aren't supported.
 12. *(optional)* Under **Send Users**, make sure the toggle is enabled if you want to send over users and their properties in real-time whenever a user is created or the user property is updated in Amplitude.
 13. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. These properties are sent to Kochava. Transformed user properties aren't supported.
@@ -68,7 +68,7 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 
 #### What is difference between Kochava Device ID and other identifiers?
 
-Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
+Send Kochava Device ID as a unique string that is consistent for each instance of the app on a single device. The other identifiers (for example, Apple Advertising ID and Google Advertising ID) are the relevant mobile advertising IDs. So, a Kochava device can have the multiple device ids but the **Kochava Device ID** must be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases
 

--- a/docs/data/destinations/kochava-event-streaming-post-installs.md
+++ b/docs/data/destinations/kochava-event-streaming-post-installs.md
@@ -60,11 +60,14 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 7. *(Optional)* Paste your secret key to **API secret** (provided by Kochava's CS team).
 8. Under **Send Events**, make sure the toggle is enabled ("Events are sent to Kochava") if you want to stream events to Kochava. When enabled, events are automatically forwarded to Kochava when they're ingested in Amplitude. Events aren't sent on a schedule or on demand using this integration.
 9. In **Select and Filter** events choose which events you want to send. Choose only the events you need in Kochava. [Transformed events](https://help.amplitude.com/hc/en-us/articles/5913315221915-Transformations-Retroactively-modify-your-event-data-structure#:~:text=Amplitude%20Data's%20transformations%20feature%20allows,them%20to%20all%20historical%20data.) aren't supported.
-10. Click on **Mappings** to specify the identity mapping between Amplitude and Kochava.  You must choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id). 
+10. Click on **Mappings** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (IP address of the device on install) are required to map to save your sync configuration. You must also choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id). 
 11. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. Transformed event properties and transformed user properties aren't supported.
 12. *(optional)* Under **Send Users**, make sure the toggle is enabled if you want to send over users and their properties in real-time whenever a user is created or the user property is updated in Amplitude.
 13. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. These properties are sent to Kochava. Transformed user properties aren't supported.
 14. When finished, enable the destination and **Save**.
+
+#### What is difference between Kochava Device ID and the other identifiers?
+Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases
 

--- a/docs/data/destinations/kochava-event-streaming.md
+++ b/docs/data/destinations/kochava-event-streaming.md
@@ -59,9 +59,12 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 7. *(Optional)* Paste your secret key to **API secret** (provided by Kochava's CS team).
 8. Under **Send Events**, make sure the toggle is enabled ("Events are sent to Kochava") if you want to stream events to Kochava. When enabled, events are automatically forwarded to Kochava when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration.
 9. In **Select and Filter** events choose which events you want to send. Choose only the events you need in Kochava. [Transformed events](https://help.amplitude.com/hc/en-us/articles/5913315221915-Transformations-Retroactively-modify-your-event-data-structure#:~:text=Amplitude%20Data's%20transformations%20feature%20allows,them%20to%20all%20historical%20data.) aren't supported.
-10. Click on **Map properties to destination** to specify the identity mapping between Amplitude and Kochava. You must choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id).
+10. Click on **Map properties to destination** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (IP address of the device on install) are required to map to save your sync configuration. You must also choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id).
 11. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. Transformed event properties and transformed user properties aren't supported.
 12. When finished, enable the destination and **Save**.
+
+#### What is difference between Kochava Device ID and the other identifiers?
+Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases
 

--- a/docs/data/destinations/kochava-event-streaming.md
+++ b/docs/data/destinations/kochava-event-streaming.md
@@ -63,7 +63,8 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 11. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. Transformed event properties and transformed user properties aren't supported.
 12. When finished, enable the destination and **Save**.
 
-#### What is difference between Kochava Device ID and the other identifiers?
+#### What is difference between Kochava Device ID and other identifiers?
+
 Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases

--- a/docs/data/destinations/kochava-event-streaming.md
+++ b/docs/data/destinations/kochava-event-streaming.md
@@ -59,13 +59,13 @@ To configure an Event Streaming integration from Amplitude to Kochava, you must 
 7. *(Optional)* Paste your secret key to **API secret** (provided by Kochava's CS team).
 8. Under **Send Events**, make sure the toggle is enabled ("Events are sent to Kochava") if you want to stream events to Kochava. When enabled, events are automatically forwarded to Kochava when they're ingested in Amplitude. Events aren't sent on a schedule or on-demand using this integration.
 9. In **Select and Filter** events choose which events you want to send. Choose only the events you need in Kochava. [Transformed events](https://help.amplitude.com/hc/en-us/articles/5913315221915-Transformations-Retroactively-modify-your-event-data-structure#:~:text=Amplitude%20Data's%20transformations%20feature%20allows,them%20to%20all%20historical%20data.) aren't supported.
-10. Click on **Map properties to destination** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (IP address of the device on install) are required to map to save your sync configuration. You must also choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id).
+10. Click **Map properties to destination** to specify the identity mapping between Amplitude and Kochava. **Kochava Device ID** and **IP Address** (the IP address of the device on install) are required to map to save your sync configuration. Choose at least one of the following identifiers, Apple Advertising ID (idfa), Apple Vendor ID (idfv), Google Advertising ID (adid) and Android ID (android_id).
 11. *(optional)* In **Select additional properties**, select any more user properties you want to send to Kochava. If you don't select any properties here, Amplitude doesn't send any. Transformed event properties and transformed user properties aren't supported.
 12. When finished, enable the destination and **Save**.
 
 #### What is difference between Kochava Device ID and other identifiers?
 
-Kochava Device ID should be sent as a unique string that is consistent for each instance of the app on a single device. The other identifiers (e.g. Apple Advertising ID and Google Advertising ID) is the relevant mobile advertising IDs. So, Kochava device can have the multiple device ids but **Kochava Device ID** has to be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
+Send the Kochava Device ID as a unique string that is consistent for each instance of the app on a single device. The other identifiers (for example, Apple Advertising ID and Google Advertising ID) are the relevant mobile advertising IDs. So, a Kochava device can have the multiple device ids but the **Kochava Device ID** must be unique. Kochava Device ID can be technically the same string as the other identifiers but it is different concept.
 
 ### Use Cases
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description
ticket: https://amplitude.atlassian.net/browse/AMP-83991

- added the explanation the difference between kochava device id and other identifiers.

## Deadline

When do these changes need to be live on the site?


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
