### PR TITLE
Fix cspell issues

### DIFF
--- a/docs/data/sdks/ios-swift/ampli.md
+++ b/docs/data/sdks/ios-swift/ampli.md
@@ -25,7 +25,7 @@ Amplitude Data supports tracking analytics events from iOS apps written in Swift
 1. [Install the Amplitude SDK](#install-the-amplitude-sdk)
 
     ```shell
-    pod 'AmplitudeSwift', '~> 0.4.14'
+    pod 'AmplitudeSwift', '~> 0.6.0'
     ```
 
 2. [Install the Ampli CLI](#install-the-ampli-cli)

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -9,7 +9,7 @@ icon: simple/ios
 This is the official documentation for the Amplitude Analytics iOS SDK.
 
 !!!beta "iOS Swift SDK Resources (Beta)"
-    [:material-github: GitHub](https://github.com/amplitude/Amplitude-Swift) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Swift/releases)
+    [:material-github: GitHub](https://github.com/amplitude/Amplitude-Swift) · [:material-code-tags-check: Releases](https://github.com/amplitude/Amplitude-Swift/releases) · [:material-book: Examples](https://github.com/amplitude/Amplitude-Swift/tree/main/Examples/AmplitudeSwiftUIExample)
 
 !!!warning "Objective-C Not Supported"
     Please note that the latest iOS SDK is NOT compatible with Objective-C projects. Use the [maintenance iOS SDK](/data/sdks/ios) if your project requires compatibility with Objective-C.

--- a/docs/data/sdks/ios-swift/index.md
+++ b/docs/data/sdks/ios-swift/index.md
@@ -19,10 +19,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
-/*cspell:disable*/
 --8<-- "includes/size/ios.md"
-    `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.4.14`.
-/*cspell:enable*/
+    `./measure_cocoapod_size.py --cocoapods AmplitudeSwift:0.6.0`.
 
 ## Getting started
 

--- a/docs/data/sdks/ios-swift/migration.md
+++ b/docs/data/sdks/ios-swift/migration.md
@@ -20,7 +20,7 @@ Add `AmplitudeSwift` dependency to `Podfile`.
 
 ```diff
 - pod 'Amplitude', '~> 8.14'
-+ pod 'AmplitudeSwift', '~> 0.4'
++ pod 'AmplitudeSwift', '~> 0.6'
 ```
 
 ### Swift Package Manager
@@ -38,7 +38,7 @@ Add `amplitude/Amplitude-Swift` to your `Cartfile`.
 
 ```diff
 - github "amplitude/Amplitude-iOS" ~> 8.14
-+ github "amplitude/Amplitude-Swift" ~> 0.4
++ github "amplitude/Amplitude-Swift" ~> 0.6
 ```
 
 ## Instrumentation

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -22,10 +22,8 @@ This is the official documentation for the Amplitude Analytics iOS SDK.
 
 --8<-- "includes/sdk-ios/apple-deprecate-carrier.md"
 
-/*cspell:disable*/
 --8<-- "includes/size/ios.md"
     `./measure_cocoapod_size.py --cocoapods Amplitude:8.17.1`.
-/*cspell:enable*/
 
 ## Getting started
 

--- a/docs/data/sdks/ios/index.md
+++ b/docs/data/sdks/ios/index.md
@@ -10,7 +10,7 @@ icon: simple/ios
 This is the official documentation for the Amplitude Analytics iOS SDK.
 
 !!!warning New Version Available
-    This is the time tested iOS SDK, however here is a new version in beta that is highly recommended for all customers using Swift. The latest [iOS Swift SDK](../ios-swift/) has additional features such as plugins and more. See the [Migration Guide](../ios-swift/migration/) for more help. For customers beginning with Amplitude Experiment, please note that the beta iOS SDK does not support the [Amplitude Experiment integration](https://www.docs.developers.amplitude.com/experiment/sdks/ios-sdk/#initialize).
+    This is the time tested iOS SDK, however here is a new version in beta that is highly recommended for all customers using Swift. The latest [iOS Swift SDK](../ios-swift/) has additional features such as plugins and more. See the [Migration Guide](../ios-swift/migration/) for more help.
 
     Please note that the latest iOS Swift SDK is **NOT** compatible with Objective-C projects. Use this SDK if your project requires compatibility with Objective-C.
 

--- a/docs/data/sdks/sdk-quickstart.md
+++ b/docs/data/sdks/sdk-quickstart.md
@@ -762,11 +762,6 @@ Use this guide to get started with the Amplitude SDKs. Choose your target platfo
 
     --8<-- "includes/sdk-quickstart/quickstart-enforce-event-schema-intro.md"
 
-    --8<-- "includes/no-ampli.md"
-        To use Ampli see the [non-Beta SDK](./ios/index.md) and [Ampli Wrapper](./ios/ampli.md) instead.
-
-    Coming soon.
-
 === "JRE"
 
     This is the documentation for the **Amplitude Analytics Java SDK**. This is not the Android SDK. See the [Java SDK documentation](../java/) for additional configurations and advanced topics.

--- a/includes/sdk-ios/swift-install-dependencies.md
+++ b/includes/sdk-ios/swift-install-dependencies.md
@@ -6,7 +6,7 @@ Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Packag
 
     1. Add dependency to `Podfile`. 
     ```bash
-    pod 'AmplitudeSwift', '~> 0.4.14'
+    pod 'AmplitudeSwift', '~> 0.6.0'
     ```
     2. Run `pod install` in the project directory to install the dependency. 
 
@@ -22,6 +22,6 @@ Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Packag
 
     Add the following line to your `Cartfile`.
     ```bash
-    github "amplitude/Amplitude-Swift" ~> 0.4.14
+    github "amplitude/Amplitude-Swift" ~> 0.6.0
     ```
     Check out the [Carthage docs](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more info.

--- a/macros/sdks/ios-install-dependencies.md
+++ b/macros/sdks/ios-install-dependencies.md
@@ -1,4 +1,4 @@
-@{% macro ios_install_dependencies(packageName='AmplitudeSwift', version='0.4.14', repo='amplitude/Amplitude-Swift') -%}
+@{% macro ios_install_dependencies(packageName='AmplitudeSwift', version='0.6.0', repo='amplitude/Amplitude-Swift') -%}
 Install the Amplitude Analytics iOS SDK via CocoaPods, Carthage, or Swift Package Manager. 
 
 === "CocoaPods"


### PR DESCRIPTION
## Description

* https://pr-984.d19s7xzcva2mw3.amplifyapp.com/data/sdks/ios-swift
* https://pr-984.d19s7xzcva2mw3.amplifyapp.com/data/sdks/sdk-quickstart/#ios-beta

 * remove cspell comments in iOS docs
 * bump AmplitudeSwift version in docs to 0.6.0 (latest)
 * added link to Swift SDK examples
 * remove Ampli not supported warnings for Swift SDK

<img width="795" alt="image" src="https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/assets/5790872/5b5a76ed-ecaf-4757-94e6-2b36c561e85d">
