### PR TITLE
AMP-85211 added static robots.txt

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /analytics/apis/taxonomy-import-api/


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

added static robots.txt with one page that is excluded from navigation and website search

## Deadline

no urgent


## Change type

- [ ] Doc bug fix. Fixes #[insert issue number]. Amplitude contributors include Jira issue number. 
- [ ] Doc update.
- [ ] New documentation.
- [X] Non-documentation related fix or update.

# PR checklist:

- [ ] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
