### PR TITLE
fix: remove experiment not supported warning

### DIFF
--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -14,9 +14,6 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 !!!warning "Objective-C Not Supported"
     Please note that the latest iOS SDK is NOT compatible with Objective-C projects. Use the [maintenance iOS SDK](/data/sdks/ios) if your project requires compatibility with Objective-C.
 
-!!!warning "Some Features Not Yet Available"
-    For customers beginning with Amplitude Experiment, please note that this SDK does not support the [Amplitude Experiment integration](https://www.docs.developers.amplitude.com/experiment/sdks/ios-sdk/#initialize). 
-
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
 /*cspell:disable*/


### PR DESCRIPTION
## Description

 * Removed warning in Swift SDK about Experiment integration not being supported. It is supported now.