### PR TITLE
fix: add homebrew instructions to Ampli overview page, code cleanup

### DIFF
--- a/includes/ampli/cli-install-only.md
+++ b/includes/ampli/cli-install-only.md
@@ -1,0 +1,16 @@
+### Install the Ampli CLI
+
+You can install the [Ampli CLI](/data/ampli/cli/) from Homebrew or NPM.
+
+=== "brew"
+
+    ```bash
+    brew tap amplitude/ampli
+    brew install ampli
+    ```
+
+=== "npm"
+
+    ```bash
+    npm install -g @amplitude/ampli
+    ```

--- a/includes/ampli/cli-install-simple.md
+++ b/includes/ampli/cli-install-simple.md
@@ -1,19 +1,5 @@
-### Install the Ampli CLI
+--8<-- "includes/ampli/cli-install-only.md"
 
-You can install the [Ampli CLI](/data/ampli/cli/) from Homebrew or NPM.
-
-=== "brew"
-
-    ```bash
-    brew tap amplitude/ampli
-    brew install ampli
-    ```
-
-=== "npm"
-
-    ```bash
-    npm install -g @amplitude/ampli
-    ```
 ### Pull the Ampli Wrapper into your project
 
 Run the Ampli CLI `pull` command to log in to Amplitude Data and download the strongly typed Ampli Wrapper for your tracking plan. Ampli CLI commands are usually run from the project root directory.

--- a/includes/ampli/pages/ampli-overview.md
+++ b/includes/ampli/pages/ampli-overview.md
@@ -87,13 +87,7 @@ The following examples will reference this tracking plan.
 
 The Ampli CLI connects to Amplitude Data and uses the schema information for a given Source to generate and verify the Ampli Wrapper in your project.
 
-### Install the Ampli CLI
-
-NPM and Homebrew are supported.
-
-```shell
-npm install -g @amplitude/ampli
-```
+--8<-- "includes/ampli/cli-install-only.md"
 
 ### Generate the Ampli Wrapper with `ampli pull`
 


### PR DESCRIPTION
## Description

[AMP-84812](https://amplitude.atlassian.net/browse/AMP-84812)

* added homebrew instructions to Ampli overview page
* code cleanup / reuse

<img width="1063" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/5790872/8709e130-79e2-4889-8d1a-e23adfd51c5c">



[AMP-84812]: https://amplitude.atlassian.net/browse/AMP-84812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ