### PR TITLE
AMP-84238 Update Android dependency to get Advertising Id

### DIFF
--- a/docs/data/sdks/typescript-react-native/index.md
+++ b/docs/data/sdks/typescript-react-native/index.md
@@ -728,11 +728,11 @@ Android Ad ID is a unique identifier for each device. Android Ad ID is reset by 
 
 To use Android Ad ID, follow these steps.
 
-1. Add `play-services-ads` as a dependency to the Android project of your app. More detailed setup is [described in our latest Android SDK docs](/data/sdks/android-kotlin/#advertiser-id).
+1. Add `play-services-ads-identifier` as a dependency to the Android project of your app. More detailed setup is [described in our latest Android SDK docs](/data/sdks/android-kotlin/#advertiser-id).
 
     ```bash
     dependencies {
-      implementation 'com.google.android.gms:play-services-ads:18.3.0'
+      implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     }
     ```
 

--- a/includes/sdk-android/android-sdk-advertiser-id.md
+++ b/includes/sdk-android/android-sdk-advertiser-id.md
@@ -8,11 +8,11 @@ Follow these steps to use Android Ad ID.
 
     As of April 1, 2022, Google allows users to opt out of Ad ID tracking. Ad ID may return null or error. You can use am alternative ID called [App Set ID](#app-set-id), which is unique to every app install on a device. [Learn more](https://support.google.com/googleplay/android-developer/answer/6048248?hl=en).
 
-1. Add `play-services-ads` as a dependency.
+1. Add `play-services-ads-identifier` as a dependency.
 
     ```bash
     dependencies {
-      implementation 'com.google.android.gms:play-services-ads:18.3.0'
+      implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     }
     ```
 


### PR DESCRIPTION
# Amplitude Developer Docs PR

## Description

Replaces Android package used to get advertising Id: `'com.google.android.gms:play-services-ads` -> `com.google.android.gms:play-services-ads-identifier`

## Change type

- [ ] Doc bug fix.
- [x] Doc update. Fixes [AMP-84238](https://amplitude.atlassian.net/browse/AMP-84238).
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [x] I previewed my documentation on a local server using `mkdocs serve`.
- [x] Running `mkdocs serve` didn't generate any failures.
- [x] I have performed a self-review of my own documentation.


@amplitude-dev-docs


[AMP-84238]: https://amplitude.atlassian.net/browse/AMP-84238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ