### PR TITLE
fix (minor): update contribution guide wiki links 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ More information is coming soon!
 ### For users
 --------
 
-If you are making substantial updates, read our [style guide](/style-guide.md) and [formatting cheatsheet](formatting-cheatsheet.md) before starting work. When you're ready, open a PR.
+If you are making substantial updates, read our [style guide](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/wiki/Style-Guide) and [formatting cheatsheet](https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/wiki/Formatting-Cheatsheet) before starting work. When you're ready, open a PR.
 
 ### For Ampliteers
 -----


### PR DESCRIPTION
# Amplitude Developer Docs PR


## Description

- #508 migrated the meta-docs to the github repository's wiki. 
- This change updates the contribution guide with corrected links to the style guide and format cheatsheet

Note that links to the wiki pages must be full URLs; relative links are not supported.

## Deadline

non-urgent

## Change type

- [x] **Doc bug fix.**
- [ ] Doc update.
- [ ] New documentation.
- [ ] Non-documentation related fix or update.

# PR checklist:

- [x] My documentation follows the style guidelines of this project.
- [ ] I previewed my documentation on a local server using `mkdocs serve`.
- [ ] Running `mkdocs serve` didn't generate any failures.
- [ ] I have performed a self-review of my own documentation.


@amplitude-dev-docs
