### PR TITLE
feat: default event tracking for Swift SDK

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -108,7 +108,7 @@ amplitude.identify(identify: identify)
 
 ### Tracking default events
 
-Starting from release v0.6.0, the SDK is able to track more default events. It can be configured to track the following events automatically:
+Starting from release v0.6.0, the SDK can track more default events. You can configure it to track the following events by default:
 
 - Sessions [^1]
 - App lifecycles

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -59,7 +59,7 @@ let amplitude = Amplitude(configuration: Configuration(
     | `flushEventsOnClose` | Flushing of unsent events on app close. | `true` |
     | `callback` | Callback function after event sent. | `nil` |
     | `optOut` | Opt the user out of tracking. | `false` |
-    | `trackingSessionEvents` | Flushing of unsent events on app close. | `true` |
+    | `defaultTracking` | Enable tracking of [default events](#tracking-default-events) for sessions, app lifecycle, screen views, and deep links. | `DefaultTrackingOptions(sessions: true)` |
     | `minTimeBetweenSessionsMillis` | The amount of time for session timeout. | `300000` |
     | `serverUrl` | The server url events upload to. | `https://api2.amplitude.com/2/httpapi` |
     | `serverZone` |  The server zone to send to, will adjust server url based on this config. | `US` |

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -106,6 +106,160 @@ identify.set(property: "color", value: "green")
 amplitude.identify(identify: identify)
 ```
 
+### Tracking default events
+
+Starting from release v0.6.0, the SDK is able to track more default events. It can be configured to track the following events automatically:
+
+- Sessions [^1]
+- App lifecycles
+- Screen views[^2]
+- Deep links [^3]
+
+[^1]:
+Session tracking is the same as supported in previous versions, which was previously enabled/disabled via the [`trackingSessionEvents`](#configuration) configuration.
+[^2]:
+Screen views are only supported in UIKit. For Swift UI, you will need to call the corresponding methods manually.
+[^3]:
+Deep link tracking is not fully automated, you will need to call the corresponding methods manually.
+
+???config "Tracking default events options"
+| <div class="big-column">Name</div> | Type | Default Value | Description |
+|-|-|-|-|
+`defaultTracking.sessions` | Optional. `boolean` | `true` | Enables session tracking. This configuration replaces [`trackingSessionEvents`](#configuration). If value is `true`, Amplitude tracks session start and session end events.<br /><br />See [Tracking sessions](#tracking-sessions) for more information.|
+`defaultTracking.appLifecycles` | Optional. `boolean` | `false` | Enables application lifecycle events tracking. If value is `true`, Amplitude tracks application installed, application updated, application opened, and application backgrounded events.<br /><br />Event properties tracked includes: `[Amplitude] Version`,<br /> `[Amplitude] Build`,<br /> `[Amplitude] Previous Version`, `[Amplitude] Previous Build`, `[Amplitude] From Background`<br /><br />See [Tracking application lifecycles](#tracking-application-lifecycles) for more information.|
+`defaultTracking.screenViews` | Optional. `boolean` | `false` | Enables screen views tracking. If value is `true`, Amplitude tracks screen viewed events.<br /><br />Event properties tracked includes: `[Amplitude] Screen Name`<br /><br />See [Tracking screen views](#tracking-screen-views) for more information.|
+
+You can enable Amplitude to start tracking all events mentioned above, use the code sample below.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions.ALL
+    ))
+    ```
+
+!!!note
+Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
+
+Similarly, you can disable Amplitude to track all events mentioned above with the code sample below.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions.NONE
+    ))
+    ```
+
+You can also customize the tracking with `DefaultTrackingOptions`, see code sample below.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions(
+            sessions: true,
+            appLifecycles: false,
+            screenViews: false
+        )
+    ))
+    ```
+
+#### Tracking sessions
+
+Session tracking is enabled by default. You can enable Amplitude to start tracking session events by setting `defaultTracking.sessions` to `true`. Refer to the code sample below.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions(
+            sessions: true,
+            appLifecycles: false,
+            screenViews: false
+        )
+    ))
+    ```
+
+For more information about session tracking, refer to [User sessions](#user-sessions).
+
+!!!note
+`trackingSessionEvents` is deprecated and replaced with `defaultTracking.sessions`.
+
+#### Tracking application lifecycles
+
+You can enable Amplitude to start tracking application lifecycle events by setting `defaultTracking.appLifecycles` to `true`. Refer to the code sample below.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions(
+            sessions: false,
+            appLifecycles: true,
+            screenViews: false
+        )
+    ))
+    ```
+
+After enabling this setting, Amplitude will track the following events:
+
+-`[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
+-`[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
+-`[Amplitude] Application Opened`, this event fires when a user launches or foregrounds the application after the first open, by observing the `UIApplicationDidFinishLaunchingNotification` or `UIApplicationWillEnterForegroundNotification` notification underneath.
+-`[Amplitude] Application Backgrounded`, this event fires when a user backgrounds the application, by observing the `UIApplicationDidEnterBackgroundNotification` notification underneath.
+
+#### Tracking screen views
+
+You can enable Amplitude to start tracking screen view events by setting `defaultTracking.screenViews` to `true`. Refer to the code sample below.
+
+!!!warning
+    This feature is only supported in UIKit. For Swift UI, you will need to track the corresponding event manually instead.
+
+=== "Swift"
+
+    ```swift
+    // UIKit
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY",
+        defaultTracking: DefaultTrackingOptions(
+            sessions: false,
+            appLifecycles: false,
+            screenViews: true
+        )
+    ))
+
+    // Swift UI
+    instance.configuration.defaultTracking.screenViews = false
+    instance.track(ScreenViewedEvent(screenName: "Screen Name"))
+    ```
+
+After enabling this setting, Amplitude will track the `[Amplitude] Screen Viewed` event with the screen name property. This property value is read from the controller class metadata with `viewDidAppear` method swizzling.
+
+#### Tracking deep links
+
+Deeplinks are not automated at this time. You will need to track the corresponding events manually instead.
+
+=== "Swift"
+
+    ```swift
+    var instance = Amplitude(configuration: Configuration(
+        apiKey: "API_KEY"
+    ))
+
+    instance.track(DeepLinkOpenedEvent(url: URL()))
+    instance.track(DeepLinkOpenedEvent(url: "url", referrer:"refferer"))
+    instance.track(DeepLinkOpenedEvent(activity: activity))
+    ```
+
+Amplitude will track the `[Amplitude] Deep Link Opened` event with the URL and referrer information.
+
 ### User groups
 
 --8<-- "includes/editions-growth-enterprise-with-accounts.md"

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -118,9 +118,9 @@ Starting from release v0.6.0, the SDK can track more default events. You can con
 [^1]:
 Session tracking is the same as supported in previous versions, which was previously enabled/disabled with the [`trackingSessionEvents`](#configuration) configuration.
 [^2]:
-Screen views are only supported in UIKit. For Swift UI, you will need to call the corresponding methods manually.
+Screen views are supported in UIKit. For Swift UI, you need to manually call the corresponding methods.
 [^3]:
-Deep link tracking is not fully automated, you will need to call the corresponding methods manually.
+Deep link tracking is not fully automated. You need to manually call the corresponding methods.
 
 ???config "Tracking default events options"
 | <div class="big-column">Name</div> | Type | Default Value | Description |
@@ -129,7 +129,7 @@ Deep link tracking is not fully automated, you will need to call the correspondi
 `defaultTracking.appLifecycles` | Optional. `boolean` | `false` | Enables application lifecycle events tracking. If value is `true`, Amplitude tracks application installed, application updated, application opened, and application backgrounded events.<br /><br />Event properties tracked includes: `[Amplitude] Version`,<br /> `[Amplitude] Build`,<br /> `[Amplitude] Previous Version`, `[Amplitude] Previous Build`, `[Amplitude] From Background`<br /><br />See [Tracking application lifecycles](#tracking-application-lifecycles) for more information.|
 `defaultTracking.screenViews` | Optional. `boolean` | `false` | Enables screen views tracking. If value is `true`, Amplitude tracks screen viewed events.<br /><br />Event properties tracked includes: `[Amplitude] Screen Name`<br /><br />See [Tracking screen views](#tracking-screen-views) for more information.|
 
-You can enable Amplitude to start tracking all events mentioned above, use the code sample below.
+Use the code sample below to enable the above-mentioned tracking events.
 
 === "Swift"
 
@@ -144,7 +144,7 @@ You can enable Amplitude to start tracking all events mentioned above, use the c
 
     Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
 
-Similarly, you can disable Amplitude to track all events mentioned above with the code sample below.
+Use the code sample below to disable tracking the above-mentioned tracking events.
 
 === "Swift"
 
@@ -155,7 +155,7 @@ Similarly, you can disable Amplitude to track all events mentioned above with th
     ))
     ```
 
-You can also customize the tracking with `DefaultTrackingOptions`, see code sample below.
+Customize the tracking with `DefaultTrackingOptions`.
 
 === "Swift"
 
@@ -172,7 +172,7 @@ You can also customize the tracking with `DefaultTrackingOptions`, see code samp
 
 #### Tracking sessions
 
-Session tracking is enabled by default. You can enable Amplitude to start tracking session events by setting `defaultTracking.sessions` to `true`. Refer to the code sample below.
+Amplitude enables session tracking by default. Set `defaultTracking.sessions` to `true` to  track session events.
 
 === "Swift"
 
@@ -195,7 +195,7 @@ For more information about session tracking, refer to [User sessions](#user-sess
 
 #### Tracking application lifecycles
 
-You can enable Amplitude to start tracking application lifecycle events by setting `defaultTracking.appLifecycles` to `true`. Refer to the code sample below.
+Set `defaultTracking.appLifecycles` to `true` to enable Amplitude to track application lifecycle events.
 
 === "Swift"
 
@@ -210,7 +210,7 @@ You can enable Amplitude to start tracking application lifecycle events by setti
     ))
     ```
 
-After enabling this setting, Amplitude will track the following events:
+When you enable this setting, Amplitude tracks the following events:
 
 -`[Amplitude] Application Installed`, this event fires when a user opens the application for the first time right after installation, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
 -`[Amplitude] Application Updated`, this event fires when a user opens the application after updating the application, by observing the `UIApplicationDidFinishLaunchingNotification` notification underneath.
@@ -219,10 +219,10 @@ After enabling this setting, Amplitude will track the following events:
 
 #### Tracking screen views
 
-You can enable Amplitude to start tracking screen view events by setting `defaultTracking.screenViews` to `true`. Refer to the code sample below.
+Set `defaultTracking.screenViews` to `true` to enable Amplitude to track screen view events.
 
 !!!warning
-    This feature is only supported in UIKit. For Swift UI, you will need to track the corresponding event manually instead.
+    This feature is supported in UIKit. For Swift UI, track the corresponding event manually.
 
 === "Swift"
 
@@ -242,11 +242,11 @@ You can enable Amplitude to start tracking screen view events by setting `defaul
     instance.track(ScreenViewedEvent(screenName: "Screen Name"))
     ```
 
-After enabling this setting, Amplitude will track the `[Amplitude] Screen Viewed` event with the screen name property. This property value is read from the controller class metadata with `viewDidAppear` method swizzling.
+When you enable this setting, Amplitude tracks the `[Amplitude] Screen Viewed` event with the screen name property. Amplitude reads this value from the controller class metadata `viewDidAppear` method swizzling.
 
 #### Tracking deep links
 
-Deeplinks are not automated at this time. You will need to track the corresponding events manually instead.
+Deeplink tracking is not automated. To track deeplinks, track the corresponding events.
 
 === "Swift"
 
@@ -260,7 +260,7 @@ Deeplinks are not automated at this time. You will need to track the correspondi
     instance.track(DeepLinkOpenedEvent(activity: activity))
     ```
 
-Amplitude will track the `[Amplitude] Deep Link Opened` event with the URL and referrer information.
+Amplitude tracks the `[Amplitude] Deep Link Opened` event with the URL and referrer information.
 
 ### User groups
 

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -116,7 +116,7 @@ Starting from release v0.6.0, the SDK can track more default events. You can con
 - Deep links [^3]
 
 [^1]:
-Session tracking is the same as supported in previous versions, which was previously enabled/disabled via the [`trackingSessionEvents`](#configuration) configuration.
+Session tracking is the same as supported in previous versions, which was previously enabled/disabled with the [`trackingSessionEvents`](#configuration) configuration.
 [^2]:
 Screen views are only supported in UIKit. For Swift UI, you will need to call the corresponding methods manually.
 [^3]:

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -141,7 +141,8 @@ You can enable Amplitude to start tracking all events mentioned above, use the c
     ```
 
 !!!note
-Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
+
+    Amplitude may add more events in a future version, and this configuration enables tracking for those events as well.
 
 Similarly, you can disable Amplitude to track all events mentioned above with the code sample below.
 
@@ -189,7 +190,8 @@ Session tracking is enabled by default. You can enable Amplitude to start tracki
 For more information about session tracking, refer to [User sessions](#user-sessions).
 
 !!!note
-`trackingSessionEvents` is deprecated and replaced with `defaultTracking.sessions`.
+
+    `trackingSessionEvents` is deprecated and replaced with `defaultTracking.sessions`.
 
 #### Tracking application lifecycles
 


### PR DESCRIPTION
## Description

[AMP-82700](https://amplitude.atlassian.net/browse/AMP-82700)

* https://pr-982.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios-swift/#tracking-default-events
* default event tracking for Swift SDK
* Mostly copied from [maintenance iOS docs](https://pr-982.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios/#tracking-default-events), code examples adjusted for Swift SDK

[AMP-82700]: https://amplitude.atlassian.net/browse/AMP-82700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ